### PR TITLE
(Feature) HLG HDR mode with hdr=3 (Request by Mathieulh)

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -22,7 +22,7 @@ hdmi_limited=0         ; 1 - use limited (16..235) color range over HDMI
 direct_video=0         ; 1 - enable core video timing over HDMI, use only with VGA converters.
 hdr=0                  ; 1 - enable HDR using the BT2020 color space (faux-HDR, use color controls to tweak).
                        ; 2 - enable HDR using the DCI P3 color space.
-                       ; 3 - enable HDR without color space conversion.
+                       ; 3 - enable HDR using HLG mode.
 fb_size=0              ; 0 - automatic, 1 - full size, 2 - 1/2 of resolution, 4 - 1/4 of resolution.
 fb_terminal=1          ; 1 - enabled (default), 0 - disabled
 osd_timeout=30         ; 5-3600 timeout (in seconds) for OSD to disappear in Menu core. 0 - never timeout.

--- a/video.cpp
+++ b/video.cpp
@@ -1481,38 +1481,43 @@ static void hdmi_config_init()
 
 static void hdmi_config_set_hdr()
 {
-	// 87:01:1a:74:02:00:c2:33:c4:86:4c:1d:b8:0b:d0:84:80 :3e:13:3d:42:40:e8:03:32:00:e8:03:90:01
+	// CTA-861-G: 6.9 Dynamic Range and Mastering InfoFrame
+	// Uses BT2020 RGB primaries and white point chromacity
+	// Max Lum: 1000cd/m2, Min Lum: 0cd/m2, MaxCLL: 1000cd/m2
+	// MaxFALL: 250cd/m2 (this value does not matter much -
+	// in essence it means that the display should expect -
+	// 25% of the image to be 1000cd/m2)
 	uint8_t hdr_data[] = {
 		0x87,
 		0x01,
 		0x1a,
-		0x74,
+		0x28,
 		0x02,
-		0x00,
-		0xc2,
-		0x33,
-		0xc4,
-		0x86,
-		0x4c,
-		0x1d,
-		0xb8,
-		0x0b,
-		0xd0,
-		0x84,
-		0x80,
-		0x3e,
+		0x48,
+		0x8a,
+		0x08,
+		0x39,
+		0x34,
+		0x21,
+		0xaa,
+		0x9b,
+		0x96,
+		0x19,
+		0xfc,
+		0x08,
 		0x13,
 		0x3d,
 		0x42,
 		0x40,
+		0x00,
 		0xe8,
 		0x03,
 		0x32,
 		0x00,
 		0xe8,
 		0x03,
-		0x90,
-		0x01
+		0xfa,
+		0x00
 	};
 
 	if (cfg.hdr == 0)

--- a/video.cpp
+++ b/video.cpp
@@ -1487,12 +1487,13 @@ static void hdmi_config_set_hdr()
 	// MaxFALL: 250cd/m2 (this value does not matter much -
 	// in essence it means that the display should expect -
 	// 25% of the image to be 1000cd/m2)
+	// If HDR == 3, use HLG instead
 	uint8_t hdr_data[] = {
 		0x87,
 		0x01,
 		0x1a,
-		0x28,
-		0x02,
+		(cfg.hdr == 3 ? uint8_t(0x27) : uint8_t(0x28)),
+		(cfg.hdr == 3 ? uint8_t(0x03) : uint8_t(0x02)),
 		0x48,
 		0x8a,
 		0x08,


### PR DESCRIPTION
Hello again, and thank you for merging the previous metadata change.
There is one more change I would like to add, it concerns `hdr=3`.

It is a small change, but when `hdr` is set to 3, it will now use HLG HDR mode.
HLG is a mode designed to be backwards compatible with SDR content.
Mathieulh on Discord mentioned it and tested it out on his own display, it was a big improvement over the other modes.

Since HLG requires no color space conversion, it made sense to use the existing `hdr=3` option. I have amended the INI to make mention of it.

---

Thanks!