### PR TITLE
Fixed potential buffer overruns when adding too many .ini array elements.

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -82,7 +82,7 @@ static const ini_var_t ini_vars[] =
 	{ "SHARED_FOLDER", (void*)(&(cfg.shared_folder)), STRING, 0, sizeof(cfg.shared_folder) - 1 },
 	{ "NO_MERGE_VID", (void*)(&(cfg.no_merge_vid)), HEX16, 0, 0xFFFF },
 	{ "NO_MERGE_PID", (void*)(&(cfg.no_merge_pid)), HEX16, 0, 0xFFFF },
-	{ "NO_MERGE_VIDPID", (void*)(cfg.no_merge_vidpid), HEX32ARR, 0, 0xFFFFFFFF },
+	{ "NO_MERGE_VIDPID", (void*)(cfg.no_merge_vidpid), HEX32ARR, 0, sizeof(cfg.no_merge_vidpid) / sizeof(cfg.no_merge_vidpid[0]) },
 	{ "CUSTOM_ASPECT_RATIO_1", (void*)(&(cfg.custom_aspect_ratio[0])), STRING, 0, sizeof(cfg.custom_aspect_ratio[0]) - 1 },
 	{ "CUSTOM_ASPECT_RATIO_2", (void*)(&(cfg.custom_aspect_ratio[1])), STRING, 0, sizeof(cfg.custom_aspect_ratio[1]) - 1 },
 	{ "SPINNER_VID", (void*)(&(cfg.spinner_vid)), HEX16, 0, 0xFFFF },
@@ -126,7 +126,7 @@ static const ini_var_t ini_vars[] =
 	{ "HDR_AVG_NITS", (void*)(&(cfg.hdr_avg_nits)), UINT16, 100, 10000 },
 	{ "VGA_MODE", (void*)(&(cfg.vga_mode)), STRING, 0, sizeof(cfg.vga_mode) - 1 },
 	{ "NTSC_MODE", (void *)(&(cfg.ntsc_mode)), UINT8, 0, 2 },
-	{ "CONTROLLER_UNIQUE_MAPPING", (void *)(cfg.controller_unique_mapping), UINT32ARR, 0, 0xFFFFFFFF },
+	{ "CONTROLLER_UNIQUE_MAPPING", (void *)(cfg.controller_unique_mapping), UINT32ARR, 0, sizeof(cfg.controller_unique_mapping) / sizeof(cfg.controller_unique_mapping[0]) },
 	{ "OSD_LOCK", (void*)(&(cfg.osd_lock)), STRING, 0, sizeof(cfg.osd_lock) - 1 },
 	{ "OSD_LOCK_TIME", (void*)(&(cfg.osd_lock_time)), UINT16, 0, 60 },
 	{ "DEBUG", (void *)(&(cfg.debug)), UINT8, 0, 1 },
@@ -410,8 +410,11 @@ static void ini_parse_var(char* buf)
 				}
 
 				uint32_t *arr = (uint32_t*)var->var;
-				uint32_t pos = ++arr[0];
-				ini_parse_numeric(var, &buf[i], &arr[pos]);
+				if (arr[0] < var->max)
+				{
+					uint32_t pos = ++arr[0];
+					ini_parse_numeric(var, &buf[i], &arr[pos]);
+				}
 			}
 			break;
 


### PR DESCRIPTION
There's no guard for writing off the end of int arrays in .ini files if too many elements are added.  This change ignores any extra elements, similar to what already happens with string arrays, and correctly sets the bounds of the `NO_MERGE_VIDPID` and `CONTROLLER_UNIQUE_MAPPING` arrays.