### PR TITLE
Auto rotation and video info

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -3753,7 +3753,7 @@ int input_test(int getchar)
 							input[n].num = 2; // force mayflash mode 1/2 as second joystick.
 						}
 
-						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330))
+						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330 || input[n].pid == 0x2009))
 						{
 							if (strcasestr(input[n].name, "Accelerometer"))
 							{

--- a/input.cpp
+++ b/input.cpp
@@ -3753,7 +3753,7 @@ int input_test(int getchar)
 							input[n].num = 2; // force mayflash mode 1/2 as second joystick.
 						}
 
-						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330 || input[n].pid == 0x2009))
+						if (input[n].vid == 0x057e && (input[n].pid == 0x0306 || input[n].pid == 0x0330))
 						{
 							if (strcasestr(input[n].name, "Accelerometer"))
 							{

--- a/menu.cpp
+++ b/menu.cpp
@@ -686,14 +686,10 @@ static void printSysInfo()
 		sysinfo_timer = GetTimer(2000);
 		struct battery_data_t bat;
 		int hasbat = getBattery(0, &bat);
-		int n = 3;
+		int n = 2;
 
 		char str[40];
 		OsdWrite(n++, info_top, 0, 0);
-		if (!hasbat)
-		{
-			infowrite(n++, "");
-		}
 
 		int j = 0;
 		char *net;
@@ -716,6 +712,8 @@ static void printSysInfo()
 
 		if (hasbat)
 		{
+			infowrite(n++, "");
+	
 			sprintf(str, "\x1F ");
 			if (bat.capacity == -1) strcat(str, "n/a");
 			else sprintf(str + strlen(str), "%d%%", bat.capacity);
@@ -752,6 +750,10 @@ static void printSysInfo()
 		else
 		{
 			infowrite(n++, "");
+			video_core_description(str, 40);
+			infowrite(n++, str);
+			video_scaler_description(str, 40);
+			infowrite(n++, str);
 		}
 		OsdWrite(n++, info_bottom, 0, 0);
 	}
@@ -3136,7 +3138,7 @@ void HandleUI(void)
 	case MENU_SFONT_FILE_SELECTED:
 		{
 			printf("MENU_SFONT_FILE_SELECTED --> '%s'\n", selPath);
-			sprintf(Selected_tmp, "/sbin/mlinkutil FSSFONT /media/fat/\"%s\"", selPath);
+			snprintf(Selected_tmp, sizeof(Selected_tmp), "/sbin/mlinkutil FSSFONT /media/fat/\"%s\"", selPath);
 			system(Selected_tmp);
 			AdjustDirectory(selPath);
 			// MENU_FILE_SELECT1 to file select OSD
@@ -3285,6 +3287,7 @@ void HandleUI(void)
 		helptext_idx = 0;
 		menumask = 0xF;
 		menustate = MENU_MISC2;
+		sysinfo_timer = 0; // force refresh
 		OsdSetTitle("Misc. Options", OSD_ARROW_RIGHT);
 
 		if (parentstate != MENU_MISC1)

--- a/video.cpp
+++ b/video.cpp
@@ -373,14 +373,7 @@ static void set_vfilter(int force)
 			valid = true;
 		}
 
-		if (video_is_rotated())
-		{
-			send_video_filters(&vert, &horiz, flt_flags & 0xF);
-		}
-		else
-		{
-			send_video_filters(&horiz, &vert, flt_flags & 0xF);
-		}
+		send_video_filters(&horiz, &vert, flt_flags & 0xF);
 	}
 
 	if (!valid) spi_uio_cmd8(UIO_SET_FLTNUM, 0);
@@ -600,23 +593,14 @@ static void setShadowMask()
 		return;
 	}
 
-	int normal_flag = 0;
-	int rotated_flag = SM_FLAG_ROTATED;
-
-	if (video_is_rotated())
-	{
-		normal_flag = SM_FLAG_ROTATED;
-		rotated_flag = 0;
-	}
-
 	has_shadow_mask = 1;
 	switch (video_get_shadow_mask_mode())
 	{
 		default: spi_w(SM_FLAG(0)); break;
-		case SM_MODE_1X: spi_w(SM_FLAG(SM_FLAG_ENABLED | normal_flag)); break;
-		case SM_MODE_2X: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_2X | normal_flag)); break;
-		case SM_MODE_1X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | rotated_flag)); break;
-		case SM_MODE_2X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | rotated_flag | SM_FLAG_2X)); break;
+		case SM_MODE_1X: spi_w(SM_FLAG(SM_FLAG_ENABLED)); break;
+		case SM_MODE_2X: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_2X)); break;
+		case SM_MODE_1X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED)); break;
+		case SM_MODE_2X_ROTATED: spi_w(SM_FLAG(SM_FLAG_ENABLED | SM_FLAG_ROTATED | SM_FLAG_2X)); break;
 	}
 
 	int loaded = 0;
@@ -1272,11 +1256,6 @@ void video_mode_adjust()
 		set_video(v, Fpix);
 		user_io_send_buttons(1);
 		force = true;
-	}
-	else if (vid_changed)
-	{
-		setScaler();
-		setShadowMask();
 	}
 	else
 	{

--- a/video.h
+++ b/video.h
@@ -5,6 +5,19 @@
 #define VFILTER_VERT 1
 #define VFILTER_SCAN 2
 
+struct VideoInfo
+{
+    uint32_t width;
+	uint32_t height;
+	uint32_t htime;
+	uint32_t vtime;
+	uint32_t ptime;
+	uint32_t vtimeh;
+
+    bool interlaced;
+    bool rotated;
+};
+
 int   video_get_scaler_flt(int type);
 void  video_set_scaler_flt(int type, int n);
 char* video_get_scaler_coeff(int type, int only_name = 1);
@@ -32,5 +45,10 @@ void video_menu_bg(int n, int idle = 0);
 int video_bg_has_picture();
 int video_chvt(int num);
 void video_cmd(char *cmd);
+
+bool video_is_rotated();
+void video_core_description(char *str, size_t len);
+void video_scaler_description(char *str, size_t len);
+
 
 #endif // VIDEO_H


### PR DESCRIPTION
Read the rotation flag when updating the video info. When the simulated display is rotated, when rotate the shadow masks and video filters also. Also calculate vscale using the width instead of the height so integer scaling is applied correctly.

Save the video info from the core and display it in the Information area (as long as there isn't a battery connected!)

![Video Info in OSD](https://user-images.githubusercontent.com/6377250/154092654-b288b63a-25d3-4c2d-ad52-c9c9645c8934.png)

Split up code a little so retrieving the info, showing it in based on `video_info` and apply the video mode are separate functions.

Depends on https://github.com/MiSTer-devel/Template_MiSTer/pull/50 for the rotation flag.

