### PR TITLE
Moved the parsing of MGL files further up the process list

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1089,6 +1089,7 @@ void user_io_init(const char *path, const char *xml)
 		is_arcade_type = 1;
 		arcade_override_name(xml);
 	}
+	if (xml && isXmlName(xml) == 2) mgl_parse(xml);
 
 	if (core_type == CORE_TYPE_8BIT)
 	{
@@ -1142,7 +1143,6 @@ void user_io_init(const char *path, const char *xml)
 	load_volume();
 
 	user_io_send_buttons(1);
-	if (xml && isXmlName(xml) == 2) mgl_parse(xml);
 
 	switch (core_type)
 	{


### PR DESCRIPTION
Moved the parsing of MGL files before the parsing of the config settings, right after the parsing of MRA files.
If the core loads any images or mounts any files during configuration parsing, mgl_done is set to 1 and not reset after parsing the mgl file.  Moving it up to just after the parsing of MRA files fixes this issue.