### PR TITLE
Namco GunCon 2 lightgun support

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -3806,6 +3806,12 @@ int input_test(int getchar)
 							input[n].lightgun = 1;
 						}
 
+						//Namco GunCon 2
+						if (input[n].vid == 0x0b9a && input[n].pid == 0x016a)
+						{
+							input[n].lightgun = 1;
+						}
+
 						//Madcatz Arcade Stick 360
 						if (input[n].vid == 0x0738 && input[n].pid == 0x4758) input[n].quirk = QUIRK_MADCATZ360;
 


### PR DESCRIPTION
Hello!

Recently, beardypig has authored a driver for the Namco GunCon 2: https://github.com/beardypig/guncon2

We were able to compile, install (as an external module), and test this driver on the MiSTer. Besides the driver module, the only other change necessary is to acknowledge the GunCon's VID/PID as a lightgun, which is the change contained in this PR.

Currently, the gun's position is reported both as a mouse input (though the mouse input currently seems to not be working correctly as an absolute mouse) and as an analog joystick (which works perfectly.)

The raw coordinates coming in from the gun are slightly misaligned. I suspect the lightgun calibration screen would be able to help with this, but it is currently only for Wiimotes. However, this is not a problem for any game with built-in calibration (such as Super Scope games), and it's close enough otherwise.

Context: The GunCon 2 is a CRT beam-timing-based lightgun that calculates its position by timing the detection of a CRT beam against the video sync timing (via an RCA cable that taps into the composite video, composite sync, or luma signal.) This has some disadvantages: the gun requires a CRT to work, and it only works if the picture is bright enough (which poses problems for games designed for IR guns such as the Genesis Menacer, unless the TV's brightness is cranked up.) However, when it does work (such as on games for the SNES Super Scope, and likely for PSX gun games as well), it is nearly flawless: highly precise, little jitter, low lag, and low sensitivity to where the player is standing.

As a side benefit, this driver also allows the MiSTer to be used with the Sinden Lightgun, if the Sinden is set up using an Arduino to report itself as a GunCon 2. An external video processor such as the OSSC is also required in order to put the necessary white border on the video output. This setup has none of the disadvantages listed above.

Thank you!