### PR TITLE
Re-ordering of HDR options to make HLG default

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -20,9 +20,8 @@ menu_pal=0             ; 1 - PAL mode for menu core
 hdmi_limited=0         ; 1 - use limited (16..235) color range over HDMI
                        ; 2 - use limited (16..255) color range over HDMI, for VGA converters.
 direct_video=0         ; 1 - enable core video timing over HDMI, use only with VGA converters.
-hdr=0                  ; 1 - enable HDR using the BT2020 color space (faux-HDR, use color controls to tweak).
-                       ; 2 - enable HDR using the DCI P3 color space.
-                       ; 3 - enable HDR using HLG mode.
+hdr=0                  ; 1 - enable HDR using HLG (recommended for most users)
+                       ; 2 - enable HDR using the DCI P3 color space (use color controls to tweak, suggestion: set saturation to 80).
 fb_size=0              ; 0 - automatic, 1 - full size, 2 - 1/2 of resolution, 4 - 1/4 of resolution.
 fb_terminal=1          ; 1 - enabled (default), 0 - disabled
 osd_timeout=30         ; 5-3600 timeout (in seconds) for OSD to disappear in Menu core. 0 - never timeout.
@@ -120,16 +119,14 @@ refresh_max=0
 ;video_mode_ntsc=0
 ;video_mode_pal=7
 
-; Provided below are parameters for HDMI color controls.
-; The defaults that are set below will result in an unaltered image.
-; Brightness, contrast and saturation all can be set to 0 - 100.
-; Hue can be set to 0 - 360, observing the HSL color representation.
-; Each of 6 (mandatory) values in gain/offset can be set to -2 - 2.
-; These 6 values represent gain and offset in order: Rg,Ro,Gg,Go,Bg,Bo
-; Example 1: Inverted colors, hue shifted 180 degrees:
-; video_hue= 180
+; Provided below are options for modulating color on the HDMI output.
+; Brightness, contrast and saturation can be set to any value between 0 and 100.
+; Hue can be set to 0 - 360, observing the HSL color model.
+; Each component of video_gain_offset can be set to any value between -2 and 2.
+; The order is "gain,offset" repeated three times to cover RGB.
+; Example 1, Inverted colors:
 ; video_gain_offset= -1, 1, -1, 1, -1, 1
-; Example 2: Slightly desaturated, warm display
+; Example 2, Slightly desaturated, warm display:
 ; video_saturation= 80
 ; video_gain_offset= 1.5, -0.1, 1.3, -0.15, 0.9, 0.05
 video_brightness=50

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -108,12 +108,12 @@ static const ini_var_t ini_vars[] =
 	{ "PLAYER_3_CONTROLLER", (void*)(&(cfg.player_controller[2])), STRING, 0, sizeof(cfg.player_controller[2]) - 1 },
 	{ "PLAYER_4_CONTROLLER", (void*)(&(cfg.player_controller[3])), STRING, 0, sizeof(cfg.player_controller[3]) - 1 },
 	{ "DISABLE_AUTOFIRE", (void *)(&(cfg.disable_autofire)), UINT8, 0, 1},
-	{ "VIDEO_BRIGHTNESS", (void *)(&(cfg.video_brightness)), UINT16, 0, 100},
-	{ "VIDEO_CONTRAST", (void *)(&(cfg.video_contrast)), UINT16, 0, 100},
-	{ "VIDEO_SATURATION", (void *)(&(cfg.video_saturation)), UINT16, 0, 100},
+	{ "VIDEO_BRIGHTNESS", (void *)(&(cfg.video_brightness)), UINT8, 0, 100},
+	{ "VIDEO_CONTRAST", (void *)(&(cfg.video_contrast)), UINT8, 0, 100},
+	{ "VIDEO_SATURATION", (void *)(&(cfg.video_saturation)), UINT8, 0, 100},
 	{ "VIDEO_HUE", (void *)(&(cfg.video_hue)), UINT16, 0, 360},
 	{ "VIDEO_GAIN_OFFSET", (void *)(&(cfg.video_gain_offset)), STRING, 0, sizeof(cfg.video_gain_offset)},
-	{ "HDR", (void*)(&cfg.hdr), UINT8, 0, 3 },
+	{ "HDR", (void*)(&cfg.hdr), UINT8, 0, 2 },
 };
 
 static const int nvars = (int)(sizeof(ini_vars) / sizeof(ini_var_t));

