### PR TITLE
add smart usb and cifs searches to game folder paths

### DIFF
--- a/file_io.h
+++ b/file_io.h
@@ -109,5 +109,6 @@ uint32_t getFileType(const char *name);
 #define COEFF_DIR "filters"
 #define GAMMA_DIR "gamma"
 #define GAMES_DIR "games"
+#define CIFS_DIR "cifs"
 
 #endif


### PR DESCRIPTION
this will search usb drives, then /media/fat/cifs, and then /media/fat/games for games folders, allowing people to also have games dirs on their usb devices or cifs drive without the need to change the root path.