### PR TITLE
(Feature+Bugfix) Add HDR metadata tweaking options + fix HDR HDMI limited

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -137,6 +137,17 @@ video_saturation=100
 video_hue=0
 video_gain_offset=1,0,1,0,1,0
 
+; These controls have been provided so you can tweak the HDR metadata values regarding
+; peak brightness and average brightness. The defaults are 1000/250 for peak and average
+; respectively.
+; Some displays will completely ignore the values in the HDR packet, some will make use of them.
+; The recommendation is to set hdr_max_nits to your display's peak luminance, while
+; setting hdr_avg_nits to at least hdr_max_nits/4.
+; Please note that setting a peak brightness far above your display's capability may result
+; in clipping in bright parts of the image.
+hdr_max_nits=1000
+hdr_avg_nits=250
+
 ; 1-10 (seconds) to display controller's button map upon first time key press
 ; 0 - disable
 controller_info=6

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -115,6 +115,8 @@ static const ini_var_t ini_vars[] =
 	{ "VIDEO_HUE", (void *)(&(cfg.video_hue)), UINT16, 0, 360},
 	{ "VIDEO_GAIN_OFFSET", (void *)(&(cfg.video_gain_offset)), STRING, 0, sizeof(cfg.video_gain_offset)},
 	{ "HDR", (void*)(&cfg.hdr), UINT8, 0, 2 },
+	{ "HDR_MAX_NITS", (void*)(&(cfg.hdr_max_nits)), UINT16, 100, 10000},
+	{ "HDR_AVG_NITS", (void*)(&(cfg.hdr_avg_nits)), UINT16, 100, 10000},
 	{ "VGA_MODE", (void*)(&(cfg.vga_mode)), STRING, 0, sizeof(cfg.vga_mode) - 1 },
 	{ "NTSC_MODE", (void *)(&(cfg.ntsc_mode)), UINT8, 0, 2},
 };
@@ -450,6 +452,8 @@ void cfg_parse()
 	cfg.wheel_force = 50;
 	cfg.dvi_mode = 2;
 	cfg.hdr = 0;
+	cfg.hdr_max_nits = 1000;
+	cfg.hdr_avg_nits = 250;
 	cfg.video_brightness = 50;
 	cfg.video_contrast = 50;
 	cfg.video_saturation = 100;

--- a/cfg.h
+++ b/cfg.h
@@ -86,6 +86,8 @@ typedef struct {
 	uint16_t video_hue;
 	char video_gain_offset[256];
 	uint8_t hdr;
+	uint16_t hdr_max_nits;
+	uint16_t hdr_avg_nits;
 	char vga_mode[16];
 	char vga_mode_int;
 	char ntsc_mode;


### PR DESCRIPTION
Hello Sorg,

This is another HDR-related PR. It's a small one, the feature was frequently requested in Discord and on the forum, and the bug I fixed was reported by a forum user as well.

Two options have been added to `MiSTer.ini`:
* `hdr_max_nits`: Maximum brightness supported by display (MaxCLL).
* `hdr_avg_nits`: Average brightness (MaxFALL).

These values are reported to the display via metadata. Because this meant the metadata is no longer static, I have added checksum calculation as required.

Not all displays listen to these values. For example, my LG C8 TV completely ignores it. However, some other TVs and HDR monitors do make use of these values. It is unpredictable, but this gives users the ability to try and optimize for their display.

I have also fixed a bug related to HDMI limited in HDR-mode. The YPbPr bugfix broke HDMI limited color space conversion when using HDR - I have corrected the code and simplified the base CSC selection for clarity.

**Impact**
Default values for the new ini options are set to what the metadata had already (1000 and 250 respectively), so users will not need to take any action if they are happy with their setup.
HDMI limited users will no longer have problems with clipping colors.

For the conceivable future, I consider this the final change in HDR logic. It is pretty much feature complete at this point - not much more can be done with our hardware.

---

Thank you for your hard work!