### PR TITLE
ignore warnings linked to the GCC 7.1 ABI change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ OBJ	= $(C_SRC:.c=.c.o) $(CPP_SRC:.cpp=.cpp.o) $(IMG:.png=.png.o)
 DEP	= $(C_SRC:.c=.c.d) $(CPP_SRC:.cpp=.cpp.d)
 
 DFLAGS	= $(INCLUDE) -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DVDATE=\"`date +"%y%m%d"`\"
-CFLAGS	= $(DFLAGS) -Wall -Wextra -Wno-strict-aliasing -c -O3
+CFLAGS	= $(DFLAGS) -Wall -Wextra -Wno-strict-aliasing -Wno-psabi -c -O3
 LFLAGS	= -lc -lstdc++ -lrt $(IMLIB2_LIB)
 
 $(PRJ): $(OBJ)


### PR DESCRIPTION
compilation currently reports 21 similar warnings:
```
...
/usr/include/c++/6/bits/stl_algo.h(1951, 4): note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<direntext_t*, std::vector<direntext_t> >’ will change in GCC 7.1
    std::__introsort_loop(__cut, __last, __depth_limit, __comp);
    ^~~
/usr/include/c++/6/bits/stl_algo.h(1669, 7): note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<direntext_t*, std::vector<direntext_t> >’ will change in GCC 7.1
       std::__make_heap(__first, __middle, __comp);
       ^~~
/usr/include/c++/6/bits/stl_algo.h: In function ‘int ScanDirectory(char*, int, const char*, int, const char*, const char*)’:
/usr/include/c++/6/bits/stl_algo.h(1965, 4): note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<direntext_t*, std::vector<direntext_t> >’ will change in GCC 7.1
    std::__introsort_loop(__first, __last,
    ^~~
/usr/include/c++/6/bits/stl_algo.h(1882, 4): note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<direntext_t*, std::vector<direntext_t> >’ will change in GCC 7.1
    std::__insertion_sort(__first, __first + int(_S_threshold), __comp);
    ^~~
/usr/include/c++/6/bits/stl_algo.h(1887, 2): note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<direntext_t*, std::vector<direntext_t> >’ will change in GCC 7.1
  std::__insertion_sort(__first, __last, __comp);
  ^~~
```
As pointed in this [stackoverflow thread](https://stackoverflow.com/questions/48149323/what-does-the-gcc-warning-project-parameter-passing-for-x-changed-in-gcc-7-1-m), these warnings can be safely ignored.