### PR TITLE
Fix: when extensions are less than 3 characters send NUL

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2510,7 +2510,8 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 	int len = strlen(f.name);
 	char *p = strrchr(f.name, '.');
 	if (p == 0) {
-	    p = f.name + len - 4;
+            // In case a '.' is not found, send all `NUL` characters.
+	    p = f.name + len;
 	}
 	user_io_file_info(p);
 

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1961,8 +1961,12 @@ void user_io_file_info(const char *ext)
 {
 	EnableFpga();
 	spi8(FIO_FILE_INFO);
-	spi_w(toupper(ext[0]) << 8 | toupper(ext[1]));
-	spi_w(toupper(ext[2]) << 8 | toupper(ext[3]));
+	char c1 = *ext ? toupper(*ext++) : 0;
+	char c2 = *ext ? toupper(*ext++) : 0;
+	char c3 = *ext ? toupper(*ext++) : 0;
+	char c4 = *ext ? toupper(*ext++) : 0;
+	spi_w(c1 << 8 | c2);
+	spi_w(c3 << 8 | c4);
 	DisableFpga();
 }
 
@@ -2504,7 +2508,10 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 	user_io_set_index(index);
 
 	int len = strlen(f.name);
-	char *p = f.name + len - 4;
+	char *p = strrchr(f.name, '.');
+	if (p == 0) {
+	    p = f.name + len - 4;
+	}
 	user_io_file_info(p);
 
 	// prepare transmission of new file


### PR DESCRIPTION
Currently if the extension is less than 3 characters the last characters of the filename will be sent to the FPGA. These are not consistent and would not help the core establish what kind of file it is.

There are few ROMs with less than 3 characters, but they do exist (e.g. .ws for WonderSwan). It is unclear reading the code how those are handled outside of this specific function.

## Security considerations
This does not fix a buffer overflow as the code to get there would fail if the complete filename would be less than 4 characters (e.g. the root filesystem is read only).

## Testing
This has been tested with the happy path; the code at least works with current files.