### PR TITLE
Writes path info of menu selection

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -4414,6 +4414,15 @@ void HandleUI(void)
 		if (flist_nDirEntries())
 		{
 			ScrollLongName(); // scrolls file name if longer than display line
+			
+			//Write out paths infos for external integration
+			FILE* filePtr = fopen("/tmp/CURRENTPATH","w");
+           		FILE* pathPtr = fopen("/tmp/FULLPATH","w");
+           		fprintf(filePtr, "%s", flist_SelectedItem()->altname);
+           		fprintf(pathPtr, "%s", selPath);
+           		fclose(filePtr);
+           		fclose(pathPtr);
+			
 
 			if (c == KEY_HOME)
 			{


### PR DESCRIPTION
Writes to current path and "full path" of whatever is highlighted in the menu for external scripts to monitor.

This was implemented specifically to support a dynamic marquee solution for MiSTer in arcade cabinets, but in a way that it is not "vendor specific". See https://pixelcade.org/mister/ for an example of a practical application.