### PR TITLE
Improved handling of Win+F12

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -70,6 +70,7 @@ static char keyboard_leds = 0;
 static bool caps_status = 0;
 static bool num_status = 0;
 static bool scrl_status = 0;
+static bool winkey_pressed = 0;
 
 static uint16_t sdram_cfg = 0;
 
@@ -3395,6 +3396,19 @@ void user_io_poll()
 
 static void send_keycode(unsigned short key, int press)
 {
+	if (is_pcxt())
+	{
+		//WIN+... we override this hotkey in the core.
+		if (key == 125 || key == 126)
+		{
+			winkey_pressed = press;			
+			return;
+		}
+		if (winkey_pressed)
+		{
+			return;
+		}
+	}
 	if (is_minimig())
 	{
 		if (press > 1) return;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3806,10 +3806,14 @@ void user_io_kbd(uint16_t key, int press)
 				if (is_menu() && !video_fb_state()) printf("PS2 code(break)%s for core: %d(0x%X)\n", (code & EXT) ? "(ext)" : "", code & 255, code & 255);
 
 				if (key == KEY_MENU) key = KEY_F12;
-				if (osd_is_visible) menu_key_set(UPSTROKE | key);
-
-				//don't block depress so keys won't stick in core if pressed before OSD.
-				send_keycode(key, press);
+				if (osd_is_visible)
+				{
+					menu_key_set(UPSTROKE | key);					
+					if (key == 125 || key == 126 || key == 88) // We release only Win+F12
+						send_keycode(key, press);
+				}
+				else
+					send_keycode(key, press);
 			}
 			else
 			{


### PR DESCRIPTION
This key is not essential for PCXT and Tandy era software, however some games and demos may intercept it and switch screens or exit to MS/Dos... which makes taking a screenshot not possible, among other things.