### PR TITLE
Revert "controller: add switch pro rev pid exemption (#539)"

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -3753,7 +3753,7 @@ int input_test(int getchar)
 							input[n].num = 2; // force mayflash mode 1/2 as second joystick.
 						}
 
-						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330 || input[n].pid == 0x2009))
+						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330))
 						{
 							if (strcasestr(input[n].name, "Accelerometer"))
 							{


### PR DESCRIPTION
This reverts commit 60a85eb630f6428109f15406df7789a1fff79f13. The original commit caused problems, I tried to fix it, and it ended up revealing that the accelerometer output was already filtered for this controller and this was instead the analog joysticks being much too sensitive.

Related to this --> https://github.com/MiSTer-devel/Main_MiSTer/issues/537