### PR TITLE
Change Analog Stick Reporting range to -128 to 127

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2799,10 +2799,10 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					else value = 0;
 				}
 
-				value = (value * 127) / hrange;
+				value = (value * 128) / hrange;
 
 				//final check to eliminate additive error
-				if (value < -127) value = -127;
+				if (value < -128) value = -128;
 				else if (value > 127) value = 127;
 
 				if (input[sub_dev].axis_pos[ev->code & 0xFF] == (int8_t)value) break;


### PR DESCRIPTION
This change sets the range multiplier to 128 from 127, and also changes the min negative value limit to -128.

According to the PadTest 1.0 application from Shendo, the PlayStation stick has an analog range from -128 to 127. When testing in the current PSX core, I'm seeing a range of -127 to 127. This becomes immediately apparent when trying to run forward in Ape Escape as only the max analog value will cause the main character to run.

I've values from an original console (SCPH 5501) along with before and after from the PSX core.
SCPH 5501 w/ dualshock 2:
![84B85794-CAC4-4440-BA6A-506D874EC408-COLLAGE](https://user-images.githubusercontent.com/20171720/147720190-e03d8716-b19e-450f-afc4-673b3e1f2afb.jpg)
Before change:
![C8668608-0DD8-4341-A18C-6607B6837702-COLLAGE](https://user-images.githubusercontent.com/20171720/147720217-d5fd358e-cdb1-4ada-9ed3-841db045457d.jpg)
After:
![E975BF1A-45AA-47FC-83F7-E05CCB84A4B6-COLLAGE](https://user-images.githubusercontent.com/20171720/147720227-837a7c94-f8ed-46dd-b94c-319c74a9bdf6.jpg)

I don't believe this causes issues for other cores that use analog inputs, but I checked in the input tester and Vectrex core and the change does not seem to break any behavior.