### PR TITLE
Minimig: Fixes for shared file system (MiSTerFileSystem)

### DIFF
--- a/support/minimig/miminig_fs_messages.h
+++ b/support/minimig/miminig_fs_messages.h
@@ -28,6 +28,7 @@
 #define ACTION_DISK_TYPE      32
 #define ACTION_DISK_CHANGE    33
 #define ACTION_SET_DATE       34
+#define ACTION_SAME_LOCK      40
 #define ACTION_SCREEN_MODE    994
 #define ACTION_READ_RETURN    1001
 #define ACTION_WRITE_RETURN   1002
@@ -73,6 +74,10 @@
 
 #define SHARED_LOCK    -2
 #define EXCLUSIVE_LOCK -1
+
+#define LOCK_DIFFERENT   -1
+#define LOCK_SAME        0
+#define LOCK_SAME_VOLUME 1
 
 #define MODE_OLDFILE    1005
 #define MODE_NEWFILE    1006
@@ -350,6 +355,21 @@ struct SetCommentRequest
 };
 
 struct SetCommentResponse
+{
+	long sz;
+	long success;
+	long error_code;
+};
+
+struct SameLockRequest
+{
+	long sz;
+	long type;
+	long key1;
+	long key2;
+};
+
+struct SameLockResponse
 {
 	long sz;
 	long success;

--- a/support/minimig/miminig_fs_messages.h
+++ b/support/minimig/miminig_fs_messages.h
@@ -39,6 +39,7 @@
 #define ACTION_SEEK           1008
 #define ACTION_TRUNCATE       1022
 #define ACTION_WRITE_PROTECT  1023
+#define ACTION_EXAMINE_FH     1034
 
 #define ERROR_NO_FREE_STORE            103
 #define ERROR_TASK_TABLE_FULL          105
@@ -374,6 +375,27 @@ struct SameLockResponse
 	long sz;
 	long success;
 	long error_code;
+};
+
+struct ExamineFhRequest
+{
+	long sz;
+	long type;
+	long arg1;
+};
+
+struct ExamineFhResponse
+{
+	long sz;
+	long success;
+	long error_code;
+
+	long disk_key;
+	long entry_type;
+	int size;
+	int protection;
+	int date[3];
+	char file_name[1];
 };
 
 struct DiskInfoRequest

--- a/support/minimig/minimig_share.cpp
+++ b/support/minimig/minimig_share.cpp
@@ -566,7 +566,7 @@ static int process_request(void *reqres_buffer)
 
 			if (!name[0])
 			{
-				ret = ERROR_DIR_NOT_FOUND;
+				ret = ERROR_OBJECT_NOT_FOUND;
 				break;
 			}
 

--- a/support/minimig/minimig_share.cpp
+++ b/support/minimig/minimig_share.cpp
@@ -694,6 +694,16 @@ static int process_request(void *reqres_buffer)
 				ret = ERROR_OBJECT_NOT_FOUND;
 				break;
 			}
+			
+			strcpy(buf, getFullPath(buf));
+			const char *fp2 = getFullPath(cp2);
+
+			// Identical match; do nothing
+			if (!strcmp(buf, fp2))
+			{
+				ret = 0;
+				break;
+			}
 
 			if (FileExists(cp2, 0) || PathIsDir(cp2, 0))
 			{
@@ -701,8 +711,7 @@ static int process_request(void *reqres_buffer)
 				break;
 			}
 
-			strcpy(buf, getFullPath(buf));
-			if (rename(buf, getFullPath(cp2)))
+			if (rename(buf, fp2))
 			{
 				ret = ERROR_OBJECT_NOT_FOUND;
 				break;

--- a/support/minimig/minimig_share.cpp
+++ b/support/minimig/minimig_share.cpp
@@ -27,6 +27,10 @@ static uint8_t *shmem = 0;
 #define REQUEST_BUFFER  4      // ~512B
 #define DATA_BUFFER     0x1000 // 4KB
 
+// Must match device name in MountList and volume name from MiSTerFileSystem
+#define DEVICE_NAME     "SHARE"
+#define VOLUME_NAME     "MiSTer"
+
 //#define DEBUG
 
 #ifdef DEBUG
@@ -124,7 +128,12 @@ static char* find_path(uint32_t key, const char *name)
 	const char* p = strchr(name, ':');
 	if (p)
 	{
-		key = 0;
+		size_t root_len = p - name;
+
+		// Don't use lock for relative path if the name contains our root
+		if (root_len == 0 || !strncasecmp(name, DEVICE_NAME, root_len) || !strncasecmp(name, VOLUME_NAME, root_len))
+			key = 0;
+
 		name = p + 1;
 	}
 

--- a/support/minimig/minimig_share.cpp
+++ b/support/minimig/minimig_share.cpp
@@ -591,10 +591,10 @@ static int process_request(void *reqres_buffer)
 				break;
 			}
 
-			uint32_t old_pos = open_file_handles[key].offset;
+			int old_pos = open_file_handles[key].offset;
 
-			uint32_t new_pos = SWAP_INT(req->new_pos);
-			uint32_t mode = SWAP_INT(req->mode);
+			int new_pos = SWAP_INT(req->new_pos);
+			int mode = SWAP_INT(req->mode);
 
 			int origin = SEEK_SET;
 			if (mode == OFFSET_CURRENT) origin = SEEK_CUR;

--- a/support/minimig/minimig_share.cpp
+++ b/support/minimig/minimig_share.cpp
@@ -781,6 +781,30 @@ static int process_request(void *reqres_buffer)
 			ret = 0;
 		}
 		break;
+
+		case ACTION_SAME_LOCK:
+		{
+			dbg_print("> ACTION_SAME_LOCK\n");
+			SameLockRequest *req = (SameLockRequest*)reqres_buffer;
+
+			uint32_t key1 = SWAP_INT(req->key1);
+			uint32_t key2 = SWAP_INT(req->key2);
+			
+			if ((locks.find(key1) == locks.end()) || (locks.find(key2) == locks.end()))
+			{
+				ret = LOCK_DIFFERENT;
+				break;
+			}
+			
+			if (locks[key1].path == locks[key2].path)
+			{
+				ret = LOCK_SAME;
+				break;
+			}
+
+			ret = LOCK_SAME_VOLUME;
+		}
+		break;
 	}
 
 	int success = ret ? 0 : 1;


### PR DESCRIPTION
This PR (combined with the accompanying PR to Minimig-AGA_MiSTer) merges some fixes from a314, and a couple of extra fixes that that take care of some of the worst bugs:

- Deleting files/directories from Workbench no longer requires the window to be refreshed.
- Files that are "Left out" onto the Workbench screen no longer reappear inside the parent window.
- Incorrect return code for ACTION_FINDINPUT.
- Some applications would fail to load some files due to negative seek offsets being corrupted by unsigned conversion.
  * A simple test case is AmigaGuide: place an AmigaGuide document on the shared volume and attempt to open it. Before this patch, this would fail silently.
- Renaming a file/folder to its existing name would fail when it should not - renaming a file or directory to its own name is legal under AmigaOS.
  * This fixes the error encountered when creating a new drawer under SHARE: and accepting the default name of "Unnamed1", for example.
- Using the `Assign` command to create an assign to a location within the shared file system didn't work correctly - it would always point to the root. This has been fixed.

Requires changes to Minimig-AGA_MiSTer (see other PR).