### PR TITLE
Fix handling of index0/pregaps for ide cdrom.

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -418,6 +418,11 @@ void ide_img_set(uint32_t drvnum, fileTYPE *f, int cd, int sectors, int heads, i
 	ide_inst[port].base = port ? IDE1_BASE : IDE0_BASE;
 	ide_inst[port].drive[drv].drvnum = drvnum;
 
+	if (drive->f && drive->f->opened())
+	{
+		FileClose(drive->f);
+	}
+
 	drive->f = f;
 
 	drive->cylinders = 0;

--- a/ide.h
+++ b/ide.h
@@ -101,6 +101,9 @@ struct drive_t
 	float    volume_l;
 	float    volume_r;
 	bool     mcr_flag;
+	uint8_t	 atapi_sense_key;
+	uint8_t  atapi_asc_code;
+	uint8_t  atapi_ascq_code;
 
 	chd_file *chd_f;
 	int      chd_hunknum;

--- a/ide_cdrom.h
+++ b/ide_cdrom.h
@@ -3,7 +3,7 @@
 
 int cdrom_handle_cmd(ide_config *ide);
 void cdrom_handle_pkt(ide_config *ide);
-void cdrom_reply(ide_config *ide, uint8_t error, bool unit_attention = true);
+void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code = 0, uint8_t ascq_code = 0, bool unit_attention = true);
 void cdrom_read(ide_config *ide);
 void cdrom_mode_select(ide_config *ide);
 void ide_cdda_send_sector();


### PR DESCRIPTION
Return CHECK CONDITION status for most commands when required, and reply with asc/ascq sense codes. Should improve compatibility with various cdda players on amiga/pc