### PR TITLE
PC Engine CDROM timing corrections

### DIFF
--- a/support/pcecd/pcecd.cpp
+++ b/support/pcecd/pcecd.cpp
@@ -34,7 +34,7 @@ void pcecd_poll()
 			if (--adj <= 0) adj = 3;
 		}
 
-		if (pcecdd.has_status ) {
+		if (pcecdd.has_status && !pcecdd.latency) {
 
 			pcecdd.SendStatus(pcecdd.GetStatus());
 			pcecdd.has_status = 0;

--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -567,6 +567,12 @@ void pcecdd_t::CommandExec() {
 		{
 			this->latency = 0;
 		}
+		/* Sherlock Holmes streams by fetching 252 sectors at a time, and suffers
+		 * from slight pauses at each seek */
+		else if ((this->lba == new_lba) && (cnt_ == 252))
+		{
+			this->latency = 5;
+		}
 		else if (comm[13] & 0x80) // fast seek (OSD setting)
 		{
 			this->latency = 0;
@@ -697,11 +703,11 @@ void pcecdd_t::CommandExec() {
 			this->state = PCECD_STATE_PLAY;
 		}
 
-		printf("\x1b[32mPCECD: Command SAPEP, end = %i, [1] = %02X, [2] = %02X, [9] = %02X\n\x1b[0m", this->CDDAEnd, comm[1], comm[2], comm[9]);
-
 		if (this->CDDAMode != PCECD_CDDAMODE_INTERRUPT) {
 			SendStatus(MAKE_STATUS(PCECD_STATUS_GOOD, 0));
 		}
+
+		printf("\x1b[32mPCECD: Command SAPEP, end = %i, [1] = %02X, [2] = %02X, [9] = %02X\n\x1b[0m", this->CDDAEnd, comm[1], comm[2], comm[9]);
 	}
 		break;
 

--- a/support/pcecd/seektime.cpp
+++ b/support/pcecd/seektime.cpp
@@ -91,11 +91,11 @@ float get_cd_seek_ms(int start_sector, int target_sector)
 	}
 
 	// Now, we use the algorithm to determine how long to wait
-	if (abs(target_sector - start_sector) < 2)
+	if (abs(target_sector - start_sector) <= 3)
 	{
 		milliseconds = (2 * 1000 / 60);
 	}
-	else if (abs(target_sector - start_sector) < 5)
+	else if (abs(target_sector - start_sector) < 7)
 	{
 		milliseconds = (9 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
 	}


### PR DESCRIPTION
1) Fix for Issue 120 broke timing for cut-scene videos.  Restoring delay for SAPSP-type seeks  (issue MiSTer-devel/TurboGrafx16_MiSTer#145)

2) fixes for issues MiSTer-devel/TurboGrafx16_MiSTer#120 & MiSTer-devel/TurboGrafx16_MiSTer#145:
a) PAUSE placed head just outside of minimum-seektime area -> when playback was restored, it was late, contributing to hangs (i.e. Bomberman Panic Bomber).  Increase minimum seektime region, so as to include this case.
b) Moved logging printf to AFTER SendStatus on SAPEP transactions; may help reduce hangs (i.e. Bomberman Panic Bomber).

3) Minor adjustment to improve timing on Sherlock Holmes games' video playback.