### PR TITLE
IDE: Semi-implement READ_VERIFY and suppress debug output

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -928,6 +928,12 @@ static int handle_hdd(ide_config *ide)
 		ide_set_regs(ide);
 		break;
 
+	case 0x40: // READ VERIFY
+		dbg_printf("Received read verify command. Not implemented but returning OK.\n");
+		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ;
+		ide_set_regs(ide);
+		break;
+
 	case 0x91: // initialize device parameters
 		ide_set_geometry(&ide->drive[ide->regs.drv], ide->regs.sector_count, ide->regs.head + 1);
 		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ;

--- a/ide.cpp
+++ b/ide.cpp
@@ -913,13 +913,13 @@ static int handle_hdd(ide_config *ide)
 			return 1;
 		}
 		ide->drive[ide->regs.drv].spb = ide->regs.sector_count;
-		printf("New block size: %d\n", ide->drive[ide->regs.drv].spb);
+		dbg_printf("New block size: %d\n", ide->drive[ide->regs.drv].spb);
 		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ;
 		ide_set_regs(ide);
 		break;
 
 	case 0x08: // reset (fail)
-		printf("Reset command (08h) for HDD not supported\n");
+		dbg_printf("Reset command (08h) for HDD not supported\n");
 		return 1;
 
 	case 0x10 ... 0x1F: // recalibrate
@@ -941,8 +941,8 @@ static int handle_hdd(ide_config *ide)
 		break;
 
 	default:
-		printf("(!) Unsupported command (%04X)\n", ide->base);
-		ide_print_regs(&ide->regs);
+		dbg_printf("(!) Unsupported command (%04X)\n", ide->base);
+		dbg_print_regs(&ide->regs);
 		return 1;
 	}
 
@@ -964,7 +964,7 @@ void ide_io(int num, int req)
 			ide->regs.status = ATA_STATUS_RDY;
 			ide_set_regs(ide);
 
-			printf("IDE %04X reset finish\n", ide->base);
+			dbg_printf("IDE %04X reset finish\n", ide->base);
 		}
 	}
 	else if (req == 4) // command

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1314,8 +1314,8 @@ void cdrom_handle_pkt(ide_config *ide)
 
 	if (err)
 	{
-		printf("(!) Error in packet command %02X\n", cmdbuf[0]);
-		hexdump(cmdbuf, 12, 0);
+		dbg_printf("(!) Error in packet command %02X\n", cmdbuf[0]);
+		dbg_hexdump(cmdbuf, 12, 0);
 		cdrom_reply(ide, ATA_ERR_ABRT);
 	}
 }
@@ -1382,8 +1382,8 @@ int cdrom_handle_cmd(ide_config *ide)
 		return 1; // must always fail
 
 	default:
-		printf("(!) Unsupported command\n");
-		ide_print_regs(&ide->regs);
+		dbg_printf("(!) Unsupported command\n");
+		dbg_print_regs(&ide->regs);
 		return 1;
 	}
 

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1314,8 +1314,8 @@ void cdrom_handle_pkt(ide_config *ide)
 
 	if (err)
 	{
-		dbg_printf("(!) Error in packet command %02X\n", cmdbuf[0]);
-		dbg_hexdump(cmdbuf, 12, 0);
+		printf("(!) Error in packet command %02X\n", cmdbuf[0]);
+		hexdump(cmdbuf, 12, 0);
 		cdrom_reply(ide, ATA_ERR_ABRT);
 	}
 }
@@ -1382,8 +1382,8 @@ int cdrom_handle_cmd(ide_config *ide)
 		return 1; // must always fail
 
 	default:
-		dbg_printf("(!) Unsupported command\n");
-		dbg_print_regs(&ide->regs);
+		printf("(!) Unsupported command\n");
+		ide_print_regs(&ide->regs);
 		return 1;
 	}
 


### PR DESCRIPTION
This is a solution for using NTFS under Windows NT on ao486.

Without supporting ATA command 0x40 (READ_VERIFY), NTFS conversion in Windows NT setup (or using convert.exe) gets stuck in an infinite loop. This PR provides an OK response to the 0x40 command although it does not actually provide any verification of a good read.

Additionally there are other unsupported commands which are called by NT during the conversion process which are OK to ignore/fail. However, they occur so rapidly during the conversion loop that this causes a flood of printf debug messages which cause significant slowdown to IDE access. This PR therefore also moves "unknown command" to dbg_printf so they are suppressed by default.