### PR TITLE
Change sorting comparison to generate expected results

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1114,11 +1114,11 @@ struct DirentComp
 		int ret = strncasecmp(de1.altname, de2.altname, len);
 		if (!ret)
 		{
-			ret = strcasecmp(de1.datecode, de2.datecode);
-			if (!ret)
+			if(len1 != len2)
 			{
 				return len1 < len2;
 			}
+			ret = strcasecmp(de1.datecode, de2.datecode);
 		}
 
 		return ret < 0;


### PR DESCRIPTION
Currently when you have two entries where one has a longer name ("foobar" and "foobar 2") it does the comparison up to the shorter of the lengths, and then if they match to that length, it does a date comparison instead. This exhibits behaviour different to what one would expect from most implementations.

This change puts the length comparison before the date comparison to make it more like the user would expect.

i.e "foobar" should always be above "foobar 2", and not move depending on the date code.