### PR TITLE
Allow overriding of array variables by a different section

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -327,6 +327,9 @@ static void ini_parse_numeric(const ini_var_t *var, const char *text, void *out)
 	}
 }
 
+// Used to determine if an array variable should be appended or restarted.
+static bool var_array_append[sizeof(ini_vars) / sizeof(ini_var_t)] = {};
+
 static void ini_parse_var(char* buf)
 {
 	// find var
@@ -371,6 +374,18 @@ static void ini_parse_var(char* buf)
 		case STRINGARR:
 			{
 				int item_sz = var->max;
+
+				if (!var_array_append[var_id])
+				{
+					var_array_append[var_id] = true;
+
+					for (int n = 0; n < var->min; n++)
+					{
+						char *str = ((char*)var->var) + (n * item_sz);
+						str[0] = 0;
+					}
+				}
+
 				for (int n = 0; n < var->min; n++)
 				{
 					char *str = ((char*)var->var) + (n * item_sz);
@@ -386,6 +401,14 @@ static void ini_parse_var(char* buf)
 		case HEX32ARR:
 		case UINT32ARR:
 			{
+				if (!var_array_append[var_id])
+				{
+					var_array_append[var_id] = true;
+
+					uint32_t *arr = (uint32_t*)var->var;
+					arr[0] = 0;
+				}
+
 				uint32_t *arr = (uint32_t*)var->var;
 				uint32_t pos = ++arr[0];
 				ini_parse_numeric(var, &buf[i], &arr[pos]);
@@ -444,10 +467,18 @@ static void ini_parse(int alt, const char *vmode)
 		{
 			// if first char in line is INI_SECTION_START, get section
 			section = ini_get_section(line, vmode);
+			if (section)
+			{
+				memset(var_array_append, 0, sizeof(var_array_append));
+			}
 		}
 		else if (line[0] == INCL_SECTION && !section)
 		{
 			section = ini_get_section(line, vmode);
+			if (section)
+			{
+				memset(var_array_append, 0, sizeof(var_array_append));
+			}
 		}
 		else if(section)
 		{


### PR DESCRIPTION
Currently, adding to an array variable in the .ini file is done by repeated use of that variable.  However, it would be beneficial to be able to replace an array in a different section.

Motivation:

```
; Set up controllers to be assigned to specific USB ports
[MiSTer]
player_1_controller=usb-1.3/
player_2_controller=usb-1.1/

; Swap assigned ports for a specific game
[gamename]
player_1_controller=usb-1.1/
player_2_controller=usb-1.3/
```

Currently, this will assign both ports to both players when playing that game, which isn't useful.  This change will clear an array if it is seen for the first time in a section, otherwise will allow multiple assignments within a section as before.