### PR TITLE
Support setting sync polarity

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -72,8 +72,8 @@ dvi_mode=0
 ;12 - 1920x1440@60
 ;13 - 2048x1536@60
 ;
-; custom mode: hact,hfp,hs,hbp,vact,vfp,vs,vbp,Fpix_in_KHz
-;   video_mode=1280,110,40,220,720,5,5,20,74250
+; custom mode: hact,hfp,hs,hbp,vact,vfp,vs,vbp,Fpix_in_KHz[,hsyncp,vsyncp]
+;   video_mode=1280,110,40,220,720,5,5,20,74250,0,0
 video_mode=0
 
 ; set to 1-10 (seconds) to display video info on startup/change


### PR DESCRIPTION
Hi, this PR adds support for changing video sync polarity.  This is useful for older CRT monitors which used sync polarity to define the display mode.  For example, I've been testing with an IBM 8512 monitor which uses the following scheme:
```
VSYNC HSYNC MODE
−     +     Mode 1 (350 lines)
+     −     Mode 2 (400 lines)
−     −     Mode 3 (480 lines)
+     +     Mode 4 (Other -- not available on all displays)
```
Without changing the sync polarity, there's no way to get these monitors to properly display common modes like 720x400 and 320x200.


In order to maintain backward compatibility with cores, the horizontal and vertical polarities are set in the high bits of the existing hsync and vsync values in the UIO_SET_VIDEO command.  Each core needs to be updated to support this, so here's an example of the changes on the FPGA side:
https://github.com/tsowell/Menu_MiSTer/commit/780a8137f1798748592296ac5119e29f53c5bdc7

The configuration changes for MiSTer.ini are also backward compatible.  Polarities are specified by two optional integers at the end of a custom mode string.

Let me know if you have any questions, or if you decide to accept this, how I should proceed with the changes to the cores.  I imagine there's a process for making universal changes, but I'd be happy to script something to spam you with PRs for each one. :)