### PR TITLE
Support for custom BIOS in PCXT core

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2182,7 +2182,7 @@ void HandleUI(void)
 
 									if (is_pce() && !bit) pcecd_reset();
 									if (is_saturn() && !bit) saturn_reset();
-									if (is_pcxt() && !bit) pcxt_init();
+									if (is_pcxt() && !bit) pcxt_init(!(bool)user_io_status_get("[23]"));
 
 									user_io_status_set(opt, 1, ex);
 									user_io_status_set(opt, 0, ex);

--- a/support/pcxt/pcxt.cpp
+++ b/support/pcxt/pcxt.cpp
@@ -40,12 +40,16 @@ typedef struct
 
 static pcxt_config config;
 
-void pcxt_init()
+void pcxt_init(bool rom_by_model)
 {	
 	user_io_status_set("[0]", 1);
+	if (rom_by_model) pcxt_model_rom();
+}
+
+void pcxt_model_rom()
+{
 	const char* home = HomeDir();
 	static char mainpath[512];
-
 	int status = user_io_status_get("[3]");
 	if (status)
 	{
@@ -54,8 +58,7 @@ void pcxt_init()
 	else
 	{
 		sprintf(mainpath, "%s/pcxt.rom", home);
-	}	
-	
+	}
 	user_io_file_tx(mainpath);
 }
 

--- a/support/pcxt/pcxt.h
+++ b/support/pcxt/pcxt.h
@@ -3,7 +3,8 @@
 
 #include "../../file_io.h"
 
-void pcxt_init(void);
+void pcxt_init(bool rom_by_model);
+void pcxt_model_rom();
 void* OpenUART(void*);
 void log(int level, const char* message, ...);
 unsigned long GetTime(void);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1407,7 +1407,7 @@ void user_io_init(const char *path, const char *xml)
 				else if (is_pcxt())
 				{
 					pcxt_config_load();
-					pcxt_init();
+					pcxt_init(true);
 				}
 				else
 				{


### PR DESCRIPTION
The optional custom ROM loading needs to be independent of model-specific ROM loading during core start-up. For this purpose, a status bit selectable from the OSD menu shall be used.

![image](https://user-images.githubusercontent.com/3509674/185856870-238ca626-d5e0-4b89-a479-68215469a1f2.png)
