### PR TITLE
lastgame bootcore feature (WIP)

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -33,6 +33,8 @@ recents=0
 ; lastexactcore - Autoboot the last loaded exact core (corename_yyyymmdd.rbf autosaved in CONFIG/lastcore.dat) first found on the SD/USB
 ; corename - Autoboot first corename_*.rbf found on the SD/USB
 ; corename_yyyymmdd.rbf - Autoboot first corename_yyyymmdd.rbf found on the SD/USB
+; lastgame - Autoboot the load loaded core (same as lastcore) and load the most recently played game (ROM) also
+; lastexactgame - Same as lastgame, but use the lastexactcore behavior to find the core to use
 ;bootcore=lastcore    ; uncomment to autoboot a core, as the last loaded core.
 
 ; 10-30 timeout before autoboot, comment for autoboot without timeout.

--- a/bootcore.h
+++ b/bootcore.h
@@ -5,14 +5,19 @@
 #ifndef __BOOTCORE_H__
 #define __BOOTCORE_H__
 
-char *getcoreName(char *path);
-char *getcoreExactName(char *path);
-char *replaceStr(const char *str, const char *oldstr, const char *newstr);
-char *loadLastcore();
-char *findCore(const char *name, char *coreName, int indent);
 void bootcore_init(const char *path);
+void bootcore_record_file(const char *path);
+void bootcore_load_file();
+void bootcore_cancel();
 
-extern char bootcoretype[64];
-extern int16_t btimeout;
+void bootcore_launch();
+bool bootcore_pending();
+bool bootcore_ready();
+
+unsigned int bootcore_remaining();
+unsigned int bootcore_delay();
+
+const char *bootcore_type();
+const char *bootcore_name();
 
 #endif // __BOOTCORE_H__

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -624,7 +624,7 @@ int FileWriteSec(fileTYPE *file, void *pBuffer)
 	return FileWriteAdv(file, pBuffer, 512);
 }
 
-int FileSave(const char *name, void *pBuffer, int size)
+int FileSave(const char *name, const void *pBuffer, int size)
 {
 	make_fullpath(name);
 
@@ -680,7 +680,7 @@ int FileLoadConfig(const char *name, void *pBuffer, int size)
 	return FileLoad(path, pBuffer, size);
 }
 
-int FileSaveConfig(const char *name, void *pBuffer, int size)
+int FileSaveConfig(const char *name, const void *pBuffer, int size)
 {
 	char path[256] = { CONFIG_DIR };
 	const char *p;

--- a/file_io.h
+++ b/file_io.h
@@ -96,14 +96,14 @@ void FileGenerateSavestatePath(const char *name, char* out_name, int sufx);
 #define SCREENSHOT_DEFAULT "screen"
 void FileGenerateScreenshotName(const char *name, char *out_name, int buflen);
 
-int FileSave(const char *name, void *pBuffer, int size);
+int FileSave(const char *name, const void *pBuffer, int size);
 int FileLoad(const char *name, void *pBuffer, int size); // supply pBuffer = 0 to get the file size without loading
 int FileDelete(const char *name);
 int DirDelete(const char *name);
 
 //save/load from config dir
 #define CONFIG_DIR "config"
-int FileSaveConfig(const char *name, void *pBuffer, int size);
+int FileSaveConfig(const char *name, const void *pBuffer, int size);
 int FileLoadConfig(const char *name, void *pBuffer, int size); // supply pBuffer = 0 to get the file size without loading
 int FileDeleteConfig(const char *name);
 

--- a/support/neogeo/neogeo_loader.cpp
+++ b/support/neogeo/neogeo_loader.cpp
@@ -1034,9 +1034,9 @@ void load_neo(char *path)
 	}
 }
 
