### PR TITLE
Tweak front and back porch calculations

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -3140,9 +3140,9 @@ static void video_calculate_cvt_int(int h_pixels, int v_lines, float refresh_rat
 	vmode->param.hs = h_sync;
 	vmode->param.hbp = h_back_porch;
 	vmode->param.vact = v_lines;
-	vmode->param.vfp = V_FRONT_PORCH;
+	vmode->param.vfp = V_FRONT_PORCH - 1;
 	vmode->param.vs = v_sync;
-	vmode->param.vbp = v_back_porch;
+	vmode->param.vbp = v_back_porch + 1;
 	vmode->param.rb = reduced_blanking ? 1 : 0;
 	vmode->Fpix = pixel_freq;
 


### PR DESCRIPTION
Remove one line from the front porch and add one to the back porch in calculated video modes. Because of how ascal calculates the start and end of vsync (https://github.com/MiSTer-devel/Template_MiSTer/blob/e09ce4689af1cfe89e38f4f74613538d44ee4dde/sys/ascal.vhd#L2672), the vsync doesn't start until the end of the first vsync line.

Results in a more compatible video mode that should address: https://github.com/MiSTer-devel/Main_MiSTer/issues/641