### PR TITLE
Fix MRA bootcore=lastcore

### DIFF
--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -1072,7 +1072,8 @@ int arcade_load(const char *xml)
 	MenuHide();
 	static char path[kBigTextSize];
 
-	strcpy(path, xml);
+	if(xml[0] == '/') strcpy(path, xml);
+	else sprintf(path, "%s/%s", getRootDir(), xml);
 
 	set_arcade_root(path);
 	printf("arcade_load [%s]\n", path);


### PR DESCRIPTION
In the case of a zero timeout 'bootcore=lastcore', the MRA path being passed to arcade_load was not an absolute path.
Change arcade_load() to behave just like fpga_load_rbf() and prepend the root path if it isn't there.

Fixes issue #280 