-int neogeo_romset_tx(char* name)
+int neogeo_romset_tx(const char* name)
 {
-	char *romset = strrchr(name, '/');
+	const char *romset = strrchr(name, '/');
 	if (!romset) return 0;
 	romset++;
 
@@ -1062,7 +1062,7 @@ int neogeo_romset_tx(char* name)
 	// Look for the romset's file list in romsets.xml
 	if (!(system_type & 2))
 	{
-		char *p = strrchr(name, '.');
+		const char *p = strrchr(name, '.');
 		if (p && !strcasecmp(p, ".neo"))
 		{
 			printf("Loading neo file.\n");
@@ -1088,11 +1088,11 @@ int neogeo_romset_tx(char* name)
 			checked_ok = false;
 			romsets = 0;
 			sax.all_event = xml_check_files;
-			parse_xml(full_path, &sax, name);
+			parse_xml(full_path, &sax, (char *)name);
 			if (!checked_ok) return 0;
 
 			sax.all_event = xml_load_files;
-			parse_xml(full_path, &sax, name);
+			parse_xml(full_path, &sax, (char *)name);
 		}
 	}
 

--- a/support/neogeo/neogeo_loader.h
+++ b/support/neogeo/neogeo_loader.h
@@ -5,6 +5,6 @@
 #define NEO_FILE_FIX 2
 #define NEO_FILE_SPR 3
 
-int neogeo_romset_tx(char* name);
+int neogeo_romset_tx(const char* name);
 int neogeo_scan_xml(char *path);
 char *neogeo_get_altname(char *path, char *name, char *altname);

--- a/support/x86/x86.cpp
+++ b/support/x86/x86.cpp
@@ -183,7 +183,7 @@ static uint32_t img_write(fileTYPE *f, uint32_t lba, void *buf, uint32_t cnt)
 	return FileWriteAdv(f, buf, cnt * 512);
 }
 
-static void fdd_set(int num, char* filename)
+static void fdd_set(int num, const char* filename)
 {
 	floppy_type[num] = FDD_TYPE_1440;
 
@@ -267,7 +267,7 @@ static void fdd_set(int num, char* filename)
 	IOWR(FDD0_BASE + subaddr, 0xC, 0);
 }
 
-static void hdd_set(int num, char* filename)
+static void hdd_set(int num, const char* filename)
 {
 	int present = 0;
 	int cd = 0;
@@ -515,7 +515,7 @@ void x86_poll()
 	}
 }
 
