### PR TITLE
Send freesync/VRR enable frames if the display supports it

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -27,6 +27,22 @@ osd_timeout=30         ; 5-3600 timeout (in seconds) for OSD to disappear in Men
 osd_rotate=0           ; Display OSD menu rotated,  0 - no rotation, 1 - rotate right (+90°), 2 - rotate left (-90°)                  
 vga_sog=0              ; 1 - enable sync on green (needs analog I/O board v6.0 or newer).
 
+
+; Variable Refresh Rate control
+; 0 - Do not enable VRR (send no VRR control frames)
+; 1 - Auto Detect VRR from display EDID. 
+; 2 - Force Enable Freesync
+; 3 - Force Enable Vesa HDMI Forum VRR
+vrr_mode=0
+; Freesync min/max framerate parameter defaults to the min/max capability reported by the display
+; Freesync minimum framerate. 
+vrr_freesync_min_framerate=0
+; Freesync maximum framerate
+vrr_freesync_max_framerate=0
+; VESA VRR base framerate. Normally set to the current video mode's output framerate
+vrr_vesa_framerate=0
+
+
 ; 1 - enables the recent file loaded/mounted.
 ; WARNING: This option will enable write to SD card on every load/mount which may wear the SD card after many writes to the same place
 ;          There is also higher chance to corrupt the File System if MiSTer will be reset or powered off while writing.

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -96,6 +96,10 @@ static const ini_var_t ini_vars[] =
 	{ "WHEEL_FORCE", (void*)(&(cfg.wheel_force)), UINT8, 0, 100 },
 	{ "WHEEL_RANGE", (void*)(&(cfg.wheel_range)), UINT16, 0, 1000 },
 	{ "HDMI_GAME_MODE", (void *)(&(cfg.hdmi_game_mode)), UINT8, 0, 1},
+	{ "VRR_MODE", (void *)(&(cfg.vrr_mode)), UINT8, 0, 3},
+	{ "VRR_FREESYNC_MIN_FRAMERATE", (void *)(&(cfg.vrr_freesync_min_framerate)), UINT8, 0, 255},
+	{ "VRR_FREESYNC_MAX_FRAMERATE", (void *)(&(cfg.vrr_freesync_max_framerate)), UINT8, 0, 255},
+	{ "VRR_VESA_FRAMERATE", (void *)(&(cfg.vrr_vesa_framerate)), UINT8, 0, 255},
 };
 
 static const int nvars = (int)(sizeof(ini_vars) / sizeof(ini_var_t));

--- a/cfg.h
+++ b/cfg.h
@@ -73,6 +73,10 @@ typedef struct {
 	uint8_t wheel_force;
 	uint16_t wheel_range;
 	uint8_t hdmi_game_mode;
+	uint8_t vrr_mode;
+	uint8_t vrr_freesync_min_framerate;
+	uint8_t vrr_freesync_max_framerate;
+	uint8_t vrr_vesa_framerate;
 } cfg_t;
 
 extern cfg_t cfg;

--- a/video.cpp
+++ b/video.cpp
@@ -50,6 +50,12 @@
 #define FB_DV_UBRD  2
 #define FB_DV_BBRD  2
 
+#define VRR_NONE 0x00
+#define VRR_FREESYNC 0x01
+#define VRR_VESA 0x02
+
+
+
 
 static volatile uint32_t *fb_base = 0;
 static int fb_enabled = 0;
@@ -65,6 +71,27 @@ static int menu_bgn = 0;
 static VideoInfo current_video_info;
 
 static int support_FHD = 0;
