### PR TITLE
Adding initial J-PAC/I-PAC support

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -106,6 +106,13 @@ controller_info=6
 jammasd_vid=0x04D8
 jammasd_pid=0xF3AD
 
+; J-PAC keys to joysticks translation
+; Provide the VID and PID for your J-PAC/I-PAC
+; Examples: Legacy J-PAC with Mini-USB or USB capable I-PAC with PS/2 connectors VID=0xD209/PID=0x0301
+; USB Capable J-PAC with only PS/2 connectors VID=0x04B4/PID=0x0101
+jpac_vid=0xD209
+jpac_pid=0x0301
+
 ; Speeds in sniper/non-sniper modes of mouse emulation by joystick 
 ; 0 - (default) - faster move in non-sniper mode, slower move in sniper mode.
 ; 1 - movement speeds are swapped.

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -68,6 +68,8 @@ static const ini_var_t ini_vars[] =
 	{ "REFRESH_MAX", (void*)(&(cfg.refresh_max)), UINT8, 0, 150 },
 	{ "JAMMASD_VID", (void*)(&(cfg.jammasd_vid)), UINT16, 0, 0xFFFF },
 	{ "JAMMASD_PID", (void*)(&(cfg.jammasd_pid)), UINT16, 0, 0xFFFF },
+	{ "JPAC_VID", (void*)(&(cfg.jpac_vid)), UINT16, 0, 0xFFFF },
+	{ "JPAC_PID", (void*)(&(cfg.jpac_pid)), UINT16, 0, 0xFFFF },
 	{ "SNIPER_MODE", (void*)(&(cfg.sniper_mode)), UINT8, 0, 1 },
 	{ "BROWSE_EXPAND", (void*)(&(cfg.browse_expand)), UINT8, 0, 1 },
 };

--- a/cfg.h
+++ b/cfg.h
@@ -42,6 +42,8 @@ typedef struct {
 	uint8_t recents;
 	uint16_t jammasd_vid;
 	uint16_t jammasd_pid;
+	uint16_t jpac_vid;
+	uint16_t jpac_pid;
 	uint8_t sniper_mode;
 	uint8_t browse_expand;
 	char bootcore[256];


### PR DESCRIPTION
This change uses the work that was done for JAMMASD support to allow for J-PAC and I-PAC to be supported in a similar fashion.  I've mapped all of the keys defined in the Default Key code table for the J-PAC and I-PAC (except for tilde, as I was not clear looking through the code what the key code for this is).  This was tested using a pre-2015 J-PAC with a mini-USB connected to an unmoddified standard JAMMA harness with buttons P4 - P6 wired from a CPS2 kick harness to the J-PAC.  Once configured, both joysticks, all 6 buttons on both players, and the shift keys are all enabled.