### PR TITLE
Add support for [arcade_vertical] section

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -12,6 +12,7 @@
 #include "file_io.h"
 #include "user_io.h"
 #include "video.h"
+#include "support/arcade/mra_loader.h"
 
 cfg_t cfg;
 
@@ -193,6 +194,7 @@ static int ini_get_section(char* buf, const char *vmode)
 
 	if (!strcasecmp(buf, "MiSTer") ||
 		(is_arcade() && !strcasecmp(buf, "arcade")) ||
+		(arcade_is_vertical() && !strcasecmp(buf, "arcade_vertical")) ||
 		((wc_pos >= 0) ? !strncasecmp(buf, user_io_get_core_name(1), wc_pos) : !strcasecmp(buf, user_io_get_core_name(1))) ||
 		((wc_pos >= 0) ? !strncasecmp(buf, user_io_get_core_name(0), wc_pos) : !strcasecmp(buf, user_io_get_core_name(0))))
 	{

--- a/support/arcade/mra_loader.h
+++ b/support/arcade/mra_loader.h
@@ -59,7 +59,11 @@ sw_struct *arcade_sw(int n);
 void arcade_sw_send(int n);
 void arcade_sw_save(int n);
 void arcade_sw_load(int n);
-void arcade_override_name(const char *xml);
+
+// Read any mra info necessary for ini processing
+void arcade_pre_parse(const char *xml);
+
+bool arcade_is_vertical();
 
 void arcade_nvm_save();
 

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1280,7 +1280,7 @@ void user_io_init(const char *path, const char *xml)
 	if (xml)
 	{
 		if (isXmlName(xml) == 1) is_arcade_type = 1;
-		arcade_override_name(xml);
+		arcade_pre_parse(xml);
 	}
 
 	if (core_type == CORE_TYPE_8BIT)
@@ -1318,7 +1318,7 @@ void user_io_init(const char *path, const char *xml)
 		xml = (const char*)defmra;
 		strcpy(core_path, xml);
 		is_arcade_type = 1;
-		arcade_override_name(xml);
+		arcade_pre_parse(xml);
 		user_io_read_core_name();
 		printf("Using default MRA: %s\n", xml);
 	}


### PR DESCRIPTION
A lot of people maintain large lists of per-game ini sections so they can configure video modes, scaling options and some other things for arcade games that have a vertical orientation. There is a `<rotation>` tag in the mra files that specifies the orientation of each game. This change adds an `[arcade_vertical]` ini section for games that have their rotation tag set to `vertical`.

Not all games have the rotation tag set correctly. There hasn't really been much reason to do it, but maybe this change will encourage people to use it more consistently.