--- a/cfg.h
+++ b/cfg.h
@@ -80,9 +80,9 @@ typedef struct {
 	uint8_t vrr_vesa_framerate;
 	uint16_t video_off;
 	uint8_t disable_autofire;
-	uint16_t video_brightness;
-	uint16_t video_contrast;
-	uint16_t video_saturation;
+	uint8_t video_brightness;
+	uint8_t video_contrast;
+	uint8_t video_saturation;
 	uint16_t video_hue;
 	char video_gain_offset[256];
 	uint8_t hdr;

--- a/video.cpp
+++ b/video.cpp
@@ -1095,13 +1095,6 @@ static void hdmi_config_set_csc()
 		0.0f, 0.0f, 0.0f, 1.0f
 	};
 
-	float hdr_bt2020_coeffs[] = {
-		0.6274f, 0.3293f, 0.0433f, 0.0f,
-		0.0691f, 0.9195f, 0.0114f, 0.0f,
-		0.0164f, 0.0880f, 0.8956f, 0.0f,
-		0.0f, 0.0f, 0.0f, 1.0f
-	};
-
 	float hdr_dcip3_coeffs[] = {
 		0.8225f, 0.1774f, 0.0000f, 0.0f,
 		0.0332f, 0.9669f, 0.0000f, 0.0f,
@@ -1120,18 +1113,20 @@ static void hdmi_config_set_csc()
 	mat4x4 coeffs = hdmi_full_coeffs;
 
 	if (hdr == 1)
-		coeffs = hdr_bt2020_coeffs;
+		coeffs = hdmi_full_coeffs;
 	else if (hdr == 2)
 		coeffs = hdr_dcip3_coeffs;
-	else if (ypbpr)
-		coeffs = ypbpr_coeffs;
-	else if (hdmi_limited_1)
-		coeffs = hdmi_limited_1_coeffs;
-	else if (hdmi_limited_2)
-		coeffs = hdmi_limited_2_coeffs;
 	else
-		coeffs = hdmi_full_coeffs;
-
+	{
+		if (ypbpr)
+			coeffs = ypbpr_coeffs;
+		else if (hdmi_limited_1)
+			coeffs = hdmi_limited_1_coeffs;
+		else if (hdmi_limited_2)
+			coeffs = hdmi_limited_2_coeffs;
+		else
+			coeffs = hdmi_full_coeffs;
+	}
 	mat4x4 csc(coeffs);
 
 	// apply color controls
@@ -1487,13 +1482,13 @@ static void hdmi_config_set_hdr()
 	// MaxFALL: 250cd/m2 (this value does not matter much -
 	// in essence it means that the display should expect -
 	// 25% of the image to be 1000cd/m2)
-	// If HDR == 3, use HLG instead
+	// If HDR == 1, use HLG
 	uint8_t hdr_data[] = {
 		0x87,
 		0x01,
 		0x1a,
-		(cfg.hdr == 3 ? uint8_t(0x27) : uint8_t(0x28)),
-		(cfg.hdr == 3 ? uint8_t(0x03) : uint8_t(0x02)),
+		(cfg.hdr == 1 ? uint8_t(0x27) : uint8_t(0x28)),
+		(cfg.hdr == 1 ? uint8_t(0x03) : uint8_t(0x02)),
 		0x48,
 		0x8a,
 		0x08,


### PR DESCRIPTION
Hey all,

This is a small change that aims to simplify the HDR option somewhat.
I have removed BT2020 HDR10 mode and changed HLG to be the default (for `hdr=1`).

I have also made some small changes to the config (uint16 -> uint8 for some options), and I have tweaked the comments in MiSTer.ini to read a bit easier. For the HDR option, I have added explicit recommendation to go with HLG mode.

**Functionality impacted**
HDR with BT2020 has been removed, people who were using it (by setting `hdr=1`) will be on HLG after this update. For those that cannot use HLG due to incompatibility, DCI P3 mode has been retained (`hdr=2`).

**Further considerations**
There has been some talk of getting rid of all HDR options beyond HLG, and getting rid of color controls. I think there is value in keeping these around, but we should monitor the community and see whether they have true value or just end up causing confusion. To that end, I decided the "default" HDR mode should be HLG - in case we decide to remove `hdr=2` and color controls.

It should be safe to make `hdr=1` default in the .ini, since displays that do not support it will display SDR as usual. I have not made this change as I think we should await feedback from users.

---

Thank you again for your hard work, and I wish you a good 2023!