### PR TITLE
Fix PAD emulation on axis 0/1

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2185,7 +2185,6 @@ int input_test(int getchar)
 								char offset_mask1, offset_mask2;
 
 								if (ev.code < 16) offset += 4;
-								if (ev.code < 2)  offset += 4;
 								offset_mask1 = (1 << (offset >> 1)); // 01XX
 								offset_mask2 = (2 << (offset >> 1)); // 10XX
 


### PR DESCRIPTION
Hi,

My understanding is that axes 0/1 should also be taken into account for emulation of the DPAD. At least it is was the comment says. Without the proposed change the offset variable is incremented twice and I am not sure it is the intended behavior. 
I have tested the fix in OSD menu, some Cores and with mouse emulation. It is working as expected and I do not experience any odd behavior.
Let me know if the removed line has a required purpose.

Regards,

