### PR TITLE
Automatically create blank .sav files for cores that save.

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -330,6 +330,27 @@ int FileCanWrite(const char *name)
 	return ((st.st_mode & S_IWUSR) != 0);
 }
 
+int FileRemove(const char *name, int mode, char mute)
+{
+	const char *root = getRootDir();
+	if (strncasecmp(getRootDir(), name, strlen(root)))
+	{
+		sprintf(full_path, "%s/%s", (mode == -1) ? "" : root, name);
+	}
+	else
+	{
+		sprintf(full_path, name);
+	}
+
+	if (!FileCanWrite(name))
+		return 0;
+
+	int ret = remove(full_path);
+	if (!mute) printf("Removing file %s. Success: %d\n", name, ret == 0 ? 1 : 0);
+
+	return ret != 0 ? 0 : 1;
+}
+
 static int device = 0;
 static int usbnum = 0;
 const char *getStorageDir(int dev)

--- a/file_io.h
+++ b/file_io.h
@@ -61,6 +61,8 @@ int FileWriteSec(fileTYPE *file, void *pBuffer);
 
 int FileCanWrite(const char *name);
 
+int FileRemove(const char *name, int mode, char mute = 0);
+
 int FileSave(const char *name, void *pBuffer, int size);
 int FileLoad(const char *name, void *pBuffer, int size); // supply pBuffer = 0 to get the file size without loading
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -1173,7 +1173,18 @@ void HandleUI(void)
 
 				if (p[0] == 'F')
 				{
-					opensave = (p[1] == 'S');
+					if (p[1] == 'S') {
+						if (p[2] >= '0' && p[2] <= '9' && p[3] >= '0' && p[3] <= '9') {
+							char sav_size_str[3];
+							snprintf(sav_size_str, 3, "%c%c", p[2], p[3]);
+							opensave = (uint8_t) strtol(sav_size_str, NULL, 10);
+							if (opensave <= 0) opensave = 17;
+						} else {
+							// Default is 128kb ( 1 << 17 ) which maintains compatibility
+							// with existing cores that save (NES, SMS, TG16).
+							opensave = 17;
+						}
+					}
 					substrcpy(ext, p, 1);
 					while (strlen(ext) < 3) strcat(ext, " ");
 					SelectFile(ext, SCANO_DIR, MENU_8BIT_MAIN_FILE_SELECTED, MENU_8BIT_MAIN1);

--- a/menu.cpp
+++ b/menu.cpp
@@ -1175,9 +1175,7 @@ void HandleUI(void)
 				{
 					if (p[1] == 'S') {
 						if (p[2] >= '0' && p[2] <= '9' && p[3] >= '0' && p[3] <= '9') {
-							char sav_size_str[3];
-							snprintf(sav_size_str, 3, "%c%c", p[2], p[3]);
-							opensave = (uint8_t) strtol(sav_size_str, NULL, 10);
+							opensave = (uint8_t) (((p[2] - '0') * 10) + (p[3] - '0'));
 							if (opensave <= 0) opensave = 17;
 						} else {
 							// Default is 128kb ( 1 << 17 ) which maintains compatibility


### PR DESCRIPTION
If the core indicates FS in the menu, and a .sav file does not exist for the rom, it will be created. The size is 128kb by default, or the core can specify the desired .sav size with a power-of-two decimal number following FS in the menu option, eg FS13. If the .sav file was not used by a game, it is automatically removed from the disk the next time a rom is loaded for any core, to avoid clutter.