### PR TITLE
Support to use mouse wheel as spinner.

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -221,7 +221,7 @@ shared_folder=
 ; Lower than 100 makes spinner faster. Negative value gives opposite direction.
 ;spinner_throttle=-50
 
-; 0 - X axis, 1 - Y axis.
+; 0 - X axis, 1 - Y axis, 2 - wheel.
 ;spinner_axis=1
 
 ; Default filters for video scaler. Paths must be relative to "Filters" folder without leading slash.

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -82,7 +82,7 @@ static const ini_var_t ini_vars[] =
 	{ "CUSTOM_ASPECT_RATIO_2", (void*)(&(cfg.custom_aspect_ratio[1])), STRING, 0, sizeof(cfg.custom_aspect_ratio[1]) - 1 },
 	{ "SPINNER_VID", (void*)(&(cfg.spinner_vid)), HEX16, 0, 0xFFFF },
 	{ "SPINNER_PID", (void*)(&(cfg.spinner_pid)), HEX16, 0, 0xFFFF },
-	{ "SPINNER_AXIS", (void*)(&(cfg.spinner_axis)), UINT8, 0, 1 },
+	{ "SPINNER_AXIS", (void*)(&(cfg.spinner_axis)), UINT8, 0, 2 },
 	{ "SPINNER_THROTTLE", (void*)(&(cfg.spinner_throttle)), INT32, -10000, 10000 },
 	{ "AFILTER_DEFAULT", (void*)(&(cfg.afilter_default)), STRING, 0, sizeof(cfg.afilter_default) - 1 },
 	{ "VFILTER_DEFAULT", (void*)(&(cfg.vfilter_default)), STRING, 0, sizeof(cfg.vfilter_default) - 1 },

--- a/input.cpp
+++ b/input.cpp
@@ -5121,9 +5121,10 @@ int input_test(int getchar)
 								continue;
 							}
 
-							int xval, yval;
+							int xval, yval, zval;
 							xval = ((data[0] & 0x10) ? -256 : 0) | data[1];
 							yval = ((data[0] & 0x20) ? -256 : 0) | data[2];
+							zval = ((data[3] & 0x80) ? -256 : 0) | data[3];
 
 							input_absinfo absinfo = {};
 							absinfo.maximum = 255;
@@ -5131,7 +5132,14 @@ int input_test(int getchar)
 
 							if (input[dev].quirk == QUIRK_MSSP)
 							{
-								int val = cfg.spinner_axis ? yval : xval;
+								int val;
+								if(cfg.spinner_axis == 0)
+									val = xval;
+								else if(cfg.spinner_axis == 1)
+									val = yval;
+								else
+									val = zval;
+
 								int btn = (data[0] & 7) ? 1 : 0;
 								if (input[i].misc_flags != btn)
 								{


### PR DESCRIPTION
Mouse wheel as spinner is useful for some spinner devices that outputs as wheel.
User should also fine tune the value for `spinner_throttle` when using.