### PR TITLE
Fix Freezing during intro on Tanjou Debut ( # 176 )

### DIFF
--- a/support/pcecd/pcecd.cpp
+++ b/support/pcecd/pcecd.cpp
@@ -38,7 +38,7 @@ void pcecd_poll()
 			pcecdd.SendStatus(pcecdd.GetStatus());
 			pcecdd.has_status = 0;
 		}
-		else if (pcecdd.data_req) {
+		else if (pcecdd.data_req && !pcecdd.latency) {
 
 			pcecdd.SendDataRequest();
 			pcecdd.data_req = false;


### PR DESCRIPTION
Treat SendDataRequest same as SendStatus during Latency wait periods. It was freezing only when "Normal Seek" was in place; this seems to be a result of sending data requests during wait periods, when statuses were not sent.