### PR TITLE
PCXT: Fix overlap in OSD menu between ROMs (Fx) and images (Sx) saved in config

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -723,6 +723,24 @@ int DirDelete(const char *name)
 	return !rmdir(full_path);
 }
 
+const char* GetNameFromPath(char *path)
+{
+	static char res[32];
+
+	char* p = strrchr(path, '/');
+	if (!p) p = path;
+	else p++;
+
+	if (strlen(p) < 19) strcpy(res, p);
+	else
+	{
+		strncpy(res, p, 19);
+		res[19] = 0;
+	}
+
+	return res;
+}
+
 int FileLoad(const char *name, void *pBuffer, int size)
 {
 	fileTYPE f;

--- a/file_io.h
+++ b/file_io.h
@@ -116,6 +116,7 @@ int DirDelete(const char *name);
 
 //save/load from config dir
 #define CONFIG_DIR "config"
+const char* GetNameFromPath(char* path);
 int FileSaveConfig(const char *name, void *pBuffer, int size);
 int FileLoadConfig(const char *name, void *pBuffer, int size); // supply pBuffer = 0 to get the file size without loading
 int FileDeleteConfig(const char *name);

--- a/menu.cpp
+++ b/menu.cpp
@@ -2297,7 +2297,7 @@ void HandleUI(void)
 			}
 
 			menustate = MENU_GENERIC_MAIN1;
-			if (selPath[0] && !is_x86()) MenuHide();
+			if (selPath[0] && !is_x86() && !is_pcxt()) MenuHide();
 
 			printf("Image selected: %s\n", selPath);
 			memcpy(Selected_S[(int)ioctl_index], selPath, sizeof(Selected_S[(int)ioctl_index]));

--- a/menu.cpp
+++ b/menu.cpp
@@ -1687,12 +1687,31 @@ void HandleUI(void)
 								strcat(s, " ");
 								strcat(s, x86_get_image_name(num));
 							}
-							else if (is_pcxt() && pcxt_get_image_name(num))
+							else if (is_pcxt() && (p[0] == 'S') && pcxt_get_image_name(num))
 							{
 								strcpy(s, " ");
 								substrcpy(s + 1, p, 2);
 								strcat(s, " ");
 								strcat(s, pcxt_get_image_name(num));
+							}
+							else if (is_pcxt() && (p[0] == 'F'))
+							{
+								strcpy(s, " ");
+								substrcpy(s + 1, p, 2);
+								static char str[1024];
+								sprintf(str, "%s.f%c", user_io_get_core_name(), p[idx]);
+								if (FileLoadConfig(str, str, sizeof(str)) && str[0])
+								{									
+									strcat(s, " ");
+									strcat(s, GetNameFromPath(str));
+								}
+								else
+								{
+									strcat(s, " *.");
+									pos = s + strlen(s);
+									substrcpy(pos, p, 1);
+									strcpy(pos, GetExt(pos));
+								}
 							}
 							else
 							{


### PR DESCRIPTION
Not only do I avoid the overlap, but I add ROM display already saved in the configuration. This, at least for the PCXT core, makes sense... I didn't want to transfer it to all the cores that load ROMs because maybe it's not always convenient to display them.

Before the fix:

![image](https://user-images.githubusercontent.com/3509674/190317848-5768d072-398f-466b-8164-11b5f2d4a472.png)

After the fix:

![image](https://user-images.githubusercontent.com/3509674/190317899-fbc60824-4f45-4d27-99b4-a466b8d295ec.png)
