### PR TITLE
Support for unoptimized mister builds.

### DIFF
--- a/lib/libchdr/include/libchdr/coretypes.h
+++ b/lib/libchdr/include/libchdr/coretypes.h
@@ -26,7 +26,7 @@ typedef int8_t INT8;
 #define core_fread(fc, buff, len) fread(buff, 1, len, fc)
 #define core_fclose fclose
 #define core_ftell ftell
-inline size_t core_fsize(core_file *f)
+static inline size_t core_fsize(core_file *f)
 {
     long rv;
     long p = ftell(f);


### PR DESCRIPTION
Pass DEBUG=1 to make to build and unoptimized version.
Seperate build directories are used for debug and release builds.
Don't strip the debug executable.
Change an `inline` to a `static inline` in coretypes.h to ensure symbol is found in debug builds.