### PR TITLE
Default preset and reset option.

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -294,3 +294,7 @@ vrr_vesa_framerate=0
 
 ; disable autofire if for some reason it's not required and accidentally triggered
 disable_autofire=0
+
+; Specify a default video processing preset that will be applied to cores.
+; Path is relative to the presets/ directory and can optionally include the .ini extension
+;preset_default=General Hardware/Console - 3rdGen

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -90,6 +90,7 @@ static const ini_var_t ini_vars[] =
 	{ "VFILTER_SCANLINES_DEFAULT", (void*)(&(cfg.vfilter_scanlines_default)), STRING, 0, sizeof(cfg.vfilter_scanlines_default) - 1 },
 	{ "SHMASK_DEFAULT", (void*)(&(cfg.shmask_default)), STRING, 0, sizeof(cfg.shmask_default) - 1 },
 	{ "SHMASK_MODE_DEFAULT", (void*)(&(cfg.shmask_mode_default)), UINT8, 0, 255 },
+	{ "PRESET_DEFAULT", (void*)(&(cfg.preset_default)), STRING, 0, sizeof(cfg.preset_default) - 1 },
 	{ "LOG_FILE_ENTRY", (void*)(&(cfg.log_file_entry)), UINT8, 0, 1 },
 	{ "BT_AUTO_DISCONNECT", (void*)(&(cfg.bt_auto_disconnect)), UINT32, 0, 180 },
 	{ "BT_RESET_BEFORE_PAIR", (void*)(&(cfg.bt_reset_before_pair)), UINT8, 0, 1 },

--- a/cfg.h
+++ b/cfg.h
@@ -69,6 +69,7 @@ typedef struct {
 	char vfilter_vertical_default[1023];
 	char vfilter_scanlines_default[1023];
 	char shmask_default[1023];
+	char preset_default[1023];
 	char player_controller[4][1024];
 	uint8_t rumble;
 	uint8_t wheel_force;

--- a/menu.cpp
+++ b/menu.cpp
@@ -2558,7 +2558,7 @@ void HandleUI(void)
 
 			case 15:
 				FileCreatePath(DOCS_DIR);
-				snprintf(Selected_tmp, sizeof(Selected_tmp), DOCS_DIR"/%s",user_io_get_core_name());
+				snprintf(Selected_tmp, sizeof(Selected_tmp), DOCS_DIR "/%s",user_io_get_core_name());
 				FileCreatePath(Selected_tmp);
 				SelectFile(Selected_tmp, "PDFTXTMD ",  SCANO_DIR | SCANO_TXT  , MENU_DOC_FILE_SELECTED, MENU_COMMON1);
 				break;
@@ -2634,7 +2634,7 @@ void HandleUI(void)
 
 	case MENU_VIDEOPROC1:
 		helptext_idx = 0;
-		menumask = 0xFFF;
+		menumask = 0x1FFF;
 		OsdSetTitle("Video Processing");
 		menustate = MENU_VIDEOPROC2;
 		parentstate = MENU_VIDEOPROC1;
@@ -2698,7 +2698,10 @@ void HandleUI(void)
 			MenuWrite(n++, s, menusub == 10, (video_get_shadow_mask_mode() <= 0) || !S_ISDIR(getFileType(SMASK_DIR)));
 
 			MenuWrite(n++);
-			MenuWrite(n++, STD_BACK, menusub == 11);
+			MenuWrite(n++, " Reset to Defaults", menusub == 11);
+
+			MenuWrite(n++);
+			MenuWrite(n++, STD_BACK, menusub == 12);
 
 			if (!adjvisible) break;
 			firstmenu += adjvisible;
@@ -2835,6 +2838,11 @@ void HandleUI(void)
 				break;
 
 			case 11:
+				video_cfg_reset();
+				menustate = parentstate;
+				break;
+
+			case 12:
 				menusub = 5;
 				menustate = MENU_COMMON1;
 				break;
@@ -3412,7 +3420,7 @@ void HandleUI(void)
 	case MENU_PRESET_FILE_SELECTED:
 		memcpy(Selected_F[15], selPath, sizeof(Selected_F[15]));
 		recent_update(SelectedDir, selPath, SelectedLabel, 15);
-		video_loadPreset(selPath);
+		video_loadPreset(selPath, true);
 		menustate = MENU_VIDEOPROC1;
 		break;
 

--- a/video.h
+++ b/video.h
@@ -41,7 +41,9 @@ int   video_get_shadow_mask_mode();
 void  video_set_shadow_mask_mode(int n);
 char* video_get_shadow_mask(int only_name = 1);
 void  video_set_shadow_mask(const char *name);
-void  video_loadPreset(char *name);
+void  video_loadPreset(char *name, bool save);
+
+void video_cfg_reset();
 
 void  video_mode_adjust();
 


### PR DESCRIPTION
`preset_default` option added to ini. Filename is relative to the presets/ path.

"Reset to defaults" option added to video processing menu which will delete the config files and reload the default configuration.

**Code Changes**
Split up the various `video_set_*` functions into apply and save functions. "apply" modifies the settings and updates the fpga, "save" writes out the config file. The `video_set_*` functions do both, the preset load function will only call the save functions if the `save` option is set, this allows the default preset loading to load up and apply the default data without saving it out to the config files.

`video_cfg_init` was add to unify the gamma, scaler and shadow mask setup and ensure that they are all initialized before the preset is loaded.