### PR TITLE
Add INI option to set HDMI output to Limited RGB

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -38,6 +38,7 @@ const ini_var_t ini_vars[] = {
 	{ "VSYNC_ADJUST", (void*)(&(cfg.vsync_adjust)), UINT8, 0, 2, 1 },
 	{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1, 1 },
 	{ "DVI_MODE", (void*)(&(cfg.dvi)), UINT8, 0, 1, 1 },
+	{ "HDMI_LIMITED", (void*)(&(cfg.hdmi_limited)), UINT8, 0, 1, 1 },
 	{ "KBD_NOMOUSE", (void*)(&(cfg.kbd_nomouse)), UINT8, 0, 1, 1 },
 	{ "MOUSE_THROTTLE", (void*)(&(cfg.mouse_throttle)), UINT8, 1, 100, 1 },
 	{ "BOOTSCREEN", (void*)(&(cfg.bootscreen)), UINT8, 0, 1, 1 },

--- a/cfg.h
+++ b/cfg.h
@@ -22,6 +22,7 @@ typedef struct {
 	uint8_t vga_scaler;
 	uint8_t hdmi_audio_96k;
 	uint8_t dvi;
+	uint8_t hdmi_limited;
 	uint8_t video_info;
 	uint8_t vsync_adjust;
 	uint8_t kbd_nomouse;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1516,6 +1516,7 @@ void user_io_send_buttons(char force)
 	if (cfg.forced_scandoubler) map |= CONF_FORCED_SCANDOUBLER;
 	if (cfg.hdmi_audio_96k) map |= CONF_AUDIO_96K;
 	if (cfg.dvi) map |= CONF_DVI;
+	if (cfg.hdmi_limited && !cfg.dvi) map |= CONF_HDMI_LIMITED;
 
 	if ((map != key_map) || force)
 	{

--- a/user_io.h
+++ b/user_io.h
@@ -116,14 +116,15 @@
 #define KBD_LED_FLAG_MASK     0xC0
 #define KBD_LED_FLAG_STATUS   0x40
 
-#define BUTTON1                 0b00000001
-#define BUTTON2                 0b00000010
-#define CONF_VGA_SCALER         0b00000100
-#define CONF_CSYNC              0b00001000
-#define CONF_FORCED_SCANDOUBLER 0b00010000
-#define CONF_YPBPR              0b00100000
-#define CONF_AUDIO_96K          0b01000000
-#define CONF_DVI                0b10000000
+#define BUTTON1                 0b000000001
+#define BUTTON2                 0b000000010
+#define CONF_VGA_SCALER         0b000000100
+#define CONF_CSYNC              0b000001000
+#define CONF_FORCED_SCANDOUBLER 0b000010000
+#define CONF_YPBPR              0b000100000
+#define CONF_AUDIO_96K          0b001000000
+#define CONF_DVI                0b010000000
+#define CONF_HDMI_LIMITED       0b100000000
 
 // core type value should be unlikely to be returned by broken cores
 #define CORE_TYPE_UNKNOWN   0x55


### PR DESCRIPTION
This tells the core to configure the HDMI output to Limited RGB range.

I've submitted a Pull Request against Menu_MiSTer for the FPGA side changes.