### PR TITLE
Screenshot: don't squish video when it is rotated

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -4124,6 +4124,17 @@ bool user_io_screenshot(const char *pngname, int rescale)
 	}
 	else
 	{
+    int scwidth = ms->output_width;
+    int scheight = ms->output_height;
+
+    if (video_get_rotated())
+    {
+
+      //If the video is rotated, the scaled output resolution results in a squished image.
+      //Calculate the scaled output res using the original AR
+      scwidth = scheight * ((float)ms->width/ms->height);
+    }
+
 		const char *basename = last_filename;
 		if( pngname && *pngname )
 			basename = pngname;
@@ -4140,7 +4151,7 @@ bool user_io_screenshot(const char *pngname, int rescale)
 		/* do we want to save a rescaled image? */
 		if (rescale)
 		{
-			Imlib_Image im_scaled=imlib_create_cropped_scaled_image(0,0,ms->width,ms->height,ms->output_width,ms->output_height);
+			Imlib_Image im_scaled=imlib_create_cropped_scaled_image(0,0,ms->width,ms->height,scwidth,scheight);
 			imlib_free_image_and_decache();
 			imlib_context_set_image(im_scaled);
 		}

--- a/video.cpp
+++ b/video.cpp
@@ -3904,3 +3904,12 @@ static void video_calculate_cvt(int h_pixels, int v_lines, float refresh_rate, i
 		video_calculate_cvt_int(h_pixels, v_lines, refresh_rate, 1, vmode);
 	}
 }
+
+
+
+int video_get_rotated()
+{
+  return current_video_info.rotated;
+}
+
+

--- a/video.h
+++ b/video.h
@@ -47,6 +47,8 @@ char* video_get_shadow_mask(int only_name = 1);
 void  video_set_shadow_mask(const char *name);
 void  video_loadPreset(char *name, bool save);
 
+int   video_get_rotated();
+
 void video_cfg_reset();
 
 void  video_mode_adjust();


### PR DESCRIPTION
Currently scaled screenshots use the output dimensions provided by the scaler to scale up the image. This causes the screenshot to be distorted if it is rotated.

Use the original aspect ratio of the core's video to calculate an upscaled resolution that maintains the original AR. (only for rotated images, non-rotated isn't changed).