+
+struct vrr_cap_t
+{
+		uint8_t active;
+		uint8_t available;
+		uint8_t min_fr;
+		uint8_t max_fr;
+		char description[128];
+};
+
+static vrr_cap_t vrr_modes[3] = {
+	{0, 0, 0, 0, "None"},
+	{0, 0, 0, 0, "AMD Freesync"},
+	{0, 0, 0, 0, "Vesa Forum VRR"},
+};
+
+static uint8_t last_vrr_mode = 0xFF;
+static float last_vrr_rate = 0.0f; 
+static uint8_t edid[256] = {};
+
+
 
 struct vmode_t
 {
@@ -1017,13 +1044,14 @@ static void hdmi_config()
 
 		0x3B, pr_flags,
 
-		0x40, 0x00,				// General Control Packet Enable
+		0x40, 0b01000001,				// General Control Packet Enable
 
 		0x48, 0b00001000,       // [6]=0 Normal bus order!
 								// [5] DDR Alignment.
 								// [4:3] b01 Data right justified (for YCbCr 422 input modes).
 
 		0x49, 0xA8,				// ADI required Write.
+		0x4A, 0b10000000, //Auto-Calculate SPD checksum
 		0x4C, 0x00,				// ADI required Write.
 
 		0x55, (uint8_t)(cfg.hdmi_game_mode ? 0b00010010 : 0b00010000),
@@ -1086,7 +1114,6 @@ static void hdmi_config()
 								// b111 = 1.6ns.
 
 		0xBB, 0x00,				// ADI required Write.
-
 		0xDE, 0x9C,				// ADI required Write.
 		0xE4, 0x60,				// ADI required Write.
 		0xFA, 0x7D,				// Nbr of times to search for good phase
@@ -1125,24 +1152,132 @@ static void hdmi_config()
 			int res = i2c_smbus_write_byte_data(fd, init_data[i], init_data[i + 1]);
 			if (res < 0) printf("i2c: write error (%02X %02X): %d\n", init_data[i], init_data[i + 1], res);
 		}
+
 		i2c_close(fd);
 	}
+
+
 	else
 	{
 		printf("*** ADV7513 not found on i2c bus! HDMI won't be available!\n");
 	}
 }
 
