### PR TITLE
Fix OSD combo button state issues

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -1592,15 +1592,21 @@ static void joy_digital(int jnum, uint32_t mask, uint32_t code, char press, int 
 			return;
 		}
 
+		// clear OSD button state if not in the OSD.  this avoids problems where buttons are still held
+		// on OSD exit and causes combinations to match when partial buttons are pressed.
+		if (!user_io_osd_is_visible()) osdbtn = 0;
+
 		if (user_io_osd_is_visible() || (bnum == BTN_OSD))
 		{
 			if (press)
 			{
 				osdbtn |= mask;
-				if ((osdbtn & (JOY_BTN1 | JOY_BTN2)) == (JOY_BTN1 | JOY_BTN2))
-				{
-					osdbtn |= JOY_BTN3;
-					mask = JOY_BTN3;
+				if (mask & (JOY_BTN1 | JOY_BTN2)) {
+					if ((osdbtn & (JOY_BTN1 | JOY_BTN2)) == (JOY_BTN1 | JOY_BTN2))
+					{
+						osdbtn |= JOY_BTN3;
+						mask = JOY_BTN3;
+					}
 				}
 			}
 			else
@@ -1608,14 +1614,16 @@ static void joy_digital(int jnum, uint32_t mask, uint32_t code, char press, int 
 				int old_osdbtn = osdbtn;
 				osdbtn &= ~mask;
 
-				if ((old_osdbtn & (JOY_BTN1 | JOY_BTN2 | JOY_BTN3)) == (JOY_BTN1 | JOY_BTN2 | JOY_BTN3))
-				{
-					mask = JOY_BTN3;
-				}
-				else if (old_osdbtn & JOY_BTN3)
-				{
-					if (!(osdbtn & (JOY_BTN1 | JOY_BTN2))) osdbtn &= ~JOY_BTN3;
-					mask = 0;
+				if (mask & (JOY_BTN1 | JOY_BTN2)) {
+					if ((old_osdbtn & (JOY_BTN1 | JOY_BTN2 | JOY_BTN3)) == (JOY_BTN1 | JOY_BTN2 | JOY_BTN3))
+					{
+						mask = JOY_BTN3;
+					}
+					else if (old_osdbtn & JOY_BTN3)
+					{
+						if (!(osdbtn & (JOY_BTN1 | JOY_BTN2))) osdbtn &= ~JOY_BTN3;
+						mask = 0;
+					}
 				}
 			}
 


### PR DESCRIPTION
The current osdbtn state machine which handles detecting of the 1+2 combo -> 3 has two issues I've noticed:
- Other buttons pressed when 1+2 are pressed can cause missing press/release.  It was difficult to trigger, but possible to get into a state where a button is treated as pressed even after release because mask gets overwritten.
- Exiting the OSD with buttons pressed would leave state for next OSD entry resulting in missed 1 or 2 button presses until it was synced back up.

It's still possible to enter the OSD with buttons pressed that are not seen, but this doesn't seem to cause problems.