### PR TITLE
Correct Princess Maker 2 freeze (TurboGrafx16_MiSTer issue #154)

### DIFF
--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -442,7 +442,7 @@ void pcecdd_t::Update() {
 
 		this->CDDAFirst = 0;
 
-		if ((this->lba >= this->CDDAEnd) || this->toc.tracks[this->index].type || this->index >= this->toc.last)
+		if ((this->lba > this->CDDAEnd) || this->toc.tracks[this->index].type || this->index > this->toc.last)
 		{
 			if (this->CDDAMode == PCECD_CDDAMODE_LOOP) {
 				this->lba = this->CDDAStart;


### PR DESCRIPTION
Fix off-by-one sector count on end of track for Princess Maker 2; the game constantly checks the subcode Q value to see whether it reached a certain time signature... Main_MiSTer was stopping the track one sector earlier than that sector.