### PR TITLE
Add an extra /tmp file to track file-selector visibility

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -1273,6 +1273,15 @@ void HandleUI(void)
 			       menu, select, up, down,
 			       left, right, plus, minus);
 
+	// Ensure we clear out the file-selector-visible file on select or cancel
+	if (cfg.log_file_entry)
+	{
+		if (menustate == fs_MenuSelect)
+			MakeFile("/tmp/FILESELECT", "selected");
+		else if (menustate == fs_MenuCancel)
+			MakeFile("/tmp/FILESELECT", "cancelled");
+	}
+
 	switch (menustate)
 	{
 	case MENU_NONE1:
@@ -4699,12 +4708,9 @@ void HandleUI(void)
 		if (cfg.log_file_entry && flist_nDirEntries())
 		{
 			//Write out paths infos for external integration
-			FILE* filePtr = fopen("/tmp/CURRENTPATH", "w");
-			FILE* pathPtr = fopen("/tmp/FULLPATH", "w");
-			fprintf(filePtr, "%s", flist_SelectedItem()->altname);
-			fprintf(pathPtr, "%s", selPath);
-			fclose(filePtr);
-			fclose(pathPtr);
+			MakeFile("/tmp/CURRENTPATH", flist_SelectedItem()->altname);
+			MakeFile("/tmp/FULLPATH", selPath);
+			MakeFile("/tmp/FILESELECT", "active");
 		}
 		break;
 

--- a/user_io.h
+++ b/user_io.h
@@ -239,6 +239,7 @@ uint16_t sdram_sz(int sz = -1);
 int user_io_is_dualsdr();
 uint16_t altcfg(int alt = -1);
 
+void MakeFile(const char * filename, const char * data);
 int GetUARTMode();
 void SetUARTMode(int mode);
 int GetMidiLinkMode();


### PR DESCRIPTION
External integrations already have access to the CURRENTPATH, FULLPATH and STARTPATH files in order to see which file is currently active in the file selector and which core was started.

Unforuntately there is no way for the integration to see when the file selector closes and whether the file was selected or the selector was cancelled. In my use-case, I have an external display showing game data and marquee images. When the file selector is active, this display shows data about the current file selection. When a game is running it shows info about that game. Without a way to know if the selection menu is visible, the transition from displaying the highlighted selection to displaying the active game is impossible when the file selector has just been cancelled. I also want to be able to use the extra data about the game that has been picked within the console menu. That data is available in CURRENTPATH, but if the menu is cancelled, we don't know if it's valid to use or not.

This new file just tracks the status of the file select menu. When the file selector menu is onscreen it contains "active". When cancelled it contains "cancelled".
If the file was actually chosen it contains "selected".

That set of extra information is enough to know which game is currently running and which is just under selection regardless of whether the menu was cancelled or actually selected.

Note: there are almost certainly nicer ways to expose all this information,  but I'm attempting to keep any existing integrations that use these files working without requiring any changes.