### PR TITLE
PSX: Fix the end sector for the last track on audio CDs

### DIFF
--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -309,19 +309,13 @@ static int load_cue(const char* filename, toc_t *table)
 				if (table->tracks[table->last].type && !table->last) table->tracks[table->last].indexes[1] = 150;
 				table->tracks[table->last].start = table->end;
 				table->end += (table->tracks[table->last].f.size / table->tracks[table->last].sector_size);
-				table->tracks[table->last].end = table->end - 1;
 				table->tracks[table->last].offset = 0;
 			}
+			table->tracks[table->last].end = table->end - 1;
 			table->last++;
 			if (table->last >= 99) break;
 		}
 	}
-
-  if (!table->tracks[table->last].end && table->tracks[table->last].offset)
-  {
-    //Single bin CUE, calculate the end of the last track based on file size.
-    table->tracks[table->last].end = (table->tracks[0].f.size-table->tracks[table->last].offset) / table->tracks[0].sector_size;
-  }
 
 	/*
 	for (int i = 0; i < table->last; i++)


### PR DESCRIPTION
I ripped some audio CDs to .bin/.cue for loading into Vib-Ribbon and I noticed that the last track was always silent. To make sure it wasn't a game-specific issue, I also tried the BIOS CD player and got the same result.

If we look at the code for loading .bin/.cue files, there's a branch which attempts to fill in the end sector for the last track, however it's using the wrong index in the array and the calculation itself is also wrong. It's sufficient to always set each new track's `end` to `table->end - 1`, because if a track is not at the end then its end sector will be adjusted on the next iteration.

This resolves the issue for me in both Vib-Ribbon and the BIOS. I assume that this mainly affects audio CDs because most game discs will only have one track.