### PR TITLE
Fix bug in dead zone code affecting DS3/DS4

### DIFF
--- a/MiSTer.sln
+++ b/MiSTer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33801.468
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MiSTer", "MiSTer.vcxproj", "{C1D6BEA2-1469-4FBC-8A27-A82BDE9041AC}"
 EndProject
@@ -15,5 +15,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2089D6CB-559A-43F3-B74D-478279388F62}
 	EndGlobalSection
 EndGlobal

--- a/MiSTer.vcxproj
+++ b/MiSTer.vcxproj
@@ -9,12 +9,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C1D6BEA2-1469-4FBC-8A27-A82BDE9041AC}</ProjectGuid>
     <Keyword>MakeFileProj</Keyword>
+    <!--<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>-->
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -24,13 +25,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <NMakeBuildCommandLine>wsl bash -lic ./build.sh</NMakeBuildCommandLine>
     <NMakeOutput>MiSTer</NMakeOutput>
     <NMakeCleanCommandLine>wsl bash -lic ./clean.sh</NMakeCleanCommandLine>
-    <NMakePreprocessorDefinitions>__arm__;__GNUC__;__USE_GNU ;_GNU_SOURCE;VDATE="000000";_FILE_OFFSET_BITS=64;_LARGEFILE64_SOURCE;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
-    <NMakeIncludeSearchPath>c:\Work\MiSTer\toolchain\gcc103\arm-none-linux-gnueabihf\libc\usr\include;c:\Work\MiSTer\toolchain\gcc103\lib\gcc\arm-none-linux-gnueabihf\10.3.1\include;c:\Work\MiSTer\toolchain\gcc103\arm-none-linux-gnueabihf\include\c++\10.3.1;c:\Work\MiSTer\toolchain\gcc103\arm-none-linux-gnueabihf\include\c++\10.3.1\arm-linux-gnueabihf;$(NMakeIncludeSearchPath);lib\libco;lib\miniz;lib\lodepng;lib\libchdr\include;lib\bluetooth</NMakeIncludeSearchPath>
+    <NMakePreprocessorDefinitions>__arm__;__GNUC__;__USE_GNU;_GNU_SOURCE;VDATE="000000";_FILE_OFFSET_BITS=64;_LARGEFILE64_SOURCE;USE_PROTOTYPES=1;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>C:\Work\MiSTer\toolchain\gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf\arm-none-linux-gnueabihf\libc\usr\include;C:\Work\MiSTer\toolchain\gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf\lib\gcc\arm-none-linux-gnueabihf\10.3.1\include;C:\Work\MiSTer\toolchain\gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf\arm-none-linux-gnueabihf\include\c++\10.3.1;C:\Work\MiSTer\toolchain\gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf\arm-none-linux-gnueabihf\include\c++\10.3.1\arm-linux-gnueabihf;$(NMakeIncludeSearchPath);lib\libco;lib\miniz;lib\lodepng;lib\libchdr\include;lib\bluetooth</NMakeIncludeSearchPath>
     <OutDir>$(TEMP)</OutDir>
     <IntDir>$(TEMP)</IntDir>
     <AdditionalOptions>
@@ -139,6 +139,7 @@
     <ClInclude Include="ide_cdrom.h" />
     <ClInclude Include="input.h" />
     <ClInclude Include="joymapping.h" />
+    <ClInclude Include="mat4x4.h" />
     <ClInclude Include="lib\imlib2\Imlib2.h" />
     <ClInclude Include="lib\libco\libco.h" />
     <ClInclude Include="lib\libco\settings.h" />
@@ -175,6 +176,7 @@
     <ClInclude Include="support\minimig\minimig_hdd.h" />
     <ClInclude Include="support\minimig\minimig_share.h" />
     <ClInclude Include="support\n64\n64.h" />
+    <ClInclude Include="support\n64\n64_cpak_header.h" />
     <ClInclude Include="support\n64\n64_joy_emu.h" />
     <ClInclude Include="support\neogeo\neogeocd.h" />
     <ClInclude Include="support\neogeo\neogeo_loader.h" />

--- a/cfg.h
+++ b/cfg.h
@@ -72,7 +72,7 @@ typedef struct {
 	char shmask_default[1023];
 	char preset_default[1023];
 	char player_controller[6][8][256];
-	char controller_deadzone[8][256];
+	char controller_deadzone[32][256];
 	uint8_t rumble;
 	uint8_t wheel_force;
 	uint16_t wheel_range;

--- a/setup_default_toolchain.sh
+++ b/setup_default_toolchain.sh
@@ -9,7 +9,7 @@ fi
 echo "Setting up default toolchain..."
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-GCC_VER=10.2-2020.11
+GCC_VER=10.3-2021.07
 GCC_PACKAGE_NAME=gcc-arm-$GCC_VER-x86_64-arm-none-linux-gnueabihf
 GCC_DIR=$SCRIPT_DIR/$GCC_PACKAGE_NAME
 
@@ -26,4 +26,3 @@ export CC=$GCC_DIR/bin/arm-none-gnueabihf-gcc
 export PATH="$GCC_DIR/bin:$PATH"
 
 echo "Done!"
-

--- a/support/n64/n64.cpp
+++ b/support/n64/n64.cpp
@@ -1274,10 +1274,9 @@ int n64_rom_tx(const char *name, unsigned char idx, uint32_t load_addr) {
 	auto save_type = get_cart_save_type();
 	char old_save_path[1024];
 	get_old_save_path(old_save_path, name);
-	bool do_reset = false;
 
 	if (save_type != MemoryType::NONE) {
-		do_reset |= mount_save_file(name, save_type, old_save_path);
+		mount_save_file(name, save_type, old_save_path);
 	}
 
 	auto use_cpak = (bool)user_io_status_get(CPAK_OPT);
@@ -1285,28 +1284,21 @@ int n64_rom_tx(const char *name, unsigned char idx, uint32_t load_addr) {
 
 	// First controller can be either tpak or cpak. Tpak is prioritized.
 	if (use_tpak || use_cpak) {
-		do_reset |= mount_save_file(name,
+		mount_save_file(name,
 			(use_tpak ? MemoryType::TPAK : MemoryType::CPAK), 
 			old_save_path);
 	}
 
 	if (use_cpak) {
-		do_reset |= mount_save_file(name, MemoryType::CPAK, old_save_path);
-		do_reset |= mount_save_file(name, MemoryType::CPAK, old_save_path);
-		do_reset |= mount_save_file(name, MemoryType::CPAK, old_save_path);
+		mount_save_file(name, MemoryType::CPAK, old_save_path);
+		mount_save_file(name, MemoryType::CPAK, old_save_path);
+		mount_save_file(name, MemoryType::CPAK, old_save_path);
 	}
 
 	// Signal end of transmission
 	user_io_set_download(0);
 
 	ProgressMessage(0, 0, 0, 0);
-
-	// reset if new save files were 
-	if (do_reset) {
-		user_io_status_set("[0]", 1);
-		usleep(100000);
-		user_io_status_set("[0]", 0);
-	}
 
 	if (!is_auto()) {
 		return 1;


### PR DESCRIPTION
A small bug was introduced with the new dead zone code that made it ignore "quirks" regarding DS3/DS4. These devices should automatically be given a dead zone of 10, as it was before. Also removed an unnecessary reset in the N64 support code.