### PR TITLE
fixed header miniz instead of zlib

### DIFF
--- a/support/uef/uef_reader.cpp
+++ b/support/uef/uef_reader.cpp
@@ -30,7 +30,7 @@
 #include <assert.h>
 
 
-#include <zlib.h>
+#include "miniz.h"
 
 #include "file_io.h"
 #include "user_io.h"


### PR DESCRIPTION
supposedly zlib.h isn't always available, but we have miniz.h in the tree