### PR TITLE
PSX: Original way to deal with mencards with file 'originalwaymemcards.txt' on PSX directory

### DIFF
--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -252,7 +252,9 @@ void psx_mount_cd(int f_index, int s_index, const char *filename)
 			if (!loaded) Info("CD BIOS not found!", 4000);
 		}
 
-		if(*last_dir) psx_mount_save(last_dir);
+		sprintf(buf, "%s/originalwaymemcards.txt", HomeDir());
+		if(!FileExists(buf))
+			if(*last_dir) psx_mount_save(last_dir);
 	}
 
 	if (loaded)


### PR DESCRIPTION
To permits user to use the original way of memory cards on PSX core.
Tested with and without file it is working as expected.
Thanks,
