### PR TITLE
Specify example video_mode lines in MiSTer.ini

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -86,10 +86,10 @@ reset_combo=0
 ;14 - 2560x1440@60
 ;
 ; custom mode: hact,hfp,hs,hbp,vact,vfp,vs,vbp,Fpix_in_KHz[,hsyncp,vsyncp]
-;   video_mode=1280,110,40,220,720,5,5,20,74250,+hsync,-vsync
+;  example: video_mode=1280,110,40,220,720,5,5,20,74250,+hsync,-vsync
 ;
 ; calculated mode: width,height,refresh[,flags]
-;   video_mode=1920,1200,60
+;  example: video_mode=1920,1200,60
 ; flags - cvt=CVT timing, cvtrb=CVT-RB timing (default)
 ;video_mode=0
 


### PR DESCRIPTION
Allows the ini_settings.sh script to correctly edit the expected video_mode line.

Currently the example mode listed on line 89 is edited due to it beginning with the variable name. An invalid video mode is set: video_mode=8+hsync,-vsync
This results in 720p output and a (helpful) 'INI Error' warning at boot