### PR TITLE
Allow use of "games" folder for core rom folders.

### DIFF
--- a/cheats.cpp
+++ b/cheats.cpp
@@ -51,7 +51,7 @@ static char cheat_zip[1024] = {};
 
 int find_by_crc(uint32_t romcrc)
 {
-	sprintf(cheat_zip, "%s/cheats/%s", getRootDir(), HomeDir);
+	sprintf(cheat_zip, "%s/cheats/%s", getRootDir(), CoreName);
 	DIR *d = opendir(cheat_zip);
 	if (!d)
 	{
@@ -108,7 +108,7 @@ void cheats_init(const char *rom_path, uint32_t romcrc)
 		const char *rom_name = strrchr(rom_path, '/');
 		if (rom_name)
 		{
-			sprintf(cheat_zip, "%s/cheats/%s%s", getRootDir(), HomeDir, rom_name);
+			sprintf(cheat_zip, "%s/cheats/%s%s", getRootDir(), CoreName, rom_name);
 			char *p = strrchr(cheat_zip, '.');
 			if (p) *p = 0;
 			strcat(cheat_zip, ".zip");

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -624,9 +624,17 @@ static void create_path(const char *base_dir, const char* sub_dir)
 	mkdir(full_path, S_IRWXU | S_IRWXG | S_IRWXO);
 }
 
+void FileCreatePath(char *dir)
+{
+	if (!isPathDirectory(dir)) {
+		make_fullpath(dir);
+		mkdir(full_path, S_IRWXU | S_IRWXG | S_IRWXO);
+	}
+}
+
 void FileGenerateScreenshotName(const char *name, char *out_name, int buflen)
 {
-	create_path(SCREENSHOT_DIR, HomeDir);
+	create_path(SCREENSHOT_DIR, CoreName);
 
 	time_t t = time(NULL);
 	struct tm tm = *localtime(&t);
@@ -634,13 +642,13 @@ void FileGenerateScreenshotName(const char *name, char *out_name, int buflen)
 	if (tm.tm_year >= 119) // 2019 or up considered valid time
 	{
 		strftime(datecode, 31, "%Y%m%d_%H%M%S", &tm);
-		snprintf(out_name, buflen, "%s/%s/%s-%s.png", SCREENSHOT_DIR, HomeDir, datecode, name[0] ? name : SCREENSHOT_DEFAULT);
+		snprintf(out_name, buflen, "%s/%s/%s-%s.png", SCREENSHOT_DIR, CoreName, datecode, name[0] ? name : SCREENSHOT_DEFAULT);
 	}
 	else
 	{
 		for (int i = 1; i < 10000; i++)
 		{
-			snprintf(out_name, buflen, "%s/%s/NODATE-%s_%04d.png", SCREENSHOT_DIR, HomeDir, name[0] ? name : SCREENSHOT_DEFAULT, i);
+			snprintf(out_name, buflen, "%s/%s/NODATE-%s_%04d.png", SCREENSHOT_DIR, CoreName, name[0] ? name : SCREENSHOT_DEFAULT, i);
 			if (!getFileType(out_name)) return;
 		}
 	}
@@ -648,9 +656,9 @@ void FileGenerateScreenshotName(const char *name, char *out_name, int buflen)
 
 void FileGenerateSavePath(const char *name, char* out_name)
 {
-	create_path(SAVE_DIR, HomeDir);
+	create_path(SAVE_DIR, CoreName);
 
-	sprintf(out_name, "%s/%s/", SAVE_DIR, HomeDir);
+	sprintf(out_name, "%s/%s/", SAVE_DIR, CoreName);
 	char *fname = out_name + strlen(out_name);
 
 	const char *p = strrchr(name, '/');
@@ -684,6 +692,20 @@ uint32_t getFileType(const char *name)
 	if (stat64(full_path, &st)) return 0;
 
 	return st.st_mode;
+}
+
+void prefixGameDir(char *dir, size_t dir_len)
+{
+	if (isPathDirectory(dir)) {
+		printf("Found existing: %s\n", dir);
+		return;
+	}
+
+	FileCreatePath((char *) GAMES_DIR);
+	static char temp_dir[1024];
+	snprintf(temp_dir, 1024, "%s/%s", GAMES_DIR, dir);
+	strncpy(dir, temp_dir, dir_len);
+	printf("Prefixed dir to %s\n", temp_dir);
 }
 
 static int device = 0;

--- a/file_io.h
+++ b/file_io.h
@@ -69,6 +69,7 @@ int FileReadAdv(fileTYPE *file, void *pBuffer, int length);
 int FileReadSec(fileTYPE *file, void *pBuffer);
 int FileWriteAdv(fileTYPE *file, void *pBuffer, int length);
 int FileWriteSec(fileTYPE *file, void *pBuffer);
+void FileCreatePath(char *dir);
 
 int FileExists(const char *name);
 int FileCanWrite(const char *name);
@@ -91,6 +92,8 @@ int FileLoadConfig(const char *name, void *pBuffer, int size); // supply pBuffer
 void AdjustDirectory(char *path);
 int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix = NULL);
 
+void prefixGameDir(char *dir, size_t dir_len);
+
 const char *getStorageDir(int dev);
 const char *getRootDir();
 const char *getFullPath(const char *name);
@@ -99,5 +102,6 @@ uint32_t getFileType(const char *name);
 
 #define COEFF_DIR "filters"
 #define GAMMA_DIR "gamma"
+#define GAMES_DIR "games"
 
 #endif

--- a/menu.cpp
+++ b/menu.cpp
@@ -333,6 +333,9 @@ static void SelectFile(const char* pFileExt, unsigned char Options, unsigned cha
 		strcpy(SelectedPath, HomeDir);
 	}
 
+	if (!strcasecmp(HomeDir, SelectedPath))
+		FileCreatePath(SelectedPath);
+
 	ScanDirectory(SelectedPath, SCANF_INIT, pFileExt, Options);
 	if (!flist_nDirEntries())
 	{

--- a/support/archie/archie.cpp
+++ b/support/archie/archie.cpp
@@ -196,7 +196,7 @@ void archie_init(void)
 
 	// set config defaults
 	config.system_ctrl = 0;
-	strcpy(config.rom_img, "Archie/RISCOS.ROM");
+	snprintf(config.rom_img, 1024, "%s/%s", HomeDir, "RISCOS.ROM");
 
 	// try to load config from card
 	int size = FileLoadConfig(CONFIG_FILENAME, 0, 0);
@@ -223,7 +223,8 @@ void archie_init(void)
 
 	// upload ext file
 	//user_io_file_tx("Archie/RISCOS.EXT", 2);
-	user_io_file_tx("Archie/CMOS.DAT", 3);
+
+	user_io_file_tx(user_io_make_filepath(HomeDir, "CMOS.DAT"), 3);
 
 	user_io_8bit_set_status(0, UIO_STATUS_RESET);
 

--- a/support/minimig/minimig_boot.cpp
+++ b/support/minimig/minimig_boot.cpp
@@ -167,7 +167,7 @@ static void BootUploadLogo()
 	int i = 0;
 	int adr;
 
-	if (FileOpen(&file, "Amiga/" LOGO_FILE) || FileOpen(&file, LOGO_FILE)) {
+	if (FileOpen(&file, user_io_make_filepath(HomeDir, LOGO_FILE)) || FileOpen(&file, LOGO_FILE)) {
 		FileReadSec(&file, buffer);
 		mem_upload_init(SCREEN_BPL1 + LOGO_OFFSET);
 		adr = SCREEN_BPL1 + LOGO_OFFSET;
@@ -226,7 +226,7 @@ static void BootUploadBall()
 	int i = 0;
 	int adr;
 
-	if (FileOpen(&file, "Amiga/" BALL_FILE) || FileOpen(&file, BALL_FILE))
+	if (FileOpen(&file, user_io_make_filepath(HomeDir, BALL_FILE)) || FileOpen(&file, BALL_FILE))
 	{
 		FileReadSec(&file, buffer);
 		mem_upload_init(BALL_ADDRESS);
@@ -256,7 +256,7 @@ static void BootUploadCopper()
 	int i = 0;
 	int adr;
 
-	if (FileOpen(&file, "Amiga/" COPPER_FILE) || FileOpen(&file, COPPER_FILE))
+	if (FileOpen(&file, user_io_make_filepath(HomeDir, COPPER_FILE)) || FileOpen(&file, COPPER_FILE))
 	{
 		FileReadSec(&file, buffer);
 		mem_upload_init(COPPER_ADDRESS);

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -90,7 +90,7 @@ static char UploadKickstart(char *name)
 	int keysize = 0;
 
 	BootPrint("Checking for Amiga Forever key file:");
-	if (FileOpen(&file, "Amiga/ROM.KEY") || FileOpen(&file, "ROM.KEY")) {
+	if (FileOpen(&file, user_io_make_filepath(HomeDir, "ROM.KEY")) || FileOpen(&file, "ROM.KEY")) {
 		keysize = file.size;
 		if (file.size<sizeof(romkey))
 		{
@@ -191,7 +191,7 @@ static char UploadKickstart(char *name)
 static char UploadActionReplay()
 {
 	fileTYPE file = {};
-	if(FileOpen(&file, "Amiga/HRTMON.ROM") || FileOpen(&file, "HRTMON.ROM"))
+	if(FileOpen(&file, user_io_make_filepath(HomeDir, "HRTMON.ROM")) || FileOpen(&file, "HRTMON.ROM"))
 	{
 		int adr, data;
 		puts("Uploading HRTmon ROM... ");
@@ -337,7 +337,7 @@ static void ApplyConfiguration(char reloadkickstart)
 		spi_uio_cmd8(UIO_MM2_RST, rstval);
 		if (!UploadKickstart(minimig_config.kickstart))
 		{
-			strcpy(minimig_config.kickstart, "Amiga/KICK.ROM");
+			snprintf(minimig_config.kickstart, 1024, "%s/%s", HomeDir, "KICK.ROM");
 			if (!UploadKickstart(minimig_config.kickstart))
 			{
 				strcpy(minimig_config.kickstart, "KICK.ROM");
@@ -440,7 +440,7 @@ int minimig_cfg_load(int num)
 		// set default configuration
 		memset((void*)&minimig_config, 0, sizeof(minimig_config));  // Finally found default config bug - params were reversed!
 		strncpy(minimig_config.id, config_id, sizeof(minimig_config.id));
-		strcpy(minimig_config.kickstart, "Amiga/KICK.ROM");
+		snprintf(minimig_config.kickstart, 1024, "%s/%s", HomeDir, "KICK.ROM");
 		minimig_config.memory = 0x11;
 		minimig_config.cpu = 0;
 		minimig_config.chipset = 0;

--- a/support/x86/x86.cpp
+++ b/support/x86/x86.cpp
@@ -500,8 +500,8 @@ void x86_init()
 {
 	user_io_8bit_set_status(UIO_STATUS_RESET, UIO_STATUS_RESET);
 
-	load_bios("ao486/boot0.rom", 0);
-	load_bios("ao486/boot1.rom", 1);
+	load_bios(user_io_make_filepath(HomeDir, "boot0.rom"), 0);
+	load_bios(user_io_make_filepath(HomeDir, "boot1.rom"), 1);
 
 	IOWR(PC_BUS_BASE, 0, 0x00FFF0EA);
 	IOWR(PC_BUS_BASE, 1, 0x000000F0);

--- a/user_io.h
+++ b/user_io.h
@@ -210,7 +210,9 @@ int user_io_file_tx(const char* name, unsigned char index = 0, char opensave = 0
 uint32_t user_io_get_file_crc();
 int  user_io_file_mount(char *name, unsigned char index = 0, char pre = 0);
 char user_io_serial_status(serial_status_t *, uint8_t);
+char *user_io_make_filepath(const char *path, const char *filename);
 char *user_io_get_core_name();
+char *user_io_get_core_path();
 const char *user_io_get_core_name_ex();
 char has_menu();
 
@@ -277,6 +279,7 @@ char is_x86_core();
 char is_snes_core();
 char is_neogeo_core();
 
-#define HomeDir (is_minimig() ? "Amiga" : is_archie() ? "Archie" : is_menu_core() ? "Scripts" : user_io_get_core_name())
+#define HomeDir (is_menu_core() ? "Scripts" : user_io_get_core_path())
+#define CoreName (is_menu_core() ? "Scripts" : user_io_get_core_name())
 
 #endif // USER_IO_H


### PR DESCRIPTION
-Allows users to put core folders in /games instead of just /
-Will check for folder in /corename first, then move to /games/corename
-If neither /corename or /games/corename exists, a /games/corename folder will be created when the user attempts to load a file from there.