### PR TITLE
IDE: Set default block size for multi r/w

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -423,7 +423,7 @@ void ide_img_set(uint32_t drvnum, fileTYPE *f, int cd, int sectors, int heads, i
 	drive->cylinders = 0;
 	drive->heads = 0;
 	drive->spt = 0;
-	drive->spb = 0;
+	drive->spb = 16;
 	drive->offset = 0;
 	drive->type = 0;
 
@@ -885,11 +885,6 @@ static int handle_hdd(ide_config *ide)
 		break;
 
 	case 0xC4: // read multiple
-		if (!ide->drive[ide->regs.drv].spb)
-		{
-			printf("(!) Read multiple is disabled!\n");
-			return 1;
-		}
 		process_read(ide, 1);
 		break;
 
@@ -899,11 +894,6 @@ static int handle_hdd(ide_config *ide)
 		break;
 
 	case 0xC5: // write multiple
-		if (!ide->drive[ide->regs.drv].spb)
-		{
-			printf("(!) Read multiple is disabled!\n");
-			return 1;
-		}
 		process_write(ide, 1);
 		break;
 


### PR DESCRIPTION
This is a solution for booting Linux on ao486 and is based on a discussion here: https://misterfpga.org/viewtopic.php?f=13&t=4006&p=43857#p43857

In that discussion, user "sajattack" reports that their attempt at booting a Linux installation is failing due to "READ MULTIPLE" commands failing to work with the IDE disk. User "user7182" notes that the MiSTer log output is showing that read multiple has been disabled because "SET MULTIPLE" has not set the block size.

I did some further research into IDE documentation I found online, and it seemed to me that there should be a default value for the block size, and "SET MULTIPLE" is an override to that default. This appears to be the way the Linux Kernel is operating as well, since it is attempting "READ MULTIPLE" without setting the block size. I experimented with some potential values for a default block size, and using a value of "16" allows Linux to boot all the way to a fully running system, and even complete a file system check.