### PR TITLE
MiSTer.ini: fix typo in default filters comment

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -145,6 +145,6 @@ shared_folder=
 ;spinner_pid=0x0005
 ;spinner_throttle=-50
 
-; Default filters for video scaler and audio. Paths must be relative to scaler/audio filter filders without leading slash.
-;vfilter_default=LCD_Effect/07.txt
+; Default filters for video scaler and audio. Paths must be relative to scaler/audio filter folder without leading slash.
+;vfilter_default=LCD Effects/LCD_Effect_07.txt
 ;afilter_default=LPF2000_3tap.txt


### PR DESCRIPTION
Also update example vfilter_default to reference an existing file from Filters_MiSTer repo