### PR TITLE
Allowing Minimig core to select ROMs in any folder

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -5658,7 +5658,7 @@ void HandleUI(void)
 			else if (menusub == 7 && select)
 			{
 				ioctl_index = 1;
-				SelectFile(Selected_F[4], "ROM", 0, MENU_MINIMIG_ROMFILE_SELECTED, MENU_MINIMIG_CHIPSET1);
+				SelectFile(Selected_F[4], "ROM", SCANO_DIR, MENU_MINIMIG_ROMFILE_SELECTED, MENU_MINIMIG_CHIPSET1);
 			}
 			else if (menusub == 8)
 			{


### PR DESCRIPTION
For a while the Minimig core has only made it possible to select ROM files in the Amiga folder directly. But many Minimig users have quite the collection of different Amiga ROMs though, so being able to have several sub-folders with kick ROMs for the core really helps.