### PR TITLE
Minor timing adjustments

### DIFF
--- a/support/pcecd/pcecd.cpp
+++ b/support/pcecd/pcecd.cpp
@@ -24,8 +24,14 @@ void pcecd_poll()
 
 	if (CheckTimer(poll_timer))
 	{
-		poll_timer += 13 + (!adj ? 1 : 0);
-		if (++adj >= 3) adj = 0;
+		if ((!pcecdd.latency) && (pcecdd.state == PCECD_STATE_READ)) {
+			poll_timer += 16 + ((adj == 10) ? 1 : 0);	// 16.1ms between frames if reading data */
+			if (--adj <= 0) adj = 10;
+		} else {
+			poll_timer += 13 + ((adj == 3) ? 1 : 0);	// 13.33ms otherwise (including latency counts) */
+			if (adj > 3) adj = 3;
+			if (--adj <= 0) adj = 3;
+		}
 
 		if (pcecdd.has_status && !pcecdd.latency) {
 			uint16_t s;

--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -538,7 +538,13 @@ void pcecdd_t::CommandExec() {
 			new_lba = this->toc.tracks[index].start;
 		}*/
 
-		this->latency = (int)(get_cd_seek_ms(this->lba, new_lba)/13.33);
+		/* HuVideo streams by fetching 120 sectors at a time, taking advantage of the geometry
+		 * of the disc to reduce/eliminate seek time */
+		if ((this->lba == new_lba) && (cnt_ == 120)) {
+			this->latency = 0;
+		} else {
+			this->latency = (int)(get_cd_seek_ms(this->lba, new_lba)/13.33);
+		}
 		printf("seek time ticks: %d\n", this->latency);
 
 		this->lba = new_lba;

--- a/support/pcecd/seektime.cpp
+++ b/support/pcecd/seektime.cpp
@@ -93,27 +93,27 @@ float get_cd_seek_ms(int start_sector, int target_sector)
 	// Now, we use the algorithm to determine how long to wait
 	if (abs(target_sector - start_sector) < 2)
 	{
-		milliseconds = (3 * 1000 / 60);
+		milliseconds = (2 * 1000 / 60);
 	}
 	else if (abs(target_sector - start_sector) < 5)
 	{
-		milliseconds = (9 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.7);
+		milliseconds = (9 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
 	}
 	else if (track_difference <= 80)
 	{
-		milliseconds = (16 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.7);
+		milliseconds = (17 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
 	}
 	else if (track_difference <= 160)
 	{
-		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.7);
+		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
 	}
 	else if (track_difference <= 644)
 	{
-		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.7) + (float)((track_difference - 161) * 16.66 / 80);
+		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75) + (float)((track_difference - 161) * 16.66 / 80);
 	}
 	else
 	{
-		milliseconds = (36 * 1000 / 60) + (float)((track_difference - 644) * 16.66 / 195);
+		milliseconds = (36 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.5) + (float)((track_difference - 644) * 16.66 / 195);
 	}
 
 	printf("From sector %d to sector %d:\n", start_sector, target_sector);


### PR DESCRIPTION
Hi,

Clould you see that rotation_ms = sec_per_revolution * 13.33 ? The array in seektime.cpp can be simplified.
The 13.33 can be replaced too by 1000.0/75.0 to show that the CDRom read 75 sectors in 1s.

After function get_cd_seek_ms could be replaced by  (int) get_cd_seek_latency to remove (float) outside the function. (float) is the devil :)

Finally, I think (2 * 1000 / 60) is an integer operation. 
I think it would be better to add .0 after all float numbers.
Example : milliseconds = (36.0 * 1000.0 / 60.0) + sector_list[target_index].rotation_ms * 0.5 + (track_difference - 644.0) * 16.66 / 195.0

Regards