### PR TITLE
Show gamepad in OSD when doing button mapping

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2200,7 +2200,44 @@ void HandleUI(void)
 
 			OsdWrite(3, s, 0, 0);
 			OsdWrite(4);
-			if (!line_info) OsdWrite(12);
+			
+			if (!line_info) {
+				if(is_menu_core() && joy_bcount && get_map_button() < DPAD_BUTTON_NAMES)
+				{
+					p = joy_bnames[get_map_button() - DPAD_NAMES];
+					// draw an on-screen gamepad to help with central button mapping
+					OsdWrite(10, "  \x86 L1\x88               \x86 R1\x88  ");
+					if (!strcmp(p, "L"))	OsdWriteDelay(10, "  \x86 \x1b \x88               \x86 R1\x88  ");
+					if (!strcmp(p, "R"))	OsdWriteDelay(10, "  \x86 L1\x88               \x86 \x1b \x88  ");
+					OsdWrite(11, " \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88");
+					OsdWrite(12, " \x83   U                 X   \x83");
+					if (!strcmp(p, "UP"))			OsdWriteDelay(12, " \x83   \x1b                 X   \x83");
+					if (!strcmp(p, "X (Backspace)"))OsdWriteDelay(12, " \x83   U                 \x1b   \x83");
+					OsdWrite(13, " \x83 L \x1b R  Sel Start  Y   A \x83");
+					if (!strcmp(p, "A (OK/Enter)"))	OsdWriteDelay(13, " \x83 L \x1b R  Sel Start  Y   \x1b \x83");
+					if (!strcmp(p, "Y"))			OsdWriteDelay(13, " \x83 L \x1b R  Sel Start  \x1b   A \x83");
+					if (!strcmp(p, "LEFT"))			OsdWriteDelay(13, " \x83 \x1b \x1b R  Sel Start  \x1b   A \x83");
+					if (!strcmp(p, "RIGHT"))		OsdWriteDelay(13, " \x83 L \x1b \x1b  Sel Start  \x1b   A \x83");
+					if (!strcmp(p, "Select"))		OsdWriteDelay(13, " \x83 L \x1b R   \x1b  Start  Y   A \x83");
+					if (!strcmp(p, "Start"))		OsdWriteDelay(13, " \x83 L \x1b R  Sel   \x1b    Y   A \x83");
+					OsdWrite(14, " \x83   D   \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88   B   \x83");
+					if (!strcmp(p, "DOWN"))			OsdWrite(14, " \x83   \x1b   \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88   B   \x83");
+					if (!strcmp(p, "B (ESC/Back)"))	OsdWrite(14, " \x83   D   \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88   \x1b   \x83");
+					OsdWrite(15, " \x8b\x81\x81\x81\x81\x81\x81\x81\x8a         \x8b\x81\x81\x81\x81\x81\x81\x81\x8a");
+				} else {
+					if(is_menu_core()){
+						//clear all gamepad gfx
+						OsdWrite(10);
+						OsdWrite(11);
+						OsdWrite(12);
+						OsdWrite(13);
+						OsdWrite(14);
+						OsdWrite(15);
+					} else {
+						OsdWrite(12);
+					}
+				}
+			}
 
 			if (get_map_vid() || get_map_pid())
 			{

--- a/osd.cpp
+++ b/osd.cpp
@@ -205,6 +205,15 @@ void OsdWrite(unsigned char n, const char *s, unsigned char invert, unsigned cha
 	OsdWriteOffset(n, s, invert, stipple, 0, 0, usebg, maxinv);
 }
 
+void OsdWriteDelay(unsigned char n, const char *s, unsigned char invert, unsigned char stipple, char usebg, int maxinv)
+{
+	if (s && s[0] && CheckTimer(scroll_timer)) // scroll if long name and timer delay elapsed
+	{
+		OsdWrite(n, s, invert, stipple, usebg, maxinv);
+		scroll_timer = GetTimer(SCROLL_DELAY2); // reset scroll timer to repeat delay
+	}
+}
+
 // write a null-terminated string <s> to the OSD buffer starting at line <n>
 void OsdWriteOffset(unsigned char n, const char *s, unsigned char invert, unsigned char stipple, char offset, char leftchar, char usebg, int maxinv)
 {

--- a/osd.h
+++ b/osd.h
@@ -24,6 +24,7 @@ void OsdSetTitle(const char *s, int arrow = 0);	// arrow > 0 = display right arr
 void OsdSetArrow(int arrow);
 void OsdWrite(unsigned char n, const char *s="", unsigned char inver=0, unsigned char stipple=0, char usebg = 0, int maxinv = 32);
 void OsdWriteOffset(unsigned char n, const char *s, unsigned char inver, unsigned char stipple, char offset, char leftchar, char usebg = 0, int maxinv = 32); // Used for scrolling "Exit" text downwards...
+void OsdWriteDelay(unsigned char n, const char *s="", unsigned char inver=0, unsigned char stipple=0, char usebg = 0, int maxinv = 32); //same as OsdWrite but with a certain delay. Used for "blinking" text lines
 void OsdClear(void);
 void OsdEnable(unsigned char mode);
 void InfoEnable(int x, int y, int width, int height);


### PR DESCRIPTION
Add visual representation of the internal MiSTer gamepad when mapping from the menu core.
(it is not shown when mapping from regular cores)

This will help users map their controllers more intuitively.

![OSDgamepad](https://user-images.githubusercontent.com/11873537/67349463-87858300-f57a-11e9-87dd-eecaf8730131.png)




