### PR TITLE
megacdd: cd audio fixes

### DIFF
--- a/support/megacd/megacd.h
+++ b/support/megacd/megacd.h
@@ -37,6 +37,7 @@
 
 #define MCD_DATA_IO_INDEX 2
 #define MCD_SUB_IO_INDEX 3
+#define MCD_CDDA_IO_INDEX 4
 
 #include "../../cd.h"
 #include <libchdr/chd.h>
@@ -99,6 +100,7 @@ void mcd_poll();
 void mcd_set_image(int num, const char *filename);
 void mcd_reset();
 int mcd_send_data(uint8_t* buf, int len, uint8_t index);
+int mcd_can_send_data(uint8_t type);
 void mcd_fill_blanksave(uint8_t *buffer, uint32_t lba);
 
 #endif

--- a/support/megacd/megacdd.cpp
+++ b/support/megacd/megacdd.cpp
@@ -459,6 +459,7 @@ void cdd_t::Update() {
 			else
 			{
 				this->lba = this->toc.end;
+				this->chd_audio_read_lba = this->lba;
 				this->status = CD_STAT_END;
 				this->isData = 0x01;
 				return;
@@ -476,6 +477,8 @@ void cdd_t::Update() {
 				this->lba = 0;
 			}
 		}
+
+		this->chd_audio_read_lba = this->lba;
 
 		this->isData = this->toc.tracks[this->index].type;
 
@@ -613,6 +616,7 @@ void cdd_t::CommandExec() {
 			stat[8] = 0;
 
 			//printf("\x1b[32mMCD: Command TOC 2, index = %i, command = %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X, status = %02X%08X, frame = %u\n\x1b[0m", this->index, comm[9], comm[8], comm[7], comm[6], comm[5], comm[4], comm[3], comm[2], comm[1], comm[0], (uint32_t)(GetStatus() >> 32), (uint32_t)GetStatus(), frame);
+
 		}
 			break;
 
@@ -1023,18 +1027,20 @@ int cdd_t::SectorSend(uint8_t* header)
 {
 	uint8_t buf[2352 + 2352];
 	int len = 2352;
+	uint8_t index = MCD_DATA_IO_INDEX;
 
 	if (header) {
 		memcpy(buf + 12, header, 4);
 		ReadData(buf + 16);
 	}
 	else {
+		index = MCD_CDDA_IO_INDEX;
 		len = ReadCDDA(buf);
 	}
 
 	SubcodeSend();
 	if (SendData)
-		return SendData(buf, len, MCD_DATA_IO_INDEX);
+		return SendData(buf, len, index);
 
 	return 0;
 }

--- a/support/neogeo/neogeocd.cpp
+++ b/support/neogeo/neogeocd.cpp
@@ -22,8 +22,6 @@ static uint8_t cd_speed = 0;
 
 #define CRC_START 5
 
-#define NEOCD_AUDIO_IO_INDEX 4
-
 #define NEOCD_GET_CMD        0
 #define NEOCD_GET_SEND_DATA  1
 
@@ -142,17 +140,8 @@ void neocd_reset() {
 }
 
 int neocd_send_data(uint8_t* buf, int len, uint8_t index) {
-	uint8_t idx = index;
-	if (idx == MCD_DATA_IO_INDEX && !cdd.isData)
-	{
-		// The MegaCD core sends the isData bit through the status to differentiate between data/audio.
-		// This requires that more commands come in after the initial play command.
-		// NeoGeo does not always send another command so use another index for audio.
-		idx = NEOCD_AUDIO_IO_INDEX;
-	}
-
 	// set index byte
-	user_io_set_index(idx);
+	user_io_set_index(index);
 
 	user_io_set_download(1);
 	user_io_file_tx_data(buf, len);


### PR DESCRIPTION
- Send audio sectors faster so buffer stays filled
- Ask FPGA if it is ready to receive a sector
- Fix SCAN with CHD files
- Fix missing start of audio by sending with separate index