### PR TITLE
OSD Locking

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -319,3 +319,14 @@ disable_autofire=0
 ; You may use several controller_unique_mapping instances to assign several VID:PID.
 ;controller_unique_mapping=0x23418037 ; example for Arduino Micro
 controller_unique_mapping=0
+
+
+; Protect access to the OSD when a core is running
+; When attempting to access the OSD players will be prompted for an unlock code.
+; U = Up, D = Down, L = Left, R = Right, A = Select, B = Back
+; Setting osd_lock to DUUUD would require entering the sequence Down, Up, Up, Up, Down
+;osd_lock=DUUUD
+
+; If osd_lock is enabled, allow the OSD to be opened without entering the unlock
+; code if less than osd_lock_time seconds have passed since the OSD was closed.
+osd_lock_time=5

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -122,6 +122,8 @@ static const ini_var_t ini_vars[] =
 	{ "VGA_MODE", (void*)(&(cfg.vga_mode)), STRING, 0, sizeof(cfg.vga_mode) - 1 },
 	{ "NTSC_MODE", (void *)(&(cfg.ntsc_mode)), UINT8, 0, 2},
 	{ "CONTROLLER_UNIQUE_MAPPING", (void *)(cfg.controller_unique_mapping), UINT32ARR, 0, 0xFFFFFFFF },
+	{ "OSD_LOCK", (void*)(&(cfg.osd_lock)), STRING, 0, sizeof(cfg.osd_lock) - 1 },
+	{ "OSD_LOCK_TIME", (void*)(&(cfg.osd_lock_time)), UINT16, 0, 60},
 };
 
 static const int nvars = (int)(sizeof(ini_vars) / sizeof(ini_var_t));

--- a/cfg.h
+++ b/cfg.h
@@ -92,6 +92,8 @@ typedef struct {
 	char vga_mode_int;
 	char ntsc_mode;
 	uint32_t controller_unique_mapping[256];
+	char osd_lock[25];
+	uint16_t osd_lock_time;
 } cfg_t;
 
 extern cfg_t cfg;


### PR DESCRIPTION
Add osd_lock and osd_lock_time config options
When osd_lock is set it specifies a sequence of button pressed that must be pressed in order to gain access to the OSD while running a core. osd_lock_time is the time (in seconds) before you will be prompted again for the unlock code after you have closes the OSD.