### PR TITLE
Main loop latency reduction with coroutines

### DIFF
--- a/3pp/libco/amd64.c
+++ b/3pp/libco/amd64.c
@@ -1,0 +1,160 @@
+/*
+  libco.amd64 (2016-09-14)
+  author: byuu
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static thread_local long long co_active_buffer[64];
+static thread_local cothread_t co_active_handle = 0;
+static void (*co_swap)(cothread_t, cothread_t) = 0;
+
+#ifdef LIBCO_MPROTECT
+  alignas(4096)
+#else
+  section(text)
+#endif
+#ifdef _WIN32
+  /* ABI: Win64 */
+  static const unsigned char co_swap_function[4096] = {
+    0x48, 0x89, 0x22,              /* mov [rdx],rsp          */
+    0x48, 0x8b, 0x21,              /* mov rsp,[rcx]          */
+    0x58,                          /* pop rax                */
+    0x48, 0x89, 0x6a, 0x08,        /* mov [rdx+ 8],rbp       */
+    0x48, 0x89, 0x72, 0x10,        /* mov [rdx+16],rsi       */
+    0x48, 0x89, 0x7a, 0x18,        /* mov [rdx+24],rdi       */
+    0x48, 0x89, 0x5a, 0x20,        /* mov [rdx+32],rbx       */
+    0x4c, 0x89, 0x62, 0x28,        /* mov [rdx+40],r12       */
+    0x4c, 0x89, 0x6a, 0x30,        /* mov [rdx+48],r13       */
+    0x4c, 0x89, 0x72, 0x38,        /* mov [rdx+56],r14       */
+    0x4c, 0x89, 0x7a, 0x40,        /* mov [rdx+64],r15       */
+  #if !defined(LIBCO_NO_SSE)
+    0x0f, 0x29, 0x72, 0x50,        /* movaps [rdx+ 80],xmm6  */
+    0x0f, 0x29, 0x7a, 0x60,        /* movaps [rdx+ 96],xmm7  */
+    0x44, 0x0f, 0x29, 0x42, 0x70,  /* movaps [rdx+112],xmm8  */
+    0x48, 0x83, 0xc2, 0x70,        /* add rdx,112            */
+    0x44, 0x0f, 0x29, 0x4a, 0x10,  /* movaps [rdx+ 16],xmm9  */
+    0x44, 0x0f, 0x29, 0x52, 0x20,  /* movaps [rdx+ 32],xmm10 */
+    0x44, 0x0f, 0x29, 0x5a, 0x30,  /* movaps [rdx+ 48],xmm11 */
+    0x44, 0x0f, 0x29, 0x62, 0x40,  /* movaps [rdx+ 64],xmm12 */
+    0x44, 0x0f, 0x29, 0x6a, 0x50,  /* movaps [rdx+ 80],xmm13 */
+    0x44, 0x0f, 0x29, 0x72, 0x60,  /* movaps [rdx+ 96],xmm14 */
+    0x44, 0x0f, 0x29, 0x7a, 0x70,  /* movaps [rdx+112],xmm15 */
+  #endif
+    0x48, 0x8b, 0x69, 0x08,        /* mov rbp,[rcx+ 8]       */
+    0x48, 0x8b, 0x71, 0x10,        /* mov rsi,[rcx+16]       */
+    0x48, 0x8b, 0x79, 0x18,        /* mov rdi,[rcx+24]       */
+    0x48, 0x8b, 0x59, 0x20,        /* mov rbx,[rcx+32]       */
+    0x4c, 0x8b, 0x61, 0x28,        /* mov r12,[rcx+40]       */
+    0x4c, 0x8b, 0x69, 0x30,        /* mov r13,[rcx+48]       */
+    0x4c, 0x8b, 0x71, 0x38,        /* mov r14,[rcx+56]       */
+    0x4c, 0x8b, 0x79, 0x40,        /* mov r15,[rcx+64]       */
+  #if !defined(LIBCO_NO_SSE)
+    0x0f, 0x28, 0x71, 0x50,        /* movaps xmm6, [rcx+ 80] */
+    0x0f, 0x28, 0x79, 0x60,        /* movaps xmm7, [rcx+ 96] */
+    0x44, 0x0f, 0x28, 0x41, 0x70,  /* movaps xmm8, [rcx+112] */
+    0x48, 0x83, 0xc1, 0x70,        /* add rcx,112            */
+    0x44, 0x0f, 0x28, 0x49, 0x10,  /* movaps xmm9, [rcx+ 16] */
+    0x44, 0x0f, 0x28, 0x51, 0x20,  /* movaps xmm10,[rcx+ 32] */
+    0x44, 0x0f, 0x28, 0x59, 0x30,  /* movaps xmm11,[rcx+ 48] */
+    0x44, 0x0f, 0x28, 0x61, 0x40,  /* movaps xmm12,[rcx+ 64] */
+    0x44, 0x0f, 0x28, 0x69, 0x50,  /* movaps xmm13,[rcx+ 80] */
+    0x44, 0x0f, 0x28, 0x71, 0x60,  /* movaps xmm14,[rcx+ 96] */
+    0x44, 0x0f, 0x28, 0x79, 0x70,  /* movaps xmm15,[rcx+112] */
+  #endif
+    0xff, 0xe0,                    /* jmp rax                */
+  };
+
+  #include <windows.h>
+
+  static void co_init() {
+    #ifdef LIBCO_MPROTECT
+    DWORD old_privileges;
+    VirtualProtect((void*)co_swap_function, sizeof co_swap_function, PAGE_EXECUTE_READ, &old_privileges);
+    #endif
+  }
+#else
+  /* ABI: SystemV */
+  static const unsigned char co_swap_function[4096] = {
+    0x48, 0x89, 0x26,        /* mov [rsi],rsp    */
+    0x48, 0x8b, 0x27,        /* mov rsp,[rdi]    */
+    0x58,                    /* pop rax          */
+    0x48, 0x89, 0x6e, 0x08,  /* mov [rsi+ 8],rbp */
+    0x48, 0x89, 0x5e, 0x10,  /* mov [rsi+16],rbx */
+    0x4c, 0x89, 0x66, 0x18,  /* mov [rsi+24],r12 */
+    0x4c, 0x89, 0x6e, 0x20,  /* mov [rsi+32],r13 */
+    0x4c, 0x89, 0x76, 0x28,  /* mov [rsi+40],r14 */
+    0x4c, 0x89, 0x7e, 0x30,  /* mov [rsi+48],r15 */
+    0x48, 0x8b, 0x6f, 0x08,  /* mov rbp,[rdi+ 8] */
+    0x48, 0x8b, 0x5f, 0x10,  /* mov rbx,[rdi+16] */
+    0x4c, 0x8b, 0x67, 0x18,  /* mov r12,[rdi+24] */
+    0x4c, 0x8b, 0x6f, 0x20,  /* mov r13,[rdi+32] */
+    0x4c, 0x8b, 0x77, 0x28,  /* mov r14,[rdi+40] */
+    0x4c, 0x8b, 0x7f, 0x30,  /* mov r15,[rdi+48] */
+    0xff, 0xe0,              /* jmp rax          */
+  };
+
+  #include <unistd.h>
+  #include <sys/mman.h>
+
+  static void co_init() {
+    #ifdef LIBCO_MPROTECT
+    unsigned long long addr = (unsigned long long)co_swap_function;
+    unsigned long long base = addr - (addr % sysconf(_SC_PAGESIZE));
+    unsigned long long size = (addr - base) + sizeof co_swap_function;
+    mprotect((void*)base, size, PROT_READ | PROT_EXEC);
+    #endif
+  }
+#endif
+
+static void crash() {
+  assert(0);  /* called only if cothread_t entrypoint returns */
+}
+
+cothread_t co_active() {
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  return co_active_handle;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
+  cothread_t handle;
+  if(!co_swap) {
+    co_init();
+    co_swap = (void (*)(cothread_t, cothread_t))co_swap_function;
+  }
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  size += 512;  /* allocate additional space for storage */
+  size &= ~15;  /* align stack to 16-byte boundary */
+
+  if(handle = (cothread_t)malloc(size)) {
+    long long *p = (long long*)((char*)handle + size);  /* seek to top of stack */
+    *--p = (long long)crash;                            /* crash if entrypoint returns */
+    *--p = (long long)entrypoint;                       /* start of function */
+    *(long long*)handle = (long long)p;                 /* stack pointer */
+  }
+
+  return handle;
+}
+
+void co_delete(cothread_t handle) {
+  free(handle);
+}
+
+void co_switch(cothread_t handle) {
+  register cothread_t co_previous_handle = co_active_handle;
+  co_swap(co_active_handle = handle, co_previous_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/3pp/libco/arm.c
+++ b/3pp/libco/arm.c
@@ -1,0 +1,79 @@
+/*
+  libco.arm (2016-09-14)
+  author: byuu
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static thread_local unsigned long co_active_buffer[64];
+static thread_local cothread_t co_active_handle = 0;
+static void (*co_swap)(cothread_t, cothread_t) = 0;
+
+#ifdef LIBCO_MPROTECT
+  alignas(4096)
+#else
+  section(text)
+#endif
+static const unsigned long co_swap_function[1024] = {
+  0xe8a16ff0,  /* stmia r1!, {r4-r11,sp,lr} */
+  0xe8b0aff0,  /* ldmia r0!, {r4-r11,sp,pc} */
+  0xe12fff1e,  /* bx lr                     */
+};
+
+static void co_init() {
+  #ifdef LIBCO_MPROTECT
+  unsigned long addr = (unsigned long)co_swap_function;
+  unsigned long base = addr - (addr % sysconf(_SC_PAGESIZE));
+  unsigned long size = (addr - base) + sizeof co_swap_function;
+  mprotect((void*)base, size, PROT_READ | PROT_EXEC);
+  #endif
+}
+
+cothread_t co_active() {
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  return co_active_handle;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
+  unsigned long* handle = 0;
+  if(!co_swap) {
+    co_init();
+    co_swap = (void (*)(cothread_t, cothread_t))co_swap_function;
+  }
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  size += 256;
+  size &= ~15;
+
+  if((handle = (unsigned long*)malloc(size))) {
+    unsigned long* p = (unsigned long*)((unsigned char*)handle + size);
+    handle[8] = (unsigned long)p;
+    handle[9] = (unsigned long)entrypoint;
+  }
+
+  return handle;
+}
+
+void co_delete(cothread_t handle) {
+  free(handle);
+}
+
+void co_switch(cothread_t handle) {
+  cothread_t co_previous_handle = co_active_handle;
+  co_swap(co_active_handle = handle, co_previous_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/3pp/libco/doc/style.css
+++ b/3pp/libco/doc/style.css
@@ -1,0 +1,8 @@
+body {
+  background: #333;
+  color: #fff;
+}
+
+code {
+  background: #444;
+}

--- a/3pp/libco/doc/targets.html
+++ b/3pp/libco/doc/targets.html
@@ -1,0 +1,89 @@
+<html>
+<head>
+  <title></title>
+  <link href="style.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+
+<b>Supported targets:</b><br/><br/>
+
+Note that supported targets are only those that have been tested and confirmed
+working. It is quite possible that libco will work on more processors, compilers
+and operating systems than those listed below.
+<hr/>
+
+<b>libco.x86</b><br/>
+Overhead: ~5x<br/>
+Supported processor(s): 32-bit x86<br/>
+Supported compiler(s): any<br/>
+Supported operating system(s):<ul>
+<li>Windows</li>
+<li>Mac OS X</li>
+<li>Linux</li>
+<li>BSD</li>
+</ul>
+<hr/>
+
+<b>libco.amd64</b><br/>
+Overhead: ~10x (Windows), ~6x (all other platforms)<br/>
+Supported processor(s): 64-bit amd64<br/>
+Supported compiler(s): any<br/>
+Supported operating system(s):<ul>
+<li>Windows</li>
+<li>Mac OS X</li>
+<li>Linux</li>
+<li>BSD</li>
+</ul>
+<hr/>
+
+<b>libco.ppc</b><br/>
+Overhead: ~20x<br/>
+Supported processor(s): 32-bit PowerPC, 64-bit PowerPC<br/>
+Supported compiler(s): GNU GCC<br/>
+Supported operating system(s):<ul>
+</ul>
+<li>Mac OS X</li>
+<li>Linux</li>
+<li>BSD</li>
+<li>Playstation 3</li>
+</ul>
+<br/>
+
+Note: this module contains compiler flags to enable/disable FPU and Altivec
+support.
+
+<hr/>
+
+<b>libco.fiber</b><br/>
+Overhead: ~15x<br/>
+Supported processor(s): Processor independent<br/>
+Supported compiler(s): any<br/>
+Supported operating system(s):<ul>
+<li>Windows</li>
+</ul>
+<hr/>
+
+<b>libco.sjlj</b><br/>
+Overhead: ~30x<br/>
+Supported processor(s): Processor independent<br/>
+Supported compiler(s): any<br/>
+Supported operating system(s):<ul>
+<li>Mac OS X</li>
+<li>Linux</li>
+<li>BSD</li>
+<li>Solaris</li>
+</ul>
+<hr/>
+
+<b>libco.ucontext</b><br/>
+Overhead: <b><font color="#ff0000">~300x</font></b><br/>
+Supported processor(s): Processor independent<br/>
+Supported compiler(s): any<br/>
+Supported operating system(s):<ul>
+<li>Linux</li>
+<li>BSD</li>
+</ul>
+<hr/>
+
+</body>
+</html>

--- a/3pp/libco/doc/usage.html
+++ b/3pp/libco/doc/usage.html
@@ -1,0 +1,107 @@
+<html>
+<head>
+  <title></title>
+  <link href="style.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+
+<b>License:</b><br/><br/>
+libco is released to the public domain.
+<hr/>
+
+<b>Contact:</b><br/><br/>
+At present, you may contact me at setsunakun0 at hotmail dot com.<br/>
+I am interested in knowing of any projects that make use of this library,
+though this is only a courtesy.
+<hr/>
+
+<b>Foreword:</b><br/><br/>
+libco is a cross-platform, public domain implementation of
+cooperative-multithreading; a feature that is sorely lacking
+from the ISO C/C++ standard.<br/>
+The library is designed for maximum speed and portability, and
+not for safety or features. If safety or extra functionality is desired,
+a wrapper API can easily be written to encapsulate all library functions.<br/>
+Behavior of executing operations that are listed as not permitted
+below result in undefined behavior. They may work anyway, they
+may cause undesired / unknown behavior, or they may crash the
+program entirely.<br/>
+The goal of this library was to simplify the base API as much as possible,
+implementing only that which cannot be implemented using pure C. Additional
+functionality after this would only complicate ports of this library to new
+platforms.
+<hr/>
+
+<b>Porting:</b><br/><br/>
+This document is included as a reference for porting libco. Please submit any
+ports you create to me, so that libco can become more useful. Please note that
+since libco is public domain, you must submit your code as a work of the
+public domain in order for it to be included in the official distribution.
+Full credit will be given in the source code of the official release. Please
+do not bother submitting code to me under any other license -- including GPL,
+LGPL, BSD or CC -- I am not interested in creating a library with multiple
+different licenses depending on which targets are used.
+<hr/>
+
+<b>Synopsis:</b><br/><br/>
+<code>
+typedef void* cothread_t;<br/>
+<br/>
+cothread_t co_active();<br/>
+cothread_t co_create(unsigned int heapsize, void (*coentry)(void));<br/>
+void &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;co_delete(cothread_t cothread);<br/>
+void &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;co_switch(cothread_t cothread);<br/>
+</code>
+<hr/>
+
+<b>Usage:</b>
+<hr/>
+
+<code>typedef void* cothread_t;</code><br/><br/>
+Handle to cothread.<br/>
+Handle must be of type void*.<br/>
+A value of null (0) indicates an uninitialized or invalid
+handle, whereas a non-zero value indicates a valid handle.
+<hr/>
+
+<code>cothread_t co_active();</code><br/><br/>
+Return handle to current cothread. Always returns a valid handle, even when
+called from the main program thread.
+<hr/>
+
+<code>cothread_t co_create(unsigned int heapsize, void (*coentry)(void));</code><br/><br/>
+Create new cothread.<br/>
+Heapsize is the amount of memory allocated for the cothread stack, specified
+in bytes. This is unfortunately impossible to make fully portable. It is
+recommended to specify sizes using `n * sizeof(void*)'. It is better to err
+on the side of caution and allocate more memory than will be needed to ensure
+compatibility with other platforms, within reason. A typical heapsize for a
+32-bit architecture is ~1MB.<br/>
+When the new cothread is first called, program execution jumps to coentry.
+This function does not take any arguments, due to portability issues with
+passing function arguments. However, arguments can be simulated by the use
+of global variables, which can be set before the first call to each cothread.<br/>
+coentry() must not return, and should end with an appropriate co_switch()
+statement. Behavior is undefined if entry point returns normally.<br/>
+Library is responsible for allocating cothread stack memory, to free
+the user from needing to allocate special memory capable of being used
+as program stack memory on platforms where this is required.<br/>
+User is always responsible for deleting cothreads with co_delete().<br/>
+Return value of null (0) indicates cothread creation failed.
+<hr/>
+
+<code>void co_delete(cothread_t cothread);</code><br/><br/>
+Delete specified cothread.<br/>
+Null (0) or invalid cothread handle is not allowed.<br/>
+Passing handle of active cothread to this function is not allowed.<br/>
+Passing handle of primary cothread is not allowed.
+<hr/>
+
+<code>void co_switch(cothread_t cothread);</code><br/><br/>
+Switch to specified cothread.<br/>
+Null (0) or invalid cothread handle is not allowed.<br/>
+Passing handle of active cothread to this function is not allowed.
+<hr/>
+
+</body>
+</html>

--- a/3pp/libco/fiber.c
+++ b/3pp/libco/fiber.c
@@ -1,0 +1,51 @@
+/*
+  libco.win (2008-01-28)
+  authors: Nach, byuu
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+
+#define WINVER 0x0400
+#define _WIN32_WINNT 0x0400
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static thread_local cothread_t co_active_ = 0;
+
+static void __stdcall co_thunk(void* coentry) {
+  ((void (*)(void))coentry)();
+}
+
+cothread_t co_active() {
+  if(!co_active_) {
+    ConvertThreadToFiber(0);
+    co_active_ = GetCurrentFiber();
+  }
+  return co_active_;
+}
+
+cothread_t co_create(unsigned int heapsize, void (*coentry)(void)) {
+  if(!co_active_) {
+    ConvertThreadToFiber(0);
+    co_active_ = GetCurrentFiber();
+  }
+  return (cothread_t)CreateFiber(heapsize, co_thunk, (void*)coentry);
+}
+
+void co_delete(cothread_t cothread) {
+  DeleteFiber(cothread);
+}
+
+void co_switch(cothread_t cothread) {
+  co_active_ = cothread;
+  SwitchToFiber(cothread);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/3pp/libco/libco.c
+++ b/3pp/libco/libco.c
@@ -1,0 +1,34 @@
+/*
+  libco
+  license: public domain
+*/
+
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wparentheses"
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+  #if defined(__i386__)
+    #include "x86.c"
+  #elif defined(__amd64__)
+    #include "amd64.c"
+  #elif defined(__arm__)
+    #include "arm.c"
+  #elif defined(_ARCH_PPC)
+    #include "ppc.c"
+  #elif defined(_WIN32)
+    #include "fiber.c"
+  #else
+    #include "sjlj.c"
+  #endif
+#elif defined(_MSC_VER)
+  #if defined(_M_IX86)
+    #include "x86.c"
+  #elif defined(_M_AMD64)
+    #include "amd64.c"
+  #else
+    #include "fiber.c"
+  #endif
+#else
+  #error "libco: unsupported processor, compiler or operating system"
+#endif

--- a/3pp/libco/libco.h
+++ b/3pp/libco/libco.h
@@ -1,0 +1,26 @@
+/*
+  libco v18 (2016-09-14)
+  author: byuu
+  license: public domain
+*/
+
+#ifndef LIBCO_H
+#define LIBCO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* cothread_t;
+
+cothread_t co_active();
+cothread_t co_create(unsigned int, void (*)(void));
+void co_delete(cothread_t);
+void co_switch(cothread_t);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ifndef LIBCO_H */
+#endif

--- a/3pp/libco/ppc.c
+++ b/3pp/libco/ppc.c
@@ -1,0 +1,367 @@
+/*
+  libco.ppc (2016-09-14)
+  author: blargg
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#if LIBCO_MPROTECT
+  #include <unistd.h>
+  #include <sys/mman.h>
+#endif
+
+/* state format (offsets in 32-bit words)
+
+ +0 pointer to swap code
+    rest of function descriptor for entry function
+ +8 PC
++10 SP
+    special registers
+    GPRs
+    FPRs
+    VRs
+    stack
+*/
+
+enum { state_size  = 1024 };
+enum { above_stack = 2048 };
+enum { stack_align = 256  };
+
+static thread_local cothread_t co_active_handle = 0;
+
+/* determine environment */
+
+#define LIBCO_PPC64 (_ARCH_PPC64 || __PPC64__ || __ppc64__ || __powerpc64__)
+
+/* whether function calls are indirect through a descriptor, or are directly to function */
+#ifndef LIBCO_PPCDESC
+  #if !_CALL_SYSV && (_CALL_AIX || _CALL_AIXDESC || LIBCO_PPC64)
+    #define LIBCO_PPCDESC 1
+  #endif
+#endif
+
+#ifdef LIBCO_MPROTECT
+  alignas(4096)
+#else
+  section(text)
+#endif
+static const uint32_t libco_ppc_code[1024] = {
+  #if LIBCO_PPC64
+  0x7d000026,  /* mfcr    r8          */
+  0xf8240028,  /* std     r1,40(r4)   */
+  0x7d2802a6,  /* mflr    r9          */
+  0xf9c40048,  /* std     r14,72(r4)  */
+  0xf9e40050,  /* std     r15,80(r4)  */
+  0xfa040058,  /* std     r16,88(r4)  */
+  0xfa240060,  /* std     r17,96(r4)  */
+  0xfa440068,  /* std     r18,104(r4) */
+  0xfa640070,  /* std     r19,112(r4) */
+  0xfa840078,  /* std     r20,120(r4) */
+  0xfaa40080,  /* std     r21,128(r4) */
+  0xfac40088,  /* std     r22,136(r4) */
+  0xfae40090,  /* std     r23,144(r4) */
+  0xfb040098,  /* std     r24,152(r4) */
+  0xfb2400a0,  /* std     r25,160(r4) */
+  0xfb4400a8,  /* std     r26,168(r4) */
+  0xfb6400b0,  /* std     r27,176(r4) */
+  0xfb8400b8,  /* std     r28,184(r4) */
+  0xfba400c0,  /* std     r29,192(r4) */
+  0xfbc400c8,  /* std     r30,200(r4) */
+  0xfbe400d0,  /* std     r31,208(r4) */
+  0xf9240020,  /* std     r9,32(r4)   */
+  0xe8e30020,  /* ld      r7,32(r3)   */
+  0xe8230028,  /* ld      r1,40(r3)   */
+  0x48000009,  /* bl      1           */
+  0x7fe00008,  /* trap                */
+  0x91040030, /*1:stw     r8,48(r4)   */
+  0x80c30030,  /* lwz     r6,48(r3)   */
+  0x7ce903a6,  /* mtctr   r7          */
+  0xe9c30048,  /* ld      r14,72(r3)  */
+  0xe9e30050,  /* ld      r15,80(r3)  */
+  0xea030058,  /* ld      r16,88(r3)  */
+  0xea230060,  /* ld      r17,96(r3)  */
+  0xea430068,  /* ld      r18,104(r3) */
+  0xea630070,  /* ld      r19,112(r3) */
+  0xea830078,  /* ld      r20,120(r3) */
+  0xeaa30080,  /* ld      r21,128(r3) */
+  0xeac30088,  /* ld      r22,136(r3) */
+  0xeae30090,  /* ld      r23,144(r3) */
+  0xeb030098,  /* ld      r24,152(r3) */
+  0xeb2300a0,  /* ld      r25,160(r3) */
+  0xeb4300a8,  /* ld      r26,168(r3) */
+  0xeb6300b0,  /* ld      r27,176(r3) */
+  0xeb8300b8,  /* ld      r28,184(r3) */
+  0xeba300c0,  /* ld      r29,192(r3) */
+  0xebc300c8,  /* ld      r30,200(r3) */
+  0xebe300d0,  /* ld      r31,208(r3) */
+  0x7ccff120,  /* mtcr    r6          */
+  #else
+  0x7d000026,  /* mfcr    r8          */
+  0x90240028,  /* stw     r1,40(r4)   */
+  0x7d2802a6,  /* mflr    r9          */
+  0x91a4003c,  /* stw     r13,60(r4)  */
+  0x91c40040,  /* stw     r14,64(r4)  */
+  0x91e40044,  /* stw     r15,68(r4)  */
+  0x92040048,  /* stw     r16,72(r4)  */
+  0x9224004c,  /* stw     r17,76(r4)  */
+  0x92440050,  /* stw     r18,80(r4)  */
+  0x92640054,  /* stw     r19,84(r4)  */
+  0x92840058,  /* stw     r20,88(r4)  */
+  0x92a4005c,  /* stw     r21,92(r4)  */
+  0x92c40060,  /* stw     r22,96(r4)  */
+  0x92e40064,  /* stw     r23,100(r4) */
+  0x93040068,  /* stw     r24,104(r4) */
+  0x9324006c,  /* stw     r25,108(r4) */
+  0x93440070,  /* stw     r26,112(r4) */
+  0x93640074,  /* stw     r27,116(r4) */
+  0x93840078,  /* stw     r28,120(r4) */
+  0x93a4007c,  /* stw     r29,124(r4) */
+  0x93c40080,  /* stw     r30,128(r4) */
+  0x93e40084,  /* stw     r31,132(r4) */
+  0x91240020,  /* stw     r9,32(r4)   */
+  0x80e30020,  /* lwz     r7,32(r3)   */
+  0x80230028,  /* lwz     r1,40(r3)   */
+  0x48000009,  /* bl      1           */
+  0x7fe00008,  /* trap                */
+  0x91040030, /*1:stw     r8,48(r4)   */
+  0x80c30030,  /* lwz     r6,48(r3)   */
+  0x7ce903a6,  /* mtctr   r7          */
+  0x81a3003c,  /* lwz     r13,60(r3)  */
+  0x81c30040,  /* lwz     r14,64(r3)  */
+  0x81e30044,  /* lwz     r15,68(r3)  */
+  0x82030048,  /* lwz     r16,72(r3)  */
+  0x8223004c,  /* lwz     r17,76(r3)  */
+  0x82430050,  /* lwz     r18,80(r3)  */
+  0x82630054,  /* lwz     r19,84(r3)  */
+  0x82830058,  /* lwz     r20,88(r3)  */
+  0x82a3005c,  /* lwz     r21,92(r3)  */
+  0x82c30060,  /* lwz     r22,96(r3)  */
+  0x82e30064,  /* lwz     r23,100(r3) */
+  0x83030068,  /* lwz     r24,104(r3) */
+  0x8323006c,  /* lwz     r25,108(r3) */
+  0x83430070,  /* lwz     r26,112(r3) */
+  0x83630074,  /* lwz     r27,116(r3) */
+  0x83830078,  /* lwz     r28,120(r3) */
+  0x83a3007c,  /* lwz     r29,124(r3) */
+  0x83c30080,  /* lwz     r30,128(r3) */
+  0x83e30084,  /* lwz     r31,132(r3) */
+  0x7ccff120,  /* mtcr    r6 */
+  #endif
+
+  #ifndef LIBCO_PPC_NOFP
+  0xd9c400e0,  /* stfd    f14,224(r4) */
+  0xd9e400e8,  /* stfd    f15,232(r4) */
+  0xda0400f0,  /* stfd    f16,240(r4) */
+  0xda2400f8,  /* stfd    f17,248(r4) */
+  0xda440100,  /* stfd    f18,256(r4) */
+  0xda640108,  /* stfd    f19,264(r4) */
+  0xda840110,  /* stfd    f20,272(r4) */
+  0xdaa40118,  /* stfd    f21,280(r4) */
+  0xdac40120,  /* stfd    f22,288(r4) */
+  0xdae40128,  /* stfd    f23,296(r4) */
+  0xdb040130,  /* stfd    f24,304(r4) */
+  0xdb240138,  /* stfd    f25,312(r4) */
+  0xdb440140,  /* stfd    f26,320(r4) */
+  0xdb640148,  /* stfd    f27,328(r4) */
+  0xdb840150,  /* stfd    f28,336(r4) */
+  0xdba40158,  /* stfd    f29,344(r4) */
+  0xdbc40160,  /* stfd    f30,352(r4) */
+  0xdbe40168,  /* stfd    f31,360(r4) */
+  0xc9c300e0,  /* lfd     f14,224(r3) */
+  0xc9e300e8,  /* lfd     f15,232(r3) */
+  0xca0300f0,  /* lfd     f16,240(r3) */
+  0xca2300f8,  /* lfd     f17,248(r3) */
+  0xca430100,  /* lfd     f18,256(r3) */
+  0xca630108,  /* lfd     f19,264(r3) */
+  0xca830110,  /* lfd     f20,272(r3) */
+  0xcaa30118,  /* lfd     f21,280(r3) */
+  0xcac30120,  /* lfd     f22,288(r3) */
+  0xcae30128,  /* lfd     f23,296(r3) */
+  0xcb030130,  /* lfd     f24,304(r3) */
+  0xcb230138,  /* lfd     f25,312(r3) */
+  0xcb430140,  /* lfd     f26,320(r3) */
+  0xcb630148,  /* lfd     f27,328(r3) */
+  0xcb830150,  /* lfd     f28,336(r3) */
+  0xcba30158,  /* lfd     f29,344(r3) */
+  0xcbc30160,  /* lfd     f30,352(r3) */
+  0xcbe30168,  /* lfd     f31,360(r3) */
+  #endif
+
+  #ifdef __ALTIVEC__
+  0x7ca042a6,  /* mfvrsave r5        */
+  0x39040180,  /* addi    r8,r4,384  */
+  0x39240190,  /* addi    r9,r4,400  */
+  0x70a00fff,  /* andi.   r0,r5,4095 */
+  0x90a40034,  /* stw     r5,52(r4)  */
+  0x4182005c,  /* beq-    2          */
+  0x7e8041ce,  /* stvx    v20,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7ea049ce,  /* stvx    v21,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7ec041ce,  /* stvx    v22,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7ee049ce,  /* stvx    v23,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f0041ce,  /* stvx    v24,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7f2049ce,  /* stvx    v25,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f4041ce,  /* stvx    v26,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7f6049ce,  /* stvx    v27,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f8041ce,  /* stvx    v28,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7fa049ce,  /* stvx    v29,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7fc041ce,  /* stvx    v30,r0,r8  */
+  0x7fe049ce,  /* stvx    v31,r0,r9  */
+  0x80a30034, /*2:lwz     r5,52(r3)  */
+  0x39030180,  /* addi    r8,r3,384  */
+  0x39230190,  /* addi    r9,r3,400  */
+  0x70a00fff,  /* andi.   r0,r5,4095 */
+  0x7ca043a6,  /* mtvrsave r5        */
+  0x4d820420,  /* beqctr             */
+  0x7e8040ce,  /* lvx     v20,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7ea048ce,  /* lvx     v21,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7ec040ce,  /* lvx     v22,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7ee048ce,  /* lvx     v23,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f0040ce,  /* lvx     v24,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7f2048ce,  /* lvx     v25,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f4040ce,  /* lvx     v26,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7f6048ce,  /* lvx     v27,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7f8040ce,  /* lvx     v28,r0,r8  */
+  0x39080020,  /* addi    r8,r8,32   */
+  0x7fa048ce,  /* lvx     v29,r0,r9  */
+  0x39290020,  /* addi    r9,r9,32   */
+  0x7fc040ce,  /* lvx     v30,r0,r8  */
+  0x7fe048ce,  /* lvx     v31,r0,r9  */
+  #endif
+
+  0x4e800420,  /* bctr */
+};
+
+#if LIBCO_PPCDESC
+  /* function call goes through indirect descriptor */
+  #define CO_SWAP_ASM(x, y) ((void (*)(cothread_t, cothread_t))(uintptr_t)x)(x, y)
+#else
+  /* function call goes directly to code */
+  #define CO_SWAP_ASM(x, y) ((void (*)(cothread_t, cothread_t))(uintptr_t)libco_ppc_code)(x, y)
+#endif
+
+static uint32_t* co_create_(unsigned size, uintptr_t entry) {
+  (void)entry;
+
+  uint32_t* t = (uint32_t*)malloc(size);
+
+  #if LIBCO_PPCDESC
+  if(t) {
+    memcpy(t, (void*)entry, sizeof(void*) * 3);  /* copy entry's descriptor */
+    *(const void**)t = libco_ppc_code;  /* set function pointer to swap routine */
+  }
+  #endif
+
+  return t;
+}
+
+cothread_t co_create(unsigned int size, void (*entry_)(void)) {
+  uintptr_t entry = (uintptr_t)entry_;
+  uint32_t* t = 0;
+
+  /* be sure main thread was successfully allocated */
+  if(co_active()) {
+    size += state_size + above_stack + stack_align;
+    t = co_create_(size, entry);
+  }
+
+  if(t) {
+    uintptr_t sp;
+    int shift;
+
+    /* save current registers into new thread, so that any special ones will have proper values when thread is begun */
+    CO_SWAP_ASM(t, t);
+
+    #if LIBCO_PPCDESC
+    entry = (uintptr_t)*(void**)entry;  /* get real address */
+    #endif
+
+    /* put stack near end of block, and align */
+    sp = (uintptr_t)t + size - above_stack;
+    sp -= sp % stack_align;
+
+    /* on PPC32, we save and restore GPRs as 32 bits. for PPC64, we
+       save and restore them as 64 bits, regardless of the size the ABI
+       uses. so, we manually write pointers at the proper size. we always
+       save and restore at the same address, and since PPC is big-endian,
+       we must put the low byte first on PPC32. */
+
+    /* if uintptr_t is 32 bits, >>32 is undefined behavior,
+       so we do two shifts and don't have to care how many bits uintptr_t is. */
+    #if LIBCO_PPC64
+    shift = 16;
+    #else
+    shift = 0;
+    #endif
+
+    /* set up so entry will be called on next swap */
+    t[ 8] = (uint32_t)(entry >> shift >> shift);
+    t[ 9] = (uint32_t)entry;
+
+    t[10] = (uint32_t)(sp >> shift >> shift); 
+    t[11] = (uint32_t)sp;
+  }
+
+  return t;
+}
+
+void co_delete(cothread_t t) {
+  free(t);
+}
+
+static void co_init_(void) {
+  #if LIBCO_MPROTECT
+  long page_size = sysconf(_SC_PAGESIZE);
+  if(page_size > 0) {
+    uintptr_t align = page_size;
+    uintptr_t begin = (uintptr_t)libco_ppc_code;
+    uintptr_t end   = begin + sizeof libco_ppc_code;
+
+    /* align beginning and end */
+    end   += align - 1;
+    end   -= end   % align;
+    begin -= begin % align;
+
+    mprotect((void*)begin, end - begin, PROT_READ | PROT_EXEC);
+  }
+  #endif
+
+  co_active_handle = co_create_(state_size, (uintptr_t)&co_switch);
+}
+
+cothread_t co_active() {
+  if(!co_active_handle) co_init_();
+
+  return co_active_handle;
+}
+
+void co_switch(cothread_t t) {
+  cothread_t old = co_active_handle;
+  co_active_handle = t;
+
+  CO_SWAP_ASM(t, old);
+}

--- a/3pp/libco/settings.h
+++ b/3pp/libco/settings.h
@@ -1,0 +1,36 @@
+#ifdef LIBCO_C
+
+/*[amd64, arm, ppc, x86]:
+   by default, co_swap_function is marked as a text (code) section
+   if not supported, uncomment the below line to use mprotect instead */
+/* #define LIBCO_MPROTECT */
+
+/*[amd64]:
+   Win64 only: provides a substantial speed-up, but will thrash XMM regs
+   do not use this unless you are certain your application won't use SSE */
+/* #define LIBCO_NO_SSE */
+
+#ifdef LIBCO_C
+  #ifdef LIBCO_MP
+    #define thread_local __thread
+  #else
+    #define thread_local
+  #endif
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+  #ifndef _MSC_VER
+    #include <stdalign.h>
+  #endif
+#else
+  #define alignas(bytes)
+#endif
+
+#ifndef _MSC_VER
+  #define section(name) __attribute__((section("." #name "#")))
+#else
+  #define section(name) __declspec(allocate("." #name))
+#endif
+
+/* ifdef LIBCO_C */
+#endif

--- a/3pp/libco/sjlj.c
+++ b/3pp/libco/sjlj.c
@@ -1,0 +1,102 @@
+/*
+  libco.sjlj (2008-01-28)
+  author: Nach
+  license: public domain
+*/
+
+/*
+  note this was designed for UNIX systems. Based on ideas expressed in a paper by Ralf Engelschall.
+  for SJLJ on other systems, one would want to rewrite springboard() and co_create() and hack the jmb_buf stack pointer.
+*/
+
+#define LIBCO_C
+#include "libco.h"
+
+#include <stdlib.h>
+#include <signal.h>
+#include <setjmp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  sigjmp_buf context;
+  void (*coentry)(void);
+  void* stack;
+} cothread_struct;
+
+static thread_local cothread_struct co_primary;
+static thread_local cothread_struct* creating;
+static thread_local cothread_struct* co_running = 0;
+
+static void springboard(int ignored) {
+  if(sigsetjmp(creating->context, 0)) {
+    co_running->coentry();
+  }
+}
+
+cothread_t co_active() {
+  if(!co_running) co_running = &co_primary;
+  return (cothread_t)co_running;
+}
+
+cothread_t co_create(unsigned int size, void (*coentry)(void)) {
+  if(!co_running) co_running = &co_primary;
+
+  cothread_struct *thread = (cothread_struct*)malloc(sizeof(cothread_struct));
+  if(thread) {
+    struct sigaction handler;
+    struct sigaction old_handler;
+
+    stack_t stack;
+    stack_t old_stack;
+
+    thread->coentry = thread->stack = 0;
+
+    stack.ss_flags = 0;
+    stack.ss_size = size;
+    thread->stack = stack.ss_sp = malloc(size);
+    if(stack.ss_sp && !sigaltstack(&stack, &old_stack)) {
+      handler.sa_handler = springboard;
+      handler.sa_flags = SA_ONSTACK;
+      sigemptyset(&handler.sa_mask);
+      creating = thread;
+
+      if(!sigaction(SIGUSR1, &handler, &old_handler)) {
+        if(!raise(SIGUSR1)) {
+          thread->coentry = coentry;
+        }
+        sigaltstack(&old_stack, 0);
+        sigaction(SIGUSR1, &old_handler, 0);
+      }
+    }
+
+    if(thread->coentry != coentry) {
+      co_delete(thread);
+      thread = 0;
+    }
+  }
+
+  return (cothread_t)thread;
+}
+
+void co_delete(cothread_t cothread) {
+  if(cothread) {
+    if(((cothread_struct*)cothread)->stack) {
+      free(((cothread_struct*)cothread)->stack);
+    }
+    free(cothread);
+  }
+}
+
+void co_switch(cothread_t cothread) {
+  if(!sigsetjmp(co_running->context, 0)) {
+    co_running = (cothread_struct*)cothread;
+    siglongjmp(co_running->context, 1);
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/3pp/libco/ucontext.c
+++ b/3pp/libco/ucontext.c
@@ -1,0 +1,69 @@
+/*
+  libco.ucontext (2008-01-28)
+  author: Nach
+  license: public domain
+*/
+
+/*
+  WARNING: the overhead of POSIX ucontext is very high,
+  assembly versions of libco or libco_sjlj should be much faster
+
+  this library only exists for two reasons:
+  1: as an initial test for the viability of a ucontext implementation
+  2: to demonstrate the power and speed of libco over existing implementations,
+     such as pth (which defaults to wrapping ucontext on unix targets)
+
+  use this library only as a *last resort*
+*/
+
+#define LIBCO_C
+#include "libco.h"
+
+#define _BSD_SOURCE
+#include <stdlib.h>
+#include <ucontext.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static thread_local ucontext_t co_primary;
+static thread_local ucontext_t* co_running = 0;
+
+cothread_t co_active() {
+  if(!co_running) co_running = &co_primary;
+  return (cothread_t)co_running;
+}
+
+cothread_t co_create(unsigned int heapsize, void (*coentry)(void)) {
+  if(!co_running) co_running = &co_primary;
+  ucontext_t* thread = (ucontext_t*)malloc(sizeof(ucontext_t));
+  if(thread) {
+    if((!getcontext(thread) && !(thread->uc_stack.ss_sp = 0)) && (thread->uc_stack.ss_sp = malloc(heapsize))) {
+      thread->uc_link = co_running;
+      thread->uc_stack.ss_size = heapsize;
+      makecontext(thread, coentry, 0);
+    } else {
+      co_delete((cothread_t)thread);
+      thread = 0;
+    }
+  }
+  return (cothread_t)thread;
+}
+
+void co_delete(cothread_t cothread) {
+  if(cothread) {
+    if(((ucontext_t*)cothread)->uc_stack.ss_sp) { free(((ucontext_t*)cothread)->uc_stack.ss_sp); }
+    free(cothread);
+  }
+}
+
+void co_switch(cothread_t cothread) {
+  ucontext_t* old_thread = co_running;
+  co_running = (ucontext_t*)cothread;
+  swapcontext(old_thread, co_running);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/3pp/libco/x86.c
+++ b/3pp/libco/x86.c
@@ -1,0 +1,114 @@
+/*
+  libco.x86 (2016-09-14)
+  author: byuu
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+  #define fastcall __attribute__((fastcall))
+#elif defined(_MSC_VER)
+  #define fastcall __fastcall
+#else
+  #error "libco: please define fastcall macro"
+#endif
+
+static thread_local long co_active_buffer[64];
+static thread_local cothread_t co_active_handle = 0;
+static void (fastcall *co_swap)(cothread_t, cothread_t) = 0;
+
+#ifdef LIBCO_MPROTECT
+  alignas(4096)
+#else
+  section(text)
+#endif
+/* ABI: fastcall */
+static const unsigned char co_swap_function[4096] = {
+  0x89, 0x22,        /* mov [edx],esp    */
+  0x8b, 0x21,        /* mov esp,[ecx]    */
+  0x58,              /* pop eax          */
+  0x89, 0x6a, 0x04,  /* mov [edx+ 4],ebp */
+  0x89, 0x72, 0x08,  /* mov [edx+ 8],esi */
+  0x89, 0x7a, 0x0c,  /* mov [edx+12],edi */
+  0x89, 0x5a, 0x10,  /* mov [edx+16],ebx */
+  0x8b, 0x69, 0x04,  /* mov ebp,[ecx+ 4] */
+  0x8b, 0x71, 0x08,  /* mov esi,[ecx+ 8] */
+  0x8b, 0x79, 0x0c,  /* mov edi,[ecx+12] */
+  0x8b, 0x59, 0x10,  /* mov ebx,[ecx+16] */
+  0xff, 0xe0,        /* jmp eax          */
+};
+
+#ifdef _WIN32
+  #include <windows.h>
+
+  static void co_init() {
+    #ifdef LIBCO_MPROTECT
+    DWORD old_privileges;
+    VirtualProtect((void*)co_swap_function, sizeof co_swap_function, PAGE_EXECUTE_READ, &old_privileges);
+    #endif
+  }
+#else
+  #include <unistd.h>
+  #include <sys/mman.h>
+
+  static void co_init() {
+    #ifdef LIBCO_MPROTECT
+    unsigned long addr = (unsigned long)co_swap_function;
+    unsigned long base = addr - (addr % sysconf(_SC_PAGESIZE));
+    unsigned long size = (addr - base) + sizeof co_swap_function;
+    mprotect((void*)base, size, PROT_READ | PROT_EXEC);
+    #endif
+  }
+#endif
+
+static void crash() {
+  assert(0);  /* called only if cothread_t entrypoint returns */
+}
+
+cothread_t co_active() {
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  return co_active_handle;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
+  cothread_t handle;
+  if(!co_swap) {
+    co_init();
+    co_swap = (void (fastcall*)(cothread_t, cothread_t))co_swap_function;
+  }
+  if(!co_active_handle) co_active_handle = &co_active_buffer;
+  size += 256;  /* allocate additional space for storage */
+  size &= ~15;  /* align stack to 16-byte boundary */
+
+  if(handle = (cothread_t)malloc(size)) {
+    long *p = (long*)((char*)handle + size);  /* seek to top of stack */
+    *--p = (long)crash;                       /* crash if entrypoint returns */
+    *--p = (long)entrypoint;                  /* start of function */
+    *(long*)handle = (long)p;                 /* stack pointer */
+  }
+
+  return handle;
+}
+
+void co_delete(cothread_t handle) {
+  free(handle);
+}
+
+void co_switch(cothread_t handle) {
+  register cothread_t co_previous_handle = co_active_handle;
+  co_swap(co_active_handle = handle, co_previous_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ LD      = $(CC)
 STRIP   = $(BASE)-strip
 
 INCLUDE	= -I./
-INCLUDE	= -I./support/minimig
+INCLUDE	+= -I./support/minimig
+INCLUDE	+= -I./3pp/libco
 
 PRJ = MiSTer
 SRC = $(wildcard *.c)
@@ -21,11 +22,12 @@ ARCHIE_SRC	= $(wildcard ./support/archie/*.cpp)
 ST_SRC	= $(wildcard ./support/st/*.cpp)
 X86_SRC	= $(wildcard ./support/x86/*.cpp)
 SNES_SRC	= $(wildcard ./support/snes/*.cpp)
+LIBCO_SRC	= 3pp/libco/arm.c
 
 VPATH	= ./:./support/minimig:./support/sharpmz:./support/archie:./support/st:./support/x86:./support/snes
 
-OBJ	= $(SRC:.c=.o) $(SRC2:.cpp=.o) $(MINIMIG_SRC:.cpp=.o) $(SHARPMZ_SRC:.cpp=.o) $(ARCHIE_SRC:.cpp=.o) $(ST_SRC:.cpp=.o) $(X86_SRC:.cpp=.o) $(SNES_SRC:.cpp=.o)
-DEP	= $(SRC:.c=.d) $(SRC2:.cpp=.d) $(MINIMIG_SRC:.cpp=.d) $(SHARPMZ_SRC:.cpp=.d) $(ARCHIE_SRC:.cpp=.d) $(ST_SRC:.cpp=.d) $(X86_SRC:.cpp=.d)	$(SNES_SRC:.cpp=.d)
+OBJ	= $(SRC:.c=.o) $(SRC2:.cpp=.o) $(MINIMIG_SRC:.cpp=.o) $(SHARPMZ_SRC:.cpp=.o) $(ARCHIE_SRC:.cpp=.o) $(ST_SRC:.cpp=.o) $(X86_SRC:.cpp=.o) $(SNES_SRC:.cpp=.o) $(LIBCO_SRC:.c=.o)
+DEP	= $(SRC:.c=.d) $(SRC2:.cpp=.d) $(MINIMIG_SRC:.cpp=.d) $(SHARPMZ_SRC:.cpp=.d) $(ARCHIE_SRC:.cpp=.d) $(ST_SRC:.cpp=.d) $(X86_SRC:.cpp=.d) $(SNES_SRC:.cpp=.d) $(LIBCO_SRC:.c=.d)
 
 DFLAGS	= $(INCLUDE)
 CFLAGS	= $(DFLAGS) -Wall -Wextra -c -O3 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DVDATE=\"`date +"%y%m%d"`\"

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "user_io.h"
 #include "input.h"
 #include "fpga_io.h"
+#include "scheduler.h"
 
 const char *version = "$VER:HPS" VDATE;
 
@@ -75,26 +76,8 @@ int main(int argc, char *argv[])
 	FindStorage();
 	user_io_init((argc > 1) ? argv[1] : "");
 
-	while(1)
-	{
-		if(!is_fpga_ready(1))
-		{
-			printf("FPGA is not ready. JTAG uploading?\n");
-			printf("Waiting for FPGA to be ready...\n");
+	scheduler_init();
+	scheduler_run();
 
-			//enable reset in advance
-			fpga_core_reset(1);
-
-			while (!is_fpga_ready(0))
-			{
-				sleep(1);
-			}
-			reboot(0);
-		}
-
-		user_io_poll();
-		input_poll(0);
-		HandleUI();
-	}
 	return 0;
 }

--- a/menu.h
+++ b/menu.h
@@ -1,6 +1,8 @@
 #ifndef MENU_H
 #define MENU_H
 
+#include <inttypes.h>
+
 // UI strings, used by boot messages
 extern const char *config_memory_chip_msg[];
 extern const char *config_memory_slow_msg[];

--- a/scheduler.cpp
+++ b/scheduler.cpp
@@ -1,0 +1,94 @@
+#include "scheduler.h"
+#include <stdio.h>
+#include "libco.h"
+#include "menu.h"
+#include "user_io.h"
+#include "input.h"
+#include "fpga_io.h"
+
+static cothread_t co_scheduler = nullptr;
+static cothread_t co_poll = nullptr;
+static cothread_t co_ui = nullptr;
+static cothread_t co_last = nullptr;
+
+static void scheduler_wait_fpga_ready(void)
+{
+	while (!is_fpga_ready(1))
+	{
+		printf("FPGA is not ready. JTAG uploading?\n");
+		printf("Waiting for FPGA to be ready...\n");
+
+		//enable reset in advance
+		fpga_core_reset(1);
+
+		while (!is_fpga_ready(0))
+		{
+			sleep(1);
+		}
+		reboot(0);
+	}
+}
+
+static void scheduler_co_poll(void)
+{
+	for (;;)
+	{
+		scheduler_wait_fpga_ready();
+
+		user_io_poll();
+		input_poll(0);
+
+		scheduler_yield();
+	}
+}
+
+static void scheduler_co_ui(void)
+{
+	for (;;)
+	{
+		HandleUI();
+
+		scheduler_yield();
+	}
+}
+
+static void scheduler_schedule(void)
+{
+	if (co_last == co_poll)
+	{
+		co_last = co_ui;
+		co_switch(co_ui);
+	}
+	else
+	{
+		co_last = co_poll;
+		co_switch(co_poll);
+	}
+}
+
+void scheduler_init(void)
+{
+	const unsigned int co_stack_size = 262144 * sizeof(void*);
+
+	co_poll = co_create(co_stack_size, scheduler_co_poll);
+	co_ui = co_create(co_stack_size, scheduler_co_ui);
+}
+
+void scheduler_run(void)
+{
+	co_scheduler = co_active();
+
+	for (;;)
+	{
+		scheduler_schedule();
+	}
+
+	co_delete(co_ui);
+	co_delete(co_poll);
+	co_delete(co_scheduler);
+}
+
+void scheduler_yield(void)
+{
+	co_switch(co_scheduler);
+}

--- a/scheduler.h
+++ b/scheduler.h
@@ -1,0 +1,8 @@
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+void scheduler_init(void);
+void scheduler_run(void);
+void scheduler_yield(void);
+
+#endif


### PR DESCRIPTION
Schedules tasks in the main loop using coroutines so that long running
tasks, particularly relating to the UI, can yield execution in order to
call the poll functions at a tighter interval.

Yields at an interval during the loading of directory entries as well as
while sorting them in order to avoid starving the poll functions while
entering directories containing a large number of files.

The maximum time between calls to `user_io_poll` in the main loop were
measured while loading a folder containing 29026 entries:

 - Original main-loop:       591ms
 - With coroutines + yields:  29ms

The amount of time it takes to load and sort the 29k entries:

 - Original main-loop:       591ms
 - With coroutines + yields: 686ms

By increasing the value of `YieldIterations` in `file_io.cpp` the load
time will decrease while increasing the delay between calls to
`user_io_poll`.