### PR TITLE
chore(ci): add simple build workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
+
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y make wget xz-utils && \
-    wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf.tar.xz?revision=d0b90559-3960-4e4b-9297-7ddbc3e52783&rev=d0b9055939604e4b92977ddbc3e52783&hash=0074C1529DE90C98726B80ED3EE0776C" | tar -xJ && \
-    mv gcc-arm-* /usr/local/bin && \
-    printf 'export PATH=$PATH:%s\n' /usr/local/bin/gcc-arm-*/bin >> ~/.bashrc && \
+    wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf.tar.xz?revision=d0b90559-3960-4e4b-9297-7ddbc3e52783&rev=d0b9055939604e4b92977ddbc3e52783&hash=0074C1529DE90C98726B80ED3EE0776C" \
+    | tar -xJf - --strip-components=1 -C /usr/local && \
     apt-get autoremove && apt-get clean && \
     rm -rf ~/.cache /tmp/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+---
+name: ci
+on:
+  merge_group:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - 'releases/*'
+  pull_request:
+    branches:
+    - "**"
+    paths-ignore:
+    - 'releases/*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: docker/setup-buildx-action@v3
+      id: buildx
+    - name: Run docker build for .devcontainer/Dockerfile
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: false
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        file: .devcontainer/Dockerfile
+        tags: mister-devel/build:stable
+        load: true
+        cache-from: type=gha,scope=${{ github.workflow }}
+        cache-to: type=gha,scope=${{ github.workflow }},mode=max
+    - name: Run make MiSTer using devcontainer
+      run: |
+       docker run --name=build \
+          -v $PWD:/usr/src \
+          -w /usr/src \
+          mister-devel/build:stable \
+          make
+       FILENAME="MiSTer_$(date +'%Y%m%d')"
+       mv -vi MiSTer "releases/${FILENAME}"
+       echo "filename=$FILENAME" >>"$GITHUB_OUTPUT"
+      id: build
+    - name: "Upload ${{ steps.build.outputs.filename }} Artifact"
+      uses: actions/upload-artifact@v4
+      with:
+        name: "${{ steps.build.outputs.filename }}"
+        path: "releases/${{ steps.build.outputs.filename }}"
+        if-no-files-found: error
+        retention-days: 7


### PR DESCRIPTION
Add a simple GitHub Action workflow which builds (and caches) the .devcontainer docker image and then runs a `make` of the MiSTer binary within it before uploading it as an artifact on the workflow result.

This provides a simple compilation test on pull requests and also allows the author or others to grab a built binary for testing purposes