### PR TITLE
Add in support for KEY_102ND on PS/2 systems

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -382,7 +382,7 @@ static const int ev2ps2[] =
 	0x71, //83  KEY_KPDOT
 	NONE, //84  ???
 	NONE, //85  KEY_ZENKAKU
-	NONE, //86  KEY_102ND
+	0x56, //86  KEY_102ND
 	0x78, //87  KEY_F11
 	0x07, //88  KEY_F12
 	NONE, //89  KEY_RO


### PR DESCRIPTION
This patch allows the backslash key to work on United Kingdom 102/105 key keyboards under ao486. It should have no effect on United States 101/104 key keyboards.