### PR TITLE
fix incorrect value for ioctl_index for more than 4 file extensions

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2216,7 +2216,7 @@ void HandleUI(void)
 			if (selPath[0])
 			{
 
-				char idx = user_io_ext_idx(selPath, fs_pFileExt) << 6 | ioctl_index;
+				uint16_t idx = user_io_ext_idx(selPath, fs_pFileExt) << 6 | ioctl_index;
 				if (addon[0] == 'f' && addon[1] != '1') process_addon(addon, idx);
 
 				if (fs_Options & SCANO_NEOGEO)

--- a/menu.cpp
+++ b/menu.cpp
@@ -2287,7 +2287,7 @@ void HandleUI(void)
 			}
 			else
 			{
-				user_io_set_index(user_io_ext_idx(selPath, fs_pFileExt) << 6 | (menusub + 1));
+				user_io_set_aindex(user_io_ext_idx(selPath, fs_pFileExt) << 6 | (menusub + 1));
 				user_io_file_mount(selPath, ioctl_index);
 			}
 

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2364,7 +2364,7 @@ int user_io_file_tx_a(const char* name, uint16_t index)
 	return 1;
 }
 
-int user_io_file_tx(const char* name, unsigned char index, char opensave, char mute, char composite, uint32_t load_addr)
+int user_io_file_tx(const char* name, uint16_t index, char opensave, char mute, char composite, uint32_t load_addr)
 {
 	fileTYPE f = {};
 	static uint8_t buf[4096];
@@ -2389,7 +2389,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 	if(load_addr) printf("Load to address 0x%X\n", load_addr);
 
 	// set index byte (0=bios rom, 1-n=OSD entry index)
-	user_io_set_index(index);
+	user_io_set_aindex(index);
 
 	int len = strlen(f.name);
 	char *p = f.name + len - 4;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -842,7 +842,7 @@ static void parse_config()
 					}
 					else
 					{
-						user_io_set_index(user_io_ext_idx(str, ext) << 6 | idx);
+						user_io_set_aindex(user_io_ext_idx(str, ext) << 6 | idx);
 						user_io_file_mount(str, idx);
 					}
 				}

--- a/user_io.h
+++ b/user_io.h
@@ -211,7 +211,7 @@ void user_io_set_ini(int ini_num);
 void user_io_send_buttons(char);
 uint16_t user_io_get_sdram_cfg();
 
-int user_io_file_tx(const char* name, unsigned char index = 0, char opensave = 0, char mute = 0, char composite = 0, uint32_t load_addr = 0);
+int user_io_file_tx(const char* name, uint16_t index = 0, char opensave = 0, char mute = 0, char composite = 0, uint32_t load_addr = 0);
 int user_io_file_tx_a(const char* name, uint16_t index);
 unsigned char user_io_ext_idx(char *, char*);
 void user_io_set_index(unsigned char index);


### PR DESCRIPTION
`ioctl_index` is 16 bits, but when loading or mounting images from the menu (`F` and `S` conf_str options), `ioctl_index` is a *char* causing all but the lower two bits of the selected extension index to be lost. 

This pull request makes the `F` and `S` options use the all 16 bits, making it possible to distinguish more than 4 file extensions in the core.