### PR TITLE
Use KPENTER as select on osd menu.

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -1153,6 +1153,7 @@ void HandleUI(void)
 			break;
 		case KEY_ENTER:
 		case KEY_SPACE:
+		case KEY_KPENTER:
 			select = true;
 			break;
 		case KEY_UP:


### PR DESCRIPTION
I bought a compact USB keyboard shown below for my MiSTer.
Its ENTER key seems to emit code which is treated as KEY_KPENTER by Linux when NumLock LED is on.
So that means the ENTER key cannot be used as select on osd menu when toggled to Joystick 1 emulation mode. 

![picture](https://user-images.githubusercontent.com/50853463/104545841-43463d00-566e-11eb-8f38-a2be28ca5d58.jpg)
