### PR TITLE
Small update to 'UART mode' menu

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -1523,13 +1523,13 @@ void HandleUI(void)
 			OsdWrite(1, s, menusub == 0, 0);
 			OsdWrite(2);
 
-			sprintf(s, " MIDI link:           %s", (midilink & 2) ? "Remote" : " Local");
+			sprintf(s, " MidiLink:            %s", (midilink & 2) ? "Remote" : " Local");
 			OsdWrite(3, s, menusub == 1, m);
 			sprintf(s, " Type:            %s", (midilink & 2) ? ((midilink & 1) ? "       UDP" : "       TCP") : ((midilink & 1) ? "      MUNT" : "FluidSynth"));
 			OsdWrite(4, s, menusub == 2, m);
 			
 			OsdWrite(5);
-			OsdWrite(6, " Reset UART Connection", menusub == 3, mode?0:1);
+			OsdWrite(6, " Reset UART connection", menusub == 3, mode?0:1);
 			OsdWrite(7);
 			OsdWrite(8, " Save", menusub == 4);
 


### PR DESCRIPTION
I thought it might be best to change the "MIDI link" to "MidiLink" to match the consistency of the existing documentation and the "MidiLink.INI" file and project names.

I also noticed I had a made capitalization inconsistent with other menus.
'Reset UART connection' vs 'Reset UART Connection'

These are entirely superficial and obviously up to you :) 

Thanks! 