-static int get_edid_vmode(vmode_custom_t *v)
+static void edid_parse_cea_ext(uint8_t *cea)
 {
-	static uint8_t edid[256];
-	int hact, vact, pixclk_khz, hfp, hsync, hbp, vfp, vsync, vbp, hbl, vbl;
-	uint8_t *x = edid + 0x36;
+
+	uint8_t *data_block_end = cea + cea[2];
+	uint8_t *cur_blk_start = cea+4; 
+	uint8_t *cur_blk_data = cur_blk_start;
+	while (cur_blk_start != data_block_end)
+	{
+			cur_blk_data = cur_blk_start;
+			uint8_t blk_tag = (*cur_blk_data & 0xe0) >> 5;
+			uint8_t blk_size = *cur_blk_data & 0x1f;
+			uint8_t blk_data_size = blk_size; //size of actual data in the block, it might be adjusted if the first byte is extended tag
+			cur_blk_data++;
+			//vendor specific block might be the only one?
+
+			uint8_t is_vendor_specific = 0;
+			if (blk_tag == 0x03) is_vendor_specific = 1;
+			if (blk_tag == 0x07)
+			{
+				if (*cur_blk_data == 0x01) is_vendor_specific = 1;
+				cur_blk_data++; //The extended tag uses the next byte for the type. We may not need it?
+				blk_data_size--;
+			}
+			if (is_vendor_specific && blk_data_size >= 3)
+			{
+
+				int oui = cur_blk_data[0] |  cur_blk_data[1] << 8 | cur_blk_data[2] << 16;
+				cur_blk_data +=3;
+				blk_data_size -= 3;
+				if (oui == 0x00001a) //AMD block
+				{
+					uint8_t min_fr = cur_blk_data[2];
+
+					uint8_t max_fr = cur_blk_data[3];
+					if (min_fr && max_fr)
+					{
+						vrr_modes[VRR_FREESYNC].available = 1;
+						vrr_modes[VRR_FREESYNC].min_fr = min_fr;
+						vrr_modes[VRR_FREESYNC].max_fr = max_fr;
+					}
+				} else if (oui == 0xc45dd8) {
+				
+					if (blk_data_size > 5) //VRR lies beyond here
+					{
+						uint8_t min_fr = cur_blk_data[5] & 0x3f;
+						uint8_t max_fr = (cur_blk_data[5] & 0xc0) << 2 | cur_blk_data[6];
+						if (min_fr && max_fr)
+						{
+							vrr_modes[VRR_VESA].available = 1;
+							vrr_modes[VRR_VESA].min_fr = min_fr;
+							vrr_modes[VRR_VESA].max_fr = max_fr;
+						}
+					}
+				}
+			}
+			cur_blk_start += blk_size+1;
+	}
+
+}
+
+
+static int find_edid_vrr_capability()
+{
+	uint8_t *cur_ext = NULL;
+	uint8_t ext_cnt = edid[126];
+
+	//Probably only one extension, but just in case...
+	for (int i = 0; i < ext_cnt; i++)
+	{
+		cur_ext = edid + 128 + i*128; //edid extension blocks are 128 bytes 
+		uint8_t ext_tag = *cur_ext;
+		if (ext_tag == 0x02) //CEA EDID extension
+		{
+			edid_parse_cea_ext(cur_ext);			
+		}
+	}
+
+	for (size_t i = 1; i < sizeof(vrr_modes)/sizeof(vrr_cap_t); i++)
+	{
+		if (vrr_modes[i].available) printf("VRR: %s available\n", vrr_modes[i].description);	
+	}
+	return 0;
+
+}
+
+static int is_edid_valid()
+{
+
 	static const uint8_t magic[] = { 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00 };
+
+	if (sizeof(edid) < sizeof(magic)) return 0;
+
+	return !memcmp(edid, magic, sizeof(magic));
+}
+
+
+static int get_active_edid()
+{
 
 	hdmi_config(); // required to get EDID
 
-	int fd = i2c_open(0x3f, 0);
+	int fd = i2c_open(0x39, 0);
+	if (fd < 0)
+	{
+		printf("EDID: cannot find main i2c device\n");
+		return 0;
+	}
+
+	for (int i = 0; i < 10; i++)
+	{
+		i2c_smbus_write_byte_data(fd, 0xC9, 0x03); 
+		i2c_smbus_write_byte_data(fd, 0xC9, 0x13);
+	}
+	i2c_close(fd);
+	fd = i2c_open(0x3f, 0);
 	if (fd < 0)
 	{
 		printf("EDID: cannot find i2c device.\n");
@@ -1153,18 +1288,37 @@ static int get_edid_vmode(vmode_custom_t *v)
 	for (int k = 0; k < 20; k++)
 	{
 		for (uint i = 0; i < sizeof(edid); i++) edid[i] = (uint8_t)i2c_smbus_read_byte_data(fd, i);
-		if (!memcmp(edid, magic, sizeof(magic))) break;
+		if (is_edid_valid()) break;
 		usleep(100000);
 	}
 
 	i2c_close(fd);
-	printf("EDID:\n"); hexdump(edid, 256, 0);
+	printf("EDID:\n"); hexdump(edid, sizeof(edid), 0);
 
-	if (memcmp(edid, magic, sizeof(magic)))
+	if (!is_edid_valid())
 	{
 		printf("Invalid EDID: incorrect header.\n");
+		bzero(edid, sizeof(edid));
 		return 0;
 	}
+	return 1;
+}
+
+
+static int get_edid_vmode(vmode_custom_t *v)
+{
+
+
+	if (!is_edid_valid())
+	{
+ 		get_active_edid();		
+	}
+
+	if (!is_edid_valid()) return 0;
+	
+
+	int hact, vact, pixclk_khz, hfp, hsync, hbp, vfp, vsync, vbp, hbl, vbl;
+	uint8_t *x = edid + 0x36;
 
 	pixclk_khz = (x[0] + (x[1] << 8)) * 10;
 	if (pixclk_khz < 10000)
@@ -1215,6 +1369,7 @@ static int get_edid_vmode(vmode_custom_t *v)
 		break;
 	}
 	*/
+
 
 	double Fpix = pixclk_khz / 1000.f;
 	double frame_rate = Fpix * 1000000.f / ((hact + hfp + hbp + hsync)*(vact + vfp + vbp + vsync));
@@ -1276,6 +1431,152 @@ static int get_edid_vmode(vmode_custom_t *v)
 	v->param.rb = 2;
 	setPLL(v->Fpix, v);
 	return 1;
+}
+
+static void set_vrr_mode()
+{
+
+
+	float vrateh = 100000000;
+	if (current_video_info.vtimeh) vrateh /= current_video_info.vtimeh; else vrateh = 0;
+	if (cfg.vrr_vesa_framerate) vrateh = cfg.vrr_vesa_framerate;
+
+	if (last_vrr_mode == cfg.vrr_mode && last_vrr_rate == vrateh) return;
+
+	if (!is_edid_valid())
+	{
+		get_active_edid();
+	}
+
+	if (!is_edid_valid())
+	{
+		printf("Set VRR: No valid edid, cannot set\n");
+		return;
+	}
+
+
+	find_edid_vrr_capability();
+
+	int use_vrr = 0;
+
+	if (cfg.vrr_mode == 1) //autodetect
+	{
+		for(uint8_t i = 0; i < sizeof(vrr_modes) / sizeof(vrr_cap_t); i++)
+		{
+			if (vrr_modes[i].available)
+			{
+					use_vrr = i;
+					break;
+			}
+		}
+	} else if (cfg.vrr_mode == 2) { //force AMD Freesync
+		use_vrr = VRR_FREESYNC;
+	} else if (cfg.vrr_mode == 3) { //force Vesa Forum VRR
+		use_vrr = VRR_VESA;
+	} else { 
+		use_vrr = 0;
+	}
+
+	uint8_t min_fr = 0;
+	uint8_t max_fr = 0;
+
+	if (use_vrr == VRR_VESA && !vrateh) return;
+	if (use_vrr)
+	{
+		if (use_vrr == VRR_FREESYNC)
+		{
+			min_fr = cfg.vrr_freesync_min_framerate ? cfg.vrr_freesync_min_framerate : vrr_modes[use_vrr].min_fr;
+			max_fr = cfg.vrr_freesync_max_framerate ? cfg.vrr_freesync_max_framerate : vrr_modes[use_vrr].max_fr;
+			if (!min_fr) min_fr = 48;
+			if (!max_fr) max_fr = 75;
+		}
+		vrr_modes[use_vrr].active = 1;
+		printf("VRR: Set %s active\n", vrr_modes[use_vrr].description);
+		if (use_vrr == VRR_VESA)
+		{
+			printf("VESA Frame Rate %d Front Porch %d\n", (int)vrateh, v_cur.param.vfp);
+		}
+	}
+
+	uint8_t freesync_data[] = {
+		//header
+		0x00, 0x83,
+		0x01, 0x01,
+		0x02, 0x08,
+		//data
+		0x04, 0x1A,
+		0x05, 0x00,
+		0x06, 0x00,
+		//0x07
+		//0x08
+		0x09, (uint8_t)(use_vrr == VRR_FREESYNC ? 0x07 : 0x00), 
+		0x0A, min_fr, 
+		0x0B, max_fr,
+	};
+
+	uint8_t vesa_data[] = {
+		0xC0, 0x7F,
+		0xC1, 0xC0,
+		0xC2, 0x00,
+
+		0xC3, 0x40,
+		0xC5, 0x01,
+		0xC6, 0x00,
+		0xC7, 0x01,
+		0xC8, 0x00,
+		0xC9, 0x04,
+
+		0xCA, (uint8_t)(use_vrr == VRR_VESA ? 0x01 : 0x00),
+		0xCB, (uint8_t)(use_vrr == VRR_VESA ? v_cur.param.vfp : 0x00),
+		0xCC, (uint8_t)(use_vrr == VRR_VESA ? ((int16_t)vrateh >> 8) & 0x03  : 0x00),
+		0xCD, (uint8_t)(use_vrr == VRR_VESA ? (int16_t)vrateh & 0xFF  : 0x00),
+	};
+
+	if (vrr_modes[VRR_FREESYNC].available || vrr_modes[VRR_VESA].available)
+	{
+		int res = 0;
+		int fd = i2c_open(0x38, 0);
+		if (fd >= 0)
+		{
+			if (vrr_modes[VRR_FREESYNC].available)
+			{
+				res = i2c_smbus_write_byte_data(fd, 0x1F, 0b10000000);
+				if (res < 0)
+				{
+					printf("i2c: Vrr: Couldn't update SPD change register (0x1F, 0x80) %d\n", res);
+				}
+
+				for (uint i = 0; i < sizeof(freesync_data); i+=2)
+				{
+					res = i2c_smbus_write_byte_data(fd, freesync_data[i], freesync_data[i+1]);
+					if (res < 0) printf("i2c: Vrr register write error (%02X %02x): %d\n",freesync_data[i], freesync_data[i+1], res);
+				}
+				res = i2c_smbus_write_byte_data(fd, 0x1F, 0x00);
+				if (res < 0) printf("i2c: Vrr: Couldn't update SPD change register (0x1F, 0x00), %d\n", res);
+			}
+
+			if (vrr_modes[VRR_VESA].available)
+			{
+				res = i2c_smbus_write_byte_data(fd, 0xDF, 0b10000000);
+				if (res < 0)
+				{
+					printf("i2c: Vrr: Couldn't update Spare Packet change register (0xDF, 0x80) %d\n", res);
+				}
+
+				for (uint i = 0; i < sizeof(vesa_data); i+=2)
+				{
+					res = i2c_smbus_write_byte_data(fd, vesa_data[i], vesa_data[i+1]);
+					if (res < 0) printf("i2c: Vrr register write error (%02X %02x): %d\n", vesa_data[i], vesa_data[i+1], res);
+				}
+				res = i2c_smbus_write_byte_data(fd, 0xDF, 0x00);
+				if (res < 0) printf("i2c: Vrr: Couldn't update Spare Packet change register (0xDF, 0x00), %d\n", res);
+			}
+
+			i2c_close(fd);
+		}
+	}
+	last_vrr_mode = cfg.vrr_mode;
+	last_vrr_rate = vrateh;
 }
 
 static char fb_reset_cmd[128] = {};
