### PR TITLE
Correct PSX light gun x/y spans + improve CRT gun performance

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2806,6 +2806,14 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					else value = 0;
 				}
 
+				// When in PSX core, adjust lightguns to Namco GunCon 1 range
+				// (NOTE: may need additional adjustments for PAL and/or the Konami Justifier)
+				if (is_psx() && input[dev].lightgun)
+				{
+					if (ev->code == 0) value = (value * 550) / 762;
+					if (ev->code == 1) value = (value * 240) / 256;
+				}
+
 				int range = is_psx() ? 128 : 127;
 				value = (value * range) / hrange;
 


### PR DESCRIPTION
The PSX core has support for using an analog joystick or a light gun to emulate the Namco GunCon.

The framework reports analog joysticks and light guns using a range of +/-128. The original GunCon reports its horizontal coordinate in 8 MHz clocks since HSYNC, and its vertical coordinate in scanlines since VSYNC.

The GunCon range is not half or double the analog joystick range, so an integer multiply would be required to remap the coordinate inside the PSX core. To economize on FPGA resources for that core, that remapping is done here in the ARM instead, where it is cheaper.