### PR TITLE
put zlib back

### DIFF
--- a/support/uef/uef_reader.cpp
+++ b/support/uef/uef_reader.cpp
@@ -30,7 +30,7 @@
 #include <assert.h>
 
 
-#include "miniz.h"
+#include <zlib.h>
 
 #include "file_io.h"
 #include "user_io.h"


### PR DESCRIPTION
miniz.h doesn't parse gzip headers. We need the real zlib library and header, or we need to implement our own gzip. We already have gzip in the binary - let's use it.