### PR TITLE
Also uses joystick button on lightgun calibration

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -6898,7 +6898,7 @@ int menu_lightgun_cb(int idx, uint16_t type, uint16_t code, int value)
 
 	if (type == EV_KEY)
 	{
-		if ((code == 0x130 || code == 0x131) && menustate == MENU_LGCAL1)
+		if ((code == 0x130 || code == 0x131 || code == 0x120) && menustate == MENU_LGCAL1)
 		{
 			gun_idx = idx;
 			if (value == 1) gun_ok = 1;


### PR DESCRIPTION
Previous implementation only catchs `gamepad` button `BTN_GAMEPAD`.
This commit add support for `joystick` button `BTN_JOYSTICK`.
Useful for lightgun devices using HID report type Joystick.