### PR TITLE
Offer force reloading of volume configs

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -27,6 +27,7 @@
 #include "video.h"
 #include "joymapping.h"
 #include "support.h"
+#include "audio.h"
 
 #define NUMDEV 30
 #define NUMPLAYERS 6
@@ -5053,6 +5054,7 @@ int input_test(int getchar)
 					{
 						user_io_screenshot_cmd(cmd);
 					}
+					else if (!strncmp(cmd, "vol_load", 8)) load_volume();
 				}
 			}
 


### PR DESCRIPTION
This patch adds a "vol_load" cmd to the /dev/MiSTer_cmd interface so the Volume.dat file can be read on request

As far as I've been able to tell, MiSTer offers no way to adjust system volume from linux besides writing directly to memory or simulating key presses of the volume media keys. It's possible to set a value in Volume.dat, but this value is not read enough to be of use right now (I understand that this is not the intended purpose)

This feature is useful to me so that the volume of background music can be adjusted in the menu. I believe it would also be of use for the Super Attract Mode script. There may be other use cases for applications like mistercon, webmenu and bcm