### PR TITLE
option to hide joystick mappings, games path change

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -71,8 +71,11 @@ dvi_mode=0             ; set to 1 for DVI mode. Audio won't be transmitted throu
 ;   video_mode=1280,110,40,220,720,5,5,20,74250
 video_mode=0
 
-; set to 1-10 (seconds) to display video info on startup/change
+; set to 0-10 (seconds) to display video info on startup/change
 video_info=0
+
+; set to 0-10 (seconds) to display controller button mappings on core start
+hide_controller_info=0
 
 ; Set to 1 for automatic HDMI VSync rate adjust to match original VSync.
 ; Set to 2 for low latency mode (single buffer).

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -32,6 +32,7 @@ const ini_var_t ini_vars[] = {
 	{ "VGA_SOG", (void*)(&(cfg.vga_sog)), UINT8, 0, 1 },
 	{ "KEYRAH_MODE", (void*)(&(cfg.keyrah_mode)), UINT32, 0, (int)0xFFFFFFFF },
 	{ "RESET_COMBO", (void*)(&(cfg.reset_combo)), UINT8, 0, 3 },
+	{ "HIDE_CONTROLLER_INFO", (void*)(&(cfg.hide_controller_info)), UINT8, 0, 1 },
 	{ "KEY_MENU_AS_RGUI", (void*)(&(cfg.key_menu_as_rgui)), UINT8, 0, 1 },
 	{ "VIDEO_MODE", (void*)(cfg.video_conf), STRING, 0, sizeof(cfg.video_conf)-1 },
 	{ "VIDEO_MODE_PAL", (void*)(cfg.video_conf_pal), STRING, 0, sizeof(cfg.video_conf_pal) - 1 },

--- a/cfg.h
+++ b/cfg.h
@@ -21,6 +21,7 @@ typedef struct {
 	uint8_t csync;
 	uint8_t vga_scaler;
 	uint8_t vga_sog;
+	uint8_t hide_controller_info;
 	uint8_t hdmi_audio_96k;
 	uint8_t dvi;
 	uint8_t hdmi_limited;

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -828,10 +828,6 @@ int findPrefixDir(char *dir, size_t dir_len)
 	// /media/fat/games/
 	// if the core folder is not found anywhere,
 	// it will be created in /media/fat/games/<dir>
-	if (isPathDirectory(dir)) {
-		printf("Found existing: %s\n", dir);
-		return 1;
-	}
 
 	static char temp_dir[1024];
 
@@ -862,6 +858,11 @@ int findPrefixDir(char *dir, size_t dir_len)
 	if (isPathDirectory(temp_dir)) {
 		printf("Found CIFS dir: %s\n", temp_dir);
 		strncpy(dir, temp_dir, dir_len);
+		return 1;
+	}
+
+	if (isPathDirectory(dir)) {
+		printf("Found existing: %s\n", dir);
 		return 1;
 	}
 

--- a/joymapping.cpp
+++ b/joymapping.cpp
@@ -246,7 +246,8 @@ void map_joystick(uint32_t *map, uint32_t *mmap)
 		n++;
 	}
 
-	Info(mapinfo, 6000);
+	if (cfg.hide_controller_info < 1)
+		Info(mapinfo, 6000);
 }
 
 static const char* get_std_name(uint16_t code, uint32_t *mmap)


### PR DESCRIPTION
- Adds an options to hide controller popup for people who capture video from mister
- Changes the root dir search order to after usb/cifs, (just before /games)