### PR TITLE
PSX: Try loading optional cd_bios.rom from both game dir and parent dir

### DIFF
--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -616,12 +616,24 @@ void psx_mount_cd(int f_index, int s_index, const char *filename)
 					{
 						int bios_loaded = 0;
 
-						strcpy(buf, last_dir);
+						// load cd_bios.rom from game directory
+						sprintf(buf, "%s/", last_dir);
 						p = strrchr(buf, '/');
 						if (p)
 						{
 							strcpy(p + 1, "cd_bios.rom");
 							bios_loaded = load_bios(buf);
+						}
+
+						// load cd_bios.rom from parent directory
+						if (!bios_loaded) {
+							strcpy(buf, last_dir);
+							p = strrchr(buf, '/');
+							if (p)
+							{
+								strcpy(p + 1, "cd_bios.rom");
+								bios_loaded = load_bios(buf);
+							}
 						}
 
 						if (!bios_loaded)


### PR DESCRIPTION
When loading a PSX game try loading `cd_bios.rom` from both game and parent directory before falling back to `boot.rom`. This is as stated in the README and doesn't force a multi-level hierarchy for enabling optional BIOSes.

> You can also place a cd_bios.rom in the same directory as the CD or 1 directory above, to have it uses together with that CD. This can be used for games that depend on the BIOS region(US,EU,JP).