### PR TITLE
Added the ability to override the GCC install location, version and host architecture.

### DIFF
--- a/setup_default_toolchain.sh
+++ b/setup_default_toolchain.sh
@@ -8,15 +8,22 @@ fi
 
 echo "Setting up default toolchain..."
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-GCC_VER=10.2-2020.11
-GCC_PACKAGE_NAME=gcc-arm-$GCC_VER-x86_64-arm-none-linux-gnueabihf
-GCC_DIR=$SCRIPT_DIR/$GCC_PACKAGE_NAME
+if [ -z "${MISTER_GCC_INSTALL_DIR}" ]; then
+	MISTER_GCC_INSTALL_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+fi
+if [ -z "${MISTER_GCC_VER}" ]; then
+	MISTER_GCC_VER=10.2-2020.11
+fi
+if [ -z "${MISTER_GCC_HOST_ARCH}" ]; then
+	MISTER_GCC_HOST_ARCH=x86_64
+fi
+GCC_PACKAGE_NAME=gcc-arm-$MISTER_GCC_VER-$MISTER_GCC_HOST_ARCH-arm-none-linux-gnueabihf
+GCC_DIR=$MISTER_GCC_INSTALL_DIR/$GCC_PACKAGE_NAME
 
 if [ ! -d $GCC_DIR ]; then
 	echo "Downloading $GCC_PACKAGE_NAME..."
 	GCC_TARBALL=$GCC_PACKAGE_NAME.tar.xz
-	wget --no-check-certificate -c https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VER/binrel/$GCC_TARBALL
+	wget --no-check-certificate -c https://developer.arm.com/-/media/Files/downloads/gnu-a/$MISTER_GCC_VER/binrel/$GCC_TARBALL
 	tar xvf $GCC_TARBALL
 	rm $GCC_TARBALL
 fi


### PR DESCRIPTION
This change allows the GCC host architecture to be overridden by the `MISTER_GCC_HOST_ARCH` envvar, allowing the use of (in my case) ARM-based GCC.  I also added `MISTER_GCC_VER` and `MISTER_GCC_INSTALL_DIR` to allow the version and install directory to be overridden too.

If none of these overrides are specified, it will default to the current behaviour.