### PR TITLE
Fix PC Engine CD player controls ( #585 )

### DIFF
--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -756,7 +756,7 @@ void pcecdd_t::CommandExec() {
 		buf[7] = BCD(msf.s);
 		buf[8] = BCD(msf.f);
 
-		LBAToMSF(this->lba, &msf);
+		LBAToMSF(this->lba+150, &msf);
 		buf[9] = BCD(msf.m);
 		buf[10] = BCD(msf.s);
 		buf[11] = BCD(msf.f);


### PR DESCRIPTION
Correct LBA-MSF conversion for absolute offset in the SUBQ request function (relative remains without offset)