### PR TITLE
Use proper filter instead of prefix to filter file lists

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1254,7 +1254,7 @@ static void get_display_name(direntext_t *dext, const char *ext, int options)
 	if (fext) *fext = 0;
 }
 
-int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix)
+int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix, const char *filter)
 {
 	static char file_name[1024];
 	static char full_path[1024];
@@ -1268,7 +1268,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 	}
 
 	int extlen = strlen(extension);
-
+    int filterlen = filter ? strlen(filter) : 0;
 	//printf("scan dir\n");
 
 	if (mode == SCANF_INIT)
@@ -1388,6 +1388,20 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 					}
 				}
 			}
+
+            if (filter) {
+                bool passes_filter = false;
+
+                for(const char *str = de->d_name; *str; str++) {
+                    if (strncasecmp(str, filter, filterlen) == 0) {
+                        passes_filter = true;
+                        break;
+                    }
+                }
+
+                if (!passes_filter) continue;
+            }
+
 
 			if (options & SCANO_NEOGEO)
 			{

--- a/file_io.h
+++ b/file_io.h
@@ -105,7 +105,7 @@ int FileLoadConfig(const char *name, void *pBuffer, int size); // supply pBuffer
 int FileDeleteConfig(const char *name);
 
 void AdjustDirectory(char *path);
-int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix = NULL);
+int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix = NULL, const char *filter = NULL);
 
 void prefixGameDir(char *dir, size_t dir_len);
 int findPrefixDir(char *dir, size_t dir_len);

--- a/menu.cpp
+++ b/menu.cpp
@@ -3992,9 +3992,9 @@ void HandleUI(void)
 
 		if (flist_nDirEntries())
 		{
-			static char prefix[256];
-			static unsigned long prefix_typing_timer = 0;
-			int prefix_len = strlen(prefix);
+			static char filter[256];
+			static unsigned long filter_typing_timer = 0;
+			int filter_len = strlen(filter);
 
 			ScrollLongName(); // scrolls file name if longer than display line
 
@@ -4023,12 +4023,12 @@ void HandleUI(void)
 				menustate = MENU_FILE_SELECT1;
 			}
 
-			if (c == KEY_BACKSPACE && prefix_len > 0)
+			if (c == KEY_BACKSPACE && filter_len > 0)
 			{
-				memset(prefix, 0, 256);
-				prefix_typing_timer = 0;
+				memset(filter, 0, 256);
+				filter_typing_timer = 0;
 				
-				printf("Prefix is: %s\n", prefix);
+				printf("filter is: %s\n", filter);
 				ScanDirectory(selPath, SCANF_INIT, fs_pFileExt, fs_Options);
 
 				menustate = MENU_FILE_SELECT1;
@@ -4050,26 +4050,26 @@ void HandleUI(void)
 				int i;
 				if ((i = GetASCIIKey(c)) > 1)
 				{
-					if (CheckTimer(prefix_typing_timer))
+					if (CheckTimer(filter_typing_timer))
 					{
-						memset(prefix, 0, 256);
-						prefix[0] = (char)i;
+						memset(filter, 0, 256);
+						filter[0] = (char)i;
 
 						// You need both ScanDirectory calls here: the first
-						// call "clears" the prefix, the second one scrolls to
+						// call "clears" the filter, the second one scrolls to
 						// the right place in the list
 						ScanDirectory(selPath, SCANF_INIT, fs_pFileExt, fs_Options);
 						ScanDirectory(selPath, i, fs_pFileExt, fs_Options);
 					}
-					else if (prefix_len < 255)
+					else if (filter_len < 255)
 					{
-						prefix[prefix_len] = (char)i;
+						filter[filter_len] = (char)i;
 
-						ScanDirectory(selPath, SCANF_INIT, fs_pFileExt, fs_Options, prefix);
+						ScanDirectory(selPath, SCANF_INIT, fs_pFileExt, fs_Options, NULL, filter);
 					}
 
-					prefix_typing_timer = GetTimer(2000);
-					printf("Prefix is: %s\n", prefix);
+					filter_typing_timer = GetTimer(2000);
+					printf("filter is: %s\n", filter);
 
 					menustate = MENU_FILE_SELECT1;
 				}
@@ -4077,9 +4077,9 @@ void HandleUI(void)
 
 			if (select)
 			{
-				memset(prefix, 0, 256);
-				prefix_typing_timer = 0;
-				printf("Prefix is: %s\n", prefix);
+				memset(filter, 0, 256);
+				filter_typing_timer = 0;
+				printf("filter is: %s\n", filter);
 
 				static char name[256];
 				char type = flist_SelectedItem()->de.d_type;


### PR DESCRIPTION
Update on the merged pull request from yesterday: I added a `filter` parameter to ScanDirectory that I use instead of the prefix that was already there. This filter parameter filters on any part of the word (per @sorgelig's suggestion), so if you type `ADV` it will include both `Advance Wars` and `Ace Combat Advance`. It also works on both files and directories (it's neat to just type "snes" at the console core selection screen). I was a little bit worried that the performance wouldn't be acceptible, but it seems to work pretty in the folders I've tried. 

I opened a new PR since the PR from yesterday was closed and merged, I hope that's the right way to do it. 