### PR TITLE
Make the wiki crawlable by google

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repo serves as the home for the MiSTer Main binaries and the Wiki.
 
 For the purposes of getting google to crawl the wiki, here's a link to the (not for humans) [crawlable wiki](https://github-wiki-see.page/m/MiSTer-devel/Main_MiSTer/wiki)
 
-If you're a human looking for the wiki, that's [here](https://github.com/iMartyn/Main_MiSTer/wiki)
+If you're a human looking for the wiki, that's [here](https://github.com/MiSTer-devel/Main_MiSTer/wiki)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Main_MiSTer Main Binary and Wiki Repo
+
+This repo serves as the home for the MiSTer Main binaries and the Wiki.
+
+For the purposes of getting google to crawl the wiki, here's a link to the (not for humans) [crawlable wiki](https://github-wiki-see.page/m/MiSTer-devel/Main_MiSTer/wiki)
+
+If you're a human looking for the wiki, that's [here](https://github.com/iMartyn/Main_MiSTer/wiki)


### PR DESCRIPTION
Using https://github.com/nelsonjchen/github-wiki-see-rs the project can have the content of the wiki crawlable simply by adding a link to https://github-wiki-see.page/m/MiSTer-devel/Main_MiSTer/wiki in the README.md  Given there wasn't one, I've but some bare-bones info in there too while I was creating the file.