### PR TITLE
Align AL_GETATTR reply size with misterfs redirector

### DIFF
--- a/support/x86/x86_share.cpp
+++ b/support/x86/x86_share.cpp
@@ -875,10 +875,9 @@ static int process_request(void *reqres_buffer)
 		*buf++ = sz >> 16;
 		*buf++ = sz >> 24;
 		*buf++ = (mode & S_IFDIR) ? FAT_DIR : 0;
-		*buf++ = 0;
 
 		res = 0;
-		reslen = 10;
+		reslen = 9;
 	}
 	break;
 


### PR DESCRIPTION
misterfs expects a 9 byte reply while we were sending 10 bytes.

Signed-off-by: Peter De Schrijver <p2@psychaos.be>