### PR TITLE
Don't initialize the cheats on all file loads

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2184,7 +2184,7 @@ void HandleUI(void)
 					}
 					if (!store_name) user_io_store_filename(selPath);
 					user_io_file_tx(selPath, idx, opensave, 0, 0, load_addr);
-					if (user_io_use_cheats()) cheats_init(selPath, user_io_get_file_crc());
+					if (user_io_use_cheats() && !store_name) cheats_init(selPath, user_io_get_file_crc());
 				}
 
 				if (addon[0] == 'f' && addon[1] == '1') process_addon(addon, idx);


### PR DESCRIPTION
Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/262

Only initialize the cheat system if `store_name` is not set. There could be other issues in here if the neogeo or pcengine cores ever use this functionality also, but I've just focused on the NES issue.