### PR TITLE
Update wiki link to direct to new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repo serves as the home for the MiSTer Main binaries and the Wiki.
 
 For the purposes of getting google to crawl the wiki, here's a link to the (not for humans) [crawlable wiki](https://github-wiki-see.page/m/MiSTer-devel/Main_MiSTer/wiki)
 
-If you're a human looking for the wiki, that's [here](https://github.com/MiSTer-devel/Main_MiSTer/wiki)
+If you're a human looking for the wiki, that's [here](https://github.com/MiSTer-devel/Wiki_MiSTer/wiki)


### PR DESCRIPTION
The wiki link should point directly to the home page of the new wiki to avoid any confusion for newcomers. Otherwise, it looks like the wiki is empty for someone unfamiliar with github and wikis.

Implements #757 