### PR TITLE
Allow setting controller assignment

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -121,6 +121,14 @@ refresh_max=0
 ; 0 - disable
 controller_info=6
 
+; Use these settings to override dynamic controller assignment.  The
+; device index is that reported in the controller button map as
+; D<index>.
+; controller_1_device=0
+; controller_2_device=1
+; controller_3_device=2
+; controller_4_device=3
+
 ; JammaSD/J-PAC/I-PAC keys to joysticks translation
 ; You have to provide correct VID and PID of your input device
 ; Examples: Legacy J-PAC with Mini-USB or USB capable I-PAC with PS/2 connectors VID=0xD209/PID=0x0301

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -67,6 +67,10 @@ static const ini_var_t ini_vars[] =
 	{ "GAMEPAD_DEFAULTS", (void*)(&(cfg.gamepad_defaults)), UINT8, 0, 1 },
 	{ "RECENTS", (void*)(&(cfg.recents)), UINT8, 0, 1 },
 	{ "CONTROLLER_INFO", (void*)(&(cfg.controller_info)), UINT8, 0, 10 },
+	{ "CONTROLLER_1_DEVICE", (void*)(&(cfg.controller_device[0])), UINT8, 0, 255 },
+	{ "CONTROLLER_2_DEVICE", (void*)(&(cfg.controller_device[1])), UINT8, 0, 255 },
+	{ "CONTROLLER_3_DEVICE", (void*)(&(cfg.controller_device[2])), UINT8, 0, 255 },
+	{ "CONTROLLER_4_DEVICE", (void*)(&(cfg.controller_device[3])), UINT8, 0, 255 },
 	{ "REFRESH_MIN", (void*)(&(cfg.refresh_min)), FLOAT, 0, 150 },
 	{ "REFRESH_MAX", (void*)(&(cfg.refresh_max)), FLOAT, 0, 150 },
 	{ "JAMMA_VID", (void*)(&(cfg.jamma_vid)), UINT16, 0, 0xFFFF },
@@ -416,6 +420,10 @@ void cfg_parse()
 	cfg.bootscreen = 1;
 	cfg.fb_terminal = 1;
 	cfg.controller_info = 6;
+	for (int i = 0; i < 4; i++)
+	{
+		cfg.controller_device[i] = 255;
+	}
 	cfg.browse_expand = 1;
 	cfg.logo = 1;
 	cfg.rumble = 1;

--- a/cfg.h
+++ b/cfg.h
@@ -25,6 +25,7 @@ typedef struct {
 	float refresh_min;
 	float refresh_max;
 	uint8_t controller_info;
+	uint8_t controller_device[4];
 	uint8_t vsync_adjust;
 	uint8_t kbd_nomouse;
 	uint8_t mouse_throttle;

--- a/input.cpp
+++ b/input.cpp
@@ -2366,6 +2366,19 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 	if (!input[dev].num)
 	{
+		for (int i = 0; i < 4; i++)
+		{
+			if (cfg.controller_device[i] == dev)
+			{
+				input[dev].num = i + 1;
+				store_player(input[dev].num, dev);
+				break;
+			}
+		}
+	}
+
+	if (!input[dev].num)
+	{
 		int assign_btn = ((input[dev].quirk == QUIRK_PDSP || input[dev].quirk == QUIRK_MSSP) && (ev->type == EV_REL || ev->type == EV_KEY));
 		if (!assign_btn && ev->type == EV_KEY && ev->value >= 1 && ev->code >= 256)
 		{
@@ -2418,7 +2431,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			}
 			else
 			{
-				map_joystick_show(input[dev].map, input[dev].mmap, input[dev].num);
+				map_joystick_show(input[dev].map, input[dev].mmap, input[dev].num, dev);
 			}
 		}
 	}

--- a/joymapping.cpp
+++ b/joymapping.cpp
@@ -247,12 +247,12 @@ static const char* get_std_name(uint16_t code, uint32_t *mmap)
 	return NULL;
 }
 
-void map_joystick_show(uint32_t *map, uint32_t *mmap, int num)
+void map_joystick_show(uint32_t *map, uint32_t *mmap, int num, int dev)
 {
 	static char mapinfo[1024];
 	read_buttons();
 
-	sprintf(mapinfo, "Map (P%d):", num);
+	sprintf(mapinfo, "Map (P%d,D%d):", num, dev);
 	if (!num) sprintf(mapinfo, " Map:");
 	char *list = mapinfo + strlen(mapinfo);
 

--- a/joymapping.h
+++ b/joymapping.h
@@ -8,7 +8,7 @@
 #include <inttypes.h>
 
 void map_joystick(uint32_t *map, uint32_t *mmap);
-void map_joystick_show(uint32_t *map, uint32_t *mmap, int num);
+void map_joystick_show(uint32_t *map, uint32_t *mmap, int num, int dev);
 int map_paddle_btn();
 
 #endif // JOYMAPPING_H


### PR DESCRIPTION
For MiSTercade at least, it can be desirable to disable dynamic
controller assignment, and instead set controllers to particular
devices.

For example, on a cabinet with left and right controls, even if the
second player mashes some buttons first, the operator may still want
the left controls to be for player 1, and the right controls for
player 2, as they would have been for the original game.

This patch allows setting up to four controllers to specific devices.

It adds the device index to the controller mapping dialog box.  The
user can first enable dynamic assignment, then experiment with which
controllers correspond to which devices.  For example, they can push a
button on controller P𝑛, note the device index, D𝑚, from the mapping
dialog, then set:

controller_𝑛_device=𝑚

in **mister.ini**.
