### PR TITLE
cfg attribute in reset tag for MGL file

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -16,6 +16,7 @@
 #include "support/arcade/mra_loader.h"
 
 cfg_t cfg;
+char cfg_pathstatus[1024] = {0};
 static FILE *orig_stdout = NULL;
 static FILE *dev_null = NULL;
 

--- a/cfg.h
+++ b/cfg.h
@@ -98,6 +98,7 @@ typedef struct {
 	char osd_lock[25];
 	uint16_t osd_lock_time;
 	char debug;
+	char pathstatus[1024] = {0};
 } cfg_t;
 
 extern cfg_t cfg;

--- a/cfg.h
+++ b/cfg.h
@@ -97,10 +97,10 @@ typedef struct {
 	uint32_t controller_unique_mapping[256];
 	char osd_lock[25];
 	uint16_t osd_lock_time;
-	char debug;
-	char pathstatus[1024] = {0};
+	char debug;	
 } cfg_t;
 
+extern char cfg_pathstatus[1024];
 extern cfg_t cfg;
 
 //// functions ////

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -16,6 +16,7 @@
 
 #include "buffer.h"
 #include "mra_loader.h"
+#include "cfg.h"
 
 #define kBigTextSize 1024
 struct arc_struct {
@@ -1312,9 +1313,13 @@ static int scan_mgl(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, const in
 					{
 						mgl.item[mgl.count].hold = strtoul(node->attributes[i].value, NULL, 0);
 					}
+					else if (!strcasecmp(node->attributes[i].name, "cfg"))
+					{
+						snprintf(cfg.pathstatus, sizeof(cfg.pathstatus), "%s", node->attributes[i].value);
+					}
 				}
 
-				printf("  action=reset\n  delay=%d\n  hold=%d\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].hold);
+				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n  cfg=%s\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid, cfg.pathstatus);
 				if (mgl.item[mgl.count].valid) mgl.count++;
 			}
 		}

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -1284,9 +1284,13 @@ static int scan_mgl(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, const in
 						snprintf(mgl.item[mgl.count].path, sizeof(mgl.item[mgl.count].path), "%s", node->attributes[i].value);
 						mgl.item[mgl.count].valid |= 0x8;
 					}
+					else if (!strcasecmp(node->attributes[i].name, "cfg"))
+					{
+						snprintf(cfg.pathstatus, sizeof(cfg.pathstatus), "%s", node->attributes[i].value);
+					}
 				}
 
-				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid);
+				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n  cfg=%s\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid, cfg.pathstatus);
 
 				if (mgl.item[mgl.count].valid == 0xF)
 				{
@@ -1313,13 +1317,9 @@ static int scan_mgl(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, const in
 					{
 						mgl.item[mgl.count].hold = strtoul(node->attributes[i].value, NULL, 0);
 					}
-					else if (!strcasecmp(node->attributes[i].name, "cfg"))
-					{
-						snprintf(cfg.pathstatus, sizeof(cfg.pathstatus), "%s", node->attributes[i].value);
-					}
 				}
 
-				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n  cfg=%s\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid, cfg.pathstatus);
+				printf("  action=reset\n  delay=%d\n  hold=%d\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].hold);
 				if (mgl.item[mgl.count].valid) mgl.count++;
 			}
 		}

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -1284,13 +1284,9 @@ static int scan_mgl(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, const in
 						snprintf(mgl.item[mgl.count].path, sizeof(mgl.item[mgl.count].path), "%s", node->attributes[i].value);
 						mgl.item[mgl.count].valid |= 0x8;
 					}
-					else if (!strcasecmp(node->attributes[i].name, "cfg"))
-					{
-						snprintf(cfg.pathstatus, sizeof(cfg.pathstatus), "%s", node->attributes[i].value);
-					}
 				}
 
-				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n  cfg=%s\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid, cfg.pathstatus);
+				printf("  action=load\n  delay=%d\n  type=%c\n  index=%d\n  path=%s\n  valid=%X\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].type, mgl.item[mgl.count].index, mgl.item[mgl.count].path, mgl.item[mgl.count].valid);
 
 				if (mgl.item[mgl.count].valid == 0xF)
 				{
@@ -1317,9 +1313,13 @@ static int scan_mgl(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, const in
 					{
 						mgl.item[mgl.count].hold = strtoul(node->attributes[i].value, NULL, 0);
 					}
+					else if (!strcasecmp(node->attributes[i].name, "cfg"))
+					{
+						snprintf(cfg_pathstatus, sizeof(cfg_pathstatus), "%s", node->attributes[i].value);
+					}
 				}
 
-				printf("  action=reset\n  delay=%d\n  hold=%d\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].hold);
+				printf("  action=reset\n  delay=%d\n  hold=%d\n  cfg=%s\n\n", mgl.item[mgl.count].delay, mgl.item[mgl.count].hold, cfg_pathstatus);
 				if (mgl.item[mgl.count].valid) mgl.count++;
 			}
 		}

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -125,16 +125,21 @@ static char config_ver[10] = {};
 
 char* user_io_create_config_name(int with_ver)
 {
-	static char str[40];
-	str[0] = 0;
-	char *p = user_io_get_core_name();
-	if (p[0])
+	if (!cfg.pathstatus[0])
 	{
-		strcpy(str, p);
-		if (with_ver) strcat(str, config_ver);
-		strcat(str, ".CFG");
+		static char str[40];
+		str[0] = 0;
+		char *p = user_io_get_core_name();
+		if (p[0])
+		{
+			strcpy(str, p);
+			if (with_ver) strcat(str, config_ver);
+			strcat(str, ".CFG");
+		}
+		return str;
 	}
-	return str;
+	else
+		return cfg.pathstatus;
 }
 
 static char core_name[32] = {};

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -125,7 +125,7 @@ static char config_ver[10] = {};
 
 char* user_io_create_config_name(int with_ver)
 {
-	if (!cfg.pathstatus[0])
+	if (!cfg_pathstatus[0])
 	{
 		static char str[40];
 		str[0] = 0;
@@ -139,7 +139,7 @@ char* user_io_create_config_name(int with_ver)
 		return str;
 	}
 	else
-		return cfg.pathstatus;
+		return cfg_pathstatus;
 }
 
 static char core_name[32] = {};


### PR DESCRIPTION
This attribute allows the use of a custom configuration setting in a core running via MGL