-void x86_set_image(int num, char *filename)
+void x86_set_image(int num, const char *filename)
 {
 	memset(config.img_name[num], 0, sizeof(config.img_name[0]));
 	strcpy(config.img_name[num], filename);

--- a/support/x86/x86.h
+++ b/support/x86/x86.h
@@ -4,7 +4,7 @@
 void x86_init();
 void x86_poll();
 
-void x86_set_image(int num, char *filename);
+void x86_set_image(int num, const char *filename);
 const char* x86_get_image_name(int num);
 const char* x86_get_image_path(int num);
 

--- a/user_io.h
+++ b/user_io.h
@@ -182,6 +182,22 @@
 #define EMU_JOY0  2
 #define EMU_JOY1  3
 
+typedef enum
+{
+	UIO_SELECTION_FILE,
+	UIO_SELECTION_IMAGE,
+} uio_selection_type;
+
+typedef struct
+{
+	uio_selection_type type;
+	int ioctl_index;
+	uint32_t load_addr;
+	bool store_name;
+	bool open_save;
+	char extensions[16];
+} uio_selection_descriptor;
+
 void user_io_init(const char *path, const char *xml);
 unsigned char user_io_core_type();
 void user_io_read_core_name();
@@ -224,7 +240,7 @@ uint16_t user_io_get_sdram_cfg();
 
 int user_io_file_tx(const char* name, unsigned char index = 0, char opensave = 0, char mute = 0, char composite = 0, uint32_t load_addr = 0);
 int user_io_file_tx_a(const char* name, uint16_t index);
-unsigned char user_io_ext_idx(char *, char*);
+unsigned char user_io_ext_idx(const char *name, const char *ext, bool *was_found);
 void user_io_set_index(unsigned char index);
 void user_io_set_aindex(uint16_t index);
 void user_io_set_download(unsigned char enable, int addr = 0);
@@ -233,6 +249,12 @@ void user_io_set_upload(unsigned char enable, int addr = 0);
 void user_io_file_rx_data(uint8_t *addr, uint32_t len);
 void user_io_file_info(const char *ext);
 int user_io_get_width();
+
+bool user_io_parse_addon(const char *confstr, char *addon, int addon_size);
+bool user_io_parse_selection(const char *confstr, int index, uio_selection_descriptor *desc);
+void user_io_load_file(const char *path, const uio_selection_descriptor* sel_desc, const char *addon);
+void user_io_mount_image(const char *path, const uio_selection_descriptor* sel_desc, const char *addon);
+void user_io_load_or_mount(const char *path);
 
 void user_io_check_reset(unsigned short modifiers, char useKeys);
 
@@ -261,7 +283,7 @@ const char* GetUARTbaud_label(int mode, int idx);
 int GetUARTbaud_idx(int mode);
 uint32_t ValidateUARTbaud(int mode, uint32_t baud);
 char * GetMidiLinkSoundfont();
-void user_io_store_filename(char *filename);
+void user_io_store_filename(const char *filename);
 int user_io_use_cheats();
 
 void diskled_on();


### PR DESCRIPTION
This still needs a lot more testing by me, I'm submitting this PR in order to get feedback on whether there is interest in having this feature, what additional things it needs (e.g. should it handle mounting disk images also?) and feedback on the changes to user_io and menu.

# Description
This change expands the `bootcore` ini option to support a new mode: "lastgame". The lastgame mode will load the previously loaded core (just like "lastcore") but it will also attempt to load the ROM that was previously being played on that core also.

## user_io and menu.

The work of parsing the confstr for file and mount descriptions and handling the loading/mount of them has been moved from the menu code to user_io.

`user_io_parse_selection` parses a confstr entry and fills a `uio_selection_descriptor` with the necessary information for the file or image. The parsing code in the menu system has been replaced by this and several of the globals and function statics (`opensave`, `load_addr`, `ioctl_index`, `store_name`) have been replaced by a static `sel_desc` instance of a `uio_selection_descriptor` which now contains the same information. The `user_io_load_or_mount` is new functionality, it works in reverse, given a filepath it determines which confstr entry matches it's extension and loads or mounts it appropriately.

The code in the `MENU_GENERIC_FILE_SELECTED` and `MENU_GENERIC_IMAGE_SELECTED` that was responsible for loading/mounting the selected file(s) has been moved to `user_io_load_file` and `user_io_mount_image` respectively. The menu code is still responsible for handling the "UI" specfic tasks like recording recent files.

These changes to the menu implementation this need a lot more testing. For instance, the archie and minimig specific code were setting `ioctl_index` but it seems like this was not actually being used for anything and mounting multiple disk images on both of these cores works without issues.

## bootcore
Rewrote most of this because it needs now needs to handle more state and I didn't want to work around how some of it previous worked. Internal functions are no longer in the header and the bootcore state is handled internally (moved from menu.cpp) and doesn't modify the cfg data anymore. The `lastcore.dat` data that gets written out is not a structure that contains the core path along with the name of the core and the last file that was loaded for the core. When a file is selected and when store_name is false (since those files would be loaded automatically when the core starts anyway) that path is written to the lastcore data via `bootcore_record_file`. On core startup the `bootcore_load_file` function will attempt to load that file via the `user_io_load_or_mount` function. Currently only files (ROMS) are tracked, the lastgame functionality doesn't make any attempt to mount disk images.

## Misc
Changes to support/* and file_io.* are just function signature fixes required for const correctness.