### PR TITLE
input: don't merge blisster adapter ports

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2596,7 +2596,8 @@ int input_test(int getchar)
 						}
 
 						// Raphnet devices: clear uniq to prevent merging the ports
-						if (input[n].vid == 0x289b)
+						// bliss-box adapters need this as well
+						if (input[n].vid == 0x289b || input[n].vid == 0x16d0)
 						{
 							memset(input[n].uniq, 0, sizeof(input[n].uniq));
 						}


### PR DESCRIPTION
The blisSTer board has the same issue as the raphnet adapters had previously, both controller adapters are seen as player 1. This commit fixes that