### PR TITLE
Write original core name to tmp file RBFNAME

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1055,6 +1055,7 @@ void SetUARTMode(int mode)
 	DisableIO();
 
 	MakeFile("/tmp/CORENAME", user_io_get_core_name());
+    MakeFile("/tmp/RBFNAME", user_io_get_confstr(0));
 
 	char data[20];
 	sprintf(data, "%d", baud);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1055,7 +1055,7 @@ void SetUARTMode(int mode)
 	DisableIO();
 
 	MakeFile("/tmp/CORENAME", user_io_get_core_name());
-    MakeFile("/tmp/RBFNAME", user_io_get_confstr(0));
+    MakeFile("/tmp/RBFNAME", user_io_get_core_name(1));
 
 	char data[20];
 	sprintf(data, "%d", baud);


### PR DESCRIPTION
After writing `/tmp/CORENAME`, also write the first CONF_STR field to `/tmp/RBFNAME`. This would allow detecting the actual loaded core when it has a setname active in a .mgl or .mra file.

---

As discussed, this change does what I wanted, but I'm not sure it's really a good solution to my overall problem. Some immediate things come to mind:

- Yet another file to watch and keep in sync from the script side
- RBFNAME makes sense to me for my intention, but it conflicts with the existing get_rbf_name function's result
- I'm not familiar enough with CONF_STR to know if this is actually reliable or necessarily safe to call from SetUARTMode

The real problem is that it's difficult (impossible?) to reliably read the current state of what core and game is active. It seems the tools to do this all exist in main, but they're not accessible besides reading memory or require .ini changes. I'd rather a more robust solution that:

- Requires no .ini changes and can be assumed to be active on a fresh MiSTer
- Does not write to SD
- Can be monitored for changes rather than polling (like CORENAME already)
- Shows info such as: setname, original name, full rbf path, rbf build date
- Shows the full path of currently loaded files (or at least the last loaded one, equivalent to monitoring the recents folder)
- Information is written earlier than SetUARTMode is run, currently CORENAME is updated a few seconds after launch 

I have been able to make do with a combination of CORENAME and recents and log_file_entry, but this solution is very complex and needs to make a lot of assumptions, and it's still missing information I think is important. It would be so much easier if main could just spit this stuff out for you instead.

