### PR TITLE
Set FD_CLOEXEC on underlying CHD file descriptors

### DIFF
--- a/support/chd/mister_chd.cpp
+++ b/support/chd/mister_chd.cpp
@@ -46,8 +46,12 @@ chd_error mister_load_chd(const char *filename, toc_t *cd_toc)
 	}
 
 	mister_chd_log("hunkbytes %d unitbytes %d logical length %llu\n", chd_header->hunkbytes, chd_header->unitbytes, chd_header->logicalbytes);
-	//Load track info
 
+	//Set CLOEXEC on underlying FD
+	int chd_fd = fileno(chd_core_file(cd_toc->chd_f));
+	if (chd_fd) fcntl(chd_fd, F_SETFD, FD_CLOEXEC);
+
+	//Load track info
 	int sector_cnt = 0;
 	for (cd_toc->last = 0; cd_toc->last < 99; cd_toc->last++)
 	{


### PR DESCRIPTION
Fixes FD leaks on core change or mister warm reboot