### PR TITLE
Only enable shadow masks if the data is correctly read

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -427,14 +427,7 @@ static void setShadowMask()
 
 	has_shadow_mask = true;
 
-	switch( video_get_shadow_mask_mode() )
-	{
-		default: spi_w(SM_FLAG(0)); break;
-		case SM_MODE_1X: spi_w(SM_FLAG(SM_FLAG_ENABLED)); break;
-		case SM_MODE_2X: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_2X)); break;
-		case SM_MODE_1X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED)); break;
-		case SM_MODE_2X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED | SM_FLAG_2X)); break;
-	}
+	spi_w(SM_FLAG(0)); // default to disabled
 
 	snprintf(filename, sizeof(filename), SMASK_DIR"/%s", shadow_mask_cfg + 1);
 
@@ -444,6 +437,7 @@ static void setShadowMask()
 		int w = -1, h = -1;
 		int y = 0;
 		int v2 = 0;
+		bool valid = false;
 
 		const char *line;
 		while ((line = FileReadLine( &reader )))
@@ -459,7 +453,6 @@ static void setShadowMask()
 				int n = sscanf(line, "%d,%d", &w, &h);
 				if ((n != 2) || (w <= 0) || (h <= 0) || (w > 16) || (h > 16))
 				{
-					spi_w(SM_FLAG(0));
 					break;
 				}
 			}
@@ -469,19 +462,31 @@ static void setShadowMask()
 				int n = sscanf(line, "%X,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x", p + 0, p + 1, p + 2, p + 3, p + 4, p + 5, p + 6, p + 7, p + 8, p + 9, p + 10, p + 11, p + 12, p + 13, p + 14, p + 15);
 				if( n != w )
 				{
-					spi_w(SM_FLAG(0));
 					break;
 				}
 
 				for (int x = 0; x < 16; x++) spi_w(SM_LUT(v2 ? (p[x] & 0x7FF) : (((p[x] & 7) << 8) | 0x2A)));
 				y += 1;
 
-				if( y == h ) break;
+				if( y == h )
+				{
+					valid = true;
+					break;
+				}
 			}
 		}
 
-		if( y == h )
+		if( valid )
 		{
+			switch( video_get_shadow_mask_mode() )
+			{
+				default: spi_w(SM_FLAG(0)); break;
+				case SM_MODE_1X: spi_w(SM_FLAG(SM_FLAG_ENABLED)); break;
+				case SM_MODE_2X: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_2X)); break;
+				case SM_MODE_1X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED)); break;
+				case SM_MODE_2X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED | SM_FLAG_2X)); break;
+			}
+
 			spi_w(SM_HMAX(w - 1));
 			spi_w(SM_VMAX(h - 1));
 		}


### PR DESCRIPTION
If shadow mask files are moved or deleted, or when people enable shadow masks without having a file selected, they will get a black screen because the shadow mask enabled flag gets set without any valid data being sent. This change defers the setting of the flag until the file has been correctly read.