### PR TITLE
fix compilation warning (misleading-indentation)

### DIFF
--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -648,14 +648,14 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 		 */
 		{
 			int result = buffer_append(arc_info->data, text);
-  			if (result<0)
+			if (result<0)
 			{
-                		printf("buffer_append failed %d\n",result);
-                		if (result==-1)
-                  			printf("-1 no data given\n");
-                		if (result==-2)
-                  			printf("-2 could not allocate\n");
-              		}
+				printf("buffer_append failed %d\n",result);
+				if (result==-1)
+					printf("-1 no data given\n");
+				if (result==-2)
+					printf("-2 could not allocate\n");
+			}
 		}
 		//printf("XML_EVENT_TEXT: text [%s]\n",text);
 		break;

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -647,15 +647,15 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 		 * the buffer_append is part of a buffer library that will realloc automatically
 		 */
 		{
-		int result = buffer_append(arc_info->data, text);
-		if (result<0)
+			int result = buffer_append(arc_info->data, text);
+  			if (result<0)
 			{
-			printf("buffer_append failed %d\n",result);
-			if (result==-1)
-			   printf("-1 no data given\n");
-			if (result==-2)
-			   printf("-2 could not allocate\n");
-			}
+                		printf("buffer_append failed %d\n",result);
+                		if (result==-1)
+                  			printf("-1 no data given\n");
+                		if (result==-2)
+                  			printf("-2 could not allocate\n");
+              		}
 		}
 		//printf("XML_EVENT_TEXT: text [%s]\n",text);
 		break;

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -649,11 +649,13 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 		{
 		int result = buffer_append(arc_info->data, text);
 		if (result<0)
+			{
 			printf("buffer_append failed %d\n",result);
 			if (result==-1)
 			   printf("-1 no data given\n");
 			if (result==-2)
 			   printf("-2 could not allocate\n");
+			}
 		}
 		//printf("XML_EVENT_TEXT: text [%s]\n",text);
 		break;


### PR DESCRIPTION
```
support/arcade/mra_loader.cpp: In function ‘int xml_send_rom(XMLEvent, const XMLNode*, SXML_CHAR*, int, SAX_Data*)’:
support/arcade/mra_loader.cpp(651, 3): warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if (result<0)
   ^~
support/arcade/mra_loader.cpp(653, 4): note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
    if (result==-1)
    ^~
```