### PR TITLE
Fix Archie menu to let you select EXIT

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -871,7 +871,7 @@ void HandleUI(void)
 	case MENU_ARCHIE_MAIN1:
 		OsdSetTitle(user_io_get_core_name(), OSD_ARROW_RIGHT | OSD_ARROW_LEFT);
 
-		menumask = 0x3f;
+		menumask = 0x7f;
 		OsdWrite(0, "", 0, 0);
 
 		strcpy(s, " Floppy 0: ");


### PR DESCRIPTION
Fix issue where you can't cursor down to [EXIT] in Archie menu

