### PR TITLE
adding approximate autofire rate in hz to OSD display

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -1890,7 +1890,7 @@ static void joy_digital(int jnum, uint32_t mask, uint32_t code, char press, int 
 
 						if (hasAPI1_5())
 						{
-							if (!found) sprintf(str, "Auto fire: %dms", af_delay[num] * 2);
+							if (!found) sprintf(str, "Auto fire: %dms (%uhz)", af_delay[num] * 2, 1000 / (af_delay[num] * 2));
 							else sprintf(str, "Auto fire: OFF");
 							Info(str);
 						}
@@ -1916,12 +1916,12 @@ static void joy_digital(int jnum, uint32_t mask, uint32_t code, char press, int 
 
 						if (hasAPI1_5())
 						{
-							sprintf(str, "Auto fire period: %dms", af_delay[num] * 2);
+							sprintf(str, "Auto fire period: %dms (%uhz)", af_delay[num] * 2, 1000 / (af_delay[num] * 2));
 							Info(str);
 						}
 						else
 						{
-							sprintf(str, "\n\n       Auto fire period\n            %dms", af_delay[num] * 2);
+							sprintf(str, "\n\n       Auto fire period\n            %dms(%uhz)", af_delay[num] * 2, 1000 / (af_delay[num] * 2));
 							InfoMessage(str);
 						}
 


### PR DESCRIPTION
some players are more used to seeing autofire represented in hz (presses per second) than ms delay. this adds the approximate hz for autofire to the OSD display when it is enabled or the rate changed.

former behavior - would display: Auto fire period: 32ms
new behavior - will display: Auto fire period: 32ms (31hz)
