### PR TITLE
PSX: Add "SIPS" region code support

### DIFF
--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -557,6 +557,7 @@ const region_info_t region_info_table[]
 	{ "SLPM", region_t::JP },
 	{ "SCPS", region_t::JP },
 	{ "SLPS", region_t::JP },
+	{ "SIPS", region_t::JP },
 	// for demo disks
 	{ "PUPX", region_t::US },
 	{ "PEPX", region_t::EU },


### PR DESCRIPTION
SIPS was a code used for some Western Imports into Japan.

http://redump.org/discs/quicksearch/sips/

I checked the bins of a few of these games in a hex editor and they do indeed have the SIPS code internally as well.