@@ -1359,6 +1660,7 @@ static void set_video(vmode_custom_t *v, double Fpix)
 	brd_y = cfg.vscale_border / fb_scale_y;
 
 	if (fb_enabled) video_fb_enable(1, fb_num);
+
 
 	sprintf(fb_reset_cmd, "echo %d %d %d %d %d >/sys/module/MiSTer_fb/parameters/mode", 8888, 1, fb_width, fb_height, fb_width * 4);
 	system(fb_reset_cmd);
@@ -1830,6 +2132,7 @@ bool video_mode_select(uint32_t vtime, vmode_custom_t* out_mode)
 
 void video_mode_adjust()
 {
+
 	static bool force = false;
 
 	VideoInfo video_info;
@@ -1849,6 +2152,7 @@ void video_mode_adjust()
 
 		show_video_info(&video_info, &v_cur);
 		video_scaling_adjust(&video_info, &v_cur);
+		set_vrr_mode();
 	}
 	force = false;
 


### PR DESCRIPTION
If the display advertises Freesync/Vesa VRR support via the edid, send the correct HDMI config frames to the display to enable it.
Many consumer TVs will handle non-standard refresh rates properly once VRR is enabled.
Users must set vrr_mode=1 to enable, the default is to send no VRR config frames.
If a display advertises both Freesync and Vesa VRR, Freesync is preferred.

This change also strobes the proper register on the ADV7513 that causes it to re-read the display edid. This is only done once per execution of main, so you must load/reload a core to get MiSTer to notice a change in display.

