### PR TITLE
Add new Config Switch dvi_mode

### DIFF
--- a/mist_cfg.c
+++ b/mist_cfg.c
@@ -32,6 +32,7 @@ const ini_var_t mist_ini_vars[] = {
 	{ "KEY_MENU_AS_RGUI", (void*)(&(mist_cfg.key_menu_as_rgui)), UINT8, 0, 1, 1 },
 	{ "VIDEO_MODE", (void*)(&(mist_cfg.video_mode)), UINT8, 0, 9, 1 },
 	{ "HDMI_AUDIO_96K", (void*)(&(mist_cfg.hdmi_audio_96k)), UINT8, 0, 1, 1 },
+        { "DVI_MODE", (void*)(&(mist_cfg.dvi)), UINT8, 0, 1, 1 },
 };
 
 // mist ini config

--- a/mist_cfg.h
+++ b/mist_cfg.h
@@ -22,6 +22,7 @@ typedef struct {
 	uint8_t vga_scaler;
 	uint8_t video_mode;
 	uint8_t hdmi_audio_96k;
+        uint8_t dvi;
 } mist_cfg_t;
 
 

--- a/user_io.c
+++ b/user_io.c
@@ -882,6 +882,7 @@ void user_io_send_buttons(char force)
 	if (mist_cfg.ypbpr) map |= CONF_YPBPR;
 	if (mist_cfg.forced_scandoubler) map |= CONF_FORCED_SCANDOUBLER;
 	if (mist_cfg.hdmi_audio_96k) map |= CONF_AUDIO_48K;
+        if (mist_cfg.dvi) map |= CONF_DVI;
 
 	if ((map != key_map) || force)
 	{

--- a/user_io.h
+++ b/user_io.h
@@ -118,6 +118,7 @@
 #define CONF_FORCED_SCANDOUBLER 0x10
 #define CONF_YPBPR              0x20
 #define CONF_AUDIO_48K          0x40
+#define CONF_DVI                0x80
 
 // core type value should be unlikely to be returned by broken cores
 #define CORE_TYPE_UNKNOWN   0x55


### PR DESCRIPTION
This adds a new config line to MiSTer.ini:

dvi_mode=1 ; set to 1 for DVI-Monitor / 0 (default) for HDMI-Monitor

The new config needs to be added the fpga core hdmi_config (see example in C64 core).
Without changes in the fpga core this configuration does nothing.