### PR TITLE
Support for reassigning player number for joypads and spinner/paddles

### DIFF
--- a/input.h
+++ b/input.h
@@ -90,6 +90,16 @@ uint16_t get_map_pid();
 int has_default_map();
 void send_map_cmd(int key);
 void reset_players();
+void swap_player(int dev_num, int new_num);
+void start_player_remapping();
+void end_player_remapping();
+int get_last_pdsp_dev();
+int get_last_input_dev();
+int get_pad_mask();
+int get_pdsp_mask();
+int get_dev_num(int dev);
+int get_remap_spinner_value();
+int get_numplayers();
 
 uint32_t get_key_mod();
 uint32_t get_ps2_code(uint16_t key);


### PR DESCRIPTION
Replace the 'Reset player assignments' with 'Change player assignments' menu.
In this menu you can change what 'player slot' any controller is assigned to by left/right or OSD 'select'. Full reset of all player assignments is also available in the menu, with the exact same functionality as the previous 'Reset player assignments'

When an input for a pad or spinner is detected the corresponding menu entry is prepended with an asterisk to indicate which one it is (to help users reassign the correct gamepad)

Primary motivation for doing this is that a number of arcade games have fairly important gameplay differences when the Player 2 side is used. If you only have one gamepad there's was no way to easily play as P2; with this you can just remap to P2. As a nice side benefit you can now pick your character in three player Gauntlet games :)
