### PR TITLE
GunCon 3 + negative gun-cal values

### DIFF
--- a/input.h
+++ b/input.h
@@ -99,7 +99,7 @@ uint32_t get_amiga_code(uint16_t key);
 uint32_t get_archie_code(uint16_t key);
 
 int input_has_lightgun();
-void input_lightgun_save(int idx, uint16_t *cal);
+void input_lightgun_save(int idx, int32_t *cal);
 
 void input_switch(int grab);
 int input_state();

--- a/menu.cpp
+++ b/menu.cpp
@@ -954,7 +954,7 @@ static int gun_y = 0;
 static int gun_ok = 0;
 static int gun_side = 0;
 static int gun_idx = 0;
-static uint16_t gun_pos[4] = {};
+static int32_t gun_pos[4] = {};
 static int page = 0;
 
 void HandleUI(void)


### PR DESCRIPTION
This PR modifies the gun calibration struct and file to use four 32-bit signed integers instead of four 16-bit unsigned integers. Many light guns use negative values for calibration, including the Namco GunCon 3, the Gun4IR system, and others.

Note: This change breaks compatibility with existing gun calibration files, so users will have to recalibrate. I've also therefore added _v2 to the gun calibration file name.

This PR also adds recognition of the Namco GunCon 3 as a lightgun with calibration enabled.

The quirks QUIRK_LIGHTGUN and QUIRK_LIGHTGUN_CRT are currently treated identically, but I'm planning to give QUIRK_LIGHTGUN_CRT some unique behavior in another upcoming PR - hence them still being separate.