### PR TITLE
Set content type to zero when not using game mode

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -1028,16 +1028,16 @@ static void hdmi_config()
 		0x56, 0b00001000,		// [5:4] Picture Aspect Ratio
 								// [3:0] Active Portion Aspect Ratio b1000 = Same as Picture Aspect Ratio
 
-		0x57, (uint8_t)((cfg.hdmi_game_mode ? 0x80 : 0x00) // [7] IT Content. 0 - No. 1 - Yes (type set in register 0x59).
-								// [6:4] Color space (ignored for RGB)
-			| ((ypbpr || cfg.hdmi_limited) ? 0b0100 : 0b1000)), // [3:2] RGB Quantization range
-								// [1:0] Non-Uniform Scaled: 00 - None. 01 - Horiz. 10 - Vert. 11 - Both.
+		0x57, (uint8_t)((cfg.hdmi_game_mode ? 0x80 : 0x00)		// [7] IT Content. 0 - No. 1 - Yes (type set in register 0x59).
+																// [6:4] Color space (ignored for RGB)
+			| ((ypbpr || cfg.hdmi_limited) ? 0b0100 : 0b1000)),	// [3:2] RGB Quantization range
+																// [1:0] Non-Uniform Scaled: 00 - None. 01 - Horiz. 10 - Vert. 11 - Both.
 
 		0x3C, vic_mode,			// VIC
 
-		0x59, (uint8_t)(((ypbpr || cfg.hdmi_limited) ? 0x00 : 0x40) // [7:6] [YQ1 YQ0] YCC Quantization Range: b00 = Limited Range, b01 = Full Range
-			| 0x30),			// [5:4] IT Content Type b11 = Game
-								// [3:0] Pixel Repetition Fields b0000 = No Repetition
+		0x59, (uint8_t)(((ypbpr || cfg.hdmi_limited) ? 0x00 : 0x40)	// [7:6] [YQ1 YQ0] YCC Quantization Range: b00 = Limited Range, b01 = Full Range
+			| (cfg.hdmi_game_mode ? 0x30 : 0x00)),					// [5:4] IT Content Type b11 = Game, b00 = Graphics/None
+																	// [3:0] Pixel Repetition Fields b0000 = No Repetition
 
 		0x73, 0x01,
 


### PR DESCRIPTION
This field should just be ignored, however in earlier versions of the CEA-861
spec this field was reserved and supposed to be initialized to 0.

Fixes: https://github.com/MiSTer-devel/PSX_MiSTer/issues/96
Fixes: https://github.com/MiSTer-devel/Main_MiSTer/issues/610
