### PR TITLE
Adjust chd lba translation based on pregap type

### DIFF
--- a/support/chd/mister_chd.cpp
+++ b/support/chd/mister_chd.cpp
@@ -98,6 +98,10 @@ chd_error mister_load_chd(const char *filename, toc_t *cd_toc)
 
 		//CHD pads tracks to a multiple of 4 sectors, keep track of the overall sector count and calculate the difference between the cdrom lba and the effective chd lba
 		cd_toc->tracks[cd_toc->last].offset = (sector_cnt + pregap - cd_toc->tracks[cd_toc->last].start); 
+		if (pgtype[0] != 'V')
+		{
+			cd_toc->tracks[cd_toc->last].offset -= pregap;
+		}
 		cd_toc->tracks[cd_toc->last].end = cd_toc->tracks[cd_toc->last].start + frames - pregap;
 		cd_toc->end = cd_toc->tracks[cd_toc->last].end + postgap;
 		sector_cnt += ((frames + CD_TRACK_PADDING - 1) / CD_TRACK_PADDING) * CD_TRACK_PADDING;


### PR DESCRIPTION
CHD track pregap type name starts with 'V' if it is 'valid', where 'valid' means the data files contain pregap data.
When the data files do not contain pregap data, ignore the pregap value when calculating the hunk offset into the chd.
This fixes some PCECD hacks that were dumped as cue/iso/wav, which apparently contain no pregap sectors.

Verified MEGACD, 'normal' PCE-CD, and ao486 images still load after this change.


