### PR TITLE
SNES: remove hardcoded index for ROM.

### DIFF
--- a/support/snes/snes.h
+++ b/support/snes/snes.h
@@ -1,6 +1,11 @@
 #ifndef SNES_H
 #define SNES_H
 
+#define SNES_FILE_RAW		0
+#define SNES_FILE_ROM		1
+#define SNES_FILE_SPC		2
+#define SNES_FILE_BS		3
+
 uint8_t* snes_get_header(fileTYPE *f);
 void snes_patch_bs_header(fileTYPE *f, uint8_t *buf);
 void snes_msu_init(const char* name);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2541,15 +2541,21 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 
 	int dosend = 1;
 
-	int is_snes_bs = 0;
+	int snes_file = SNES_FILE_RAW;
 	if (is_snes() && bytes2send && !load_addr)
 	{
 		const char *ext = strrchr(f.name, '.');
-		if (ext && !strcasecmp(ext, ".BS")) {
-			is_snes_bs = 1;
+		if (ext) {
+			if (index == 0 || !strcasecmp(ext, ".SMC") || !strcasecmp(ext, ".SFC") || !strcasecmp(ext, ".BIN")) {
+				snes_file = SNES_FILE_ROM;
+			} else if (!strcasecmp(ext, ".BS")) {
+				snes_file = SNES_FILE_BS;
+			} else if (!strcasecmp(ext, ".SPC")) {
+				snes_file = SNES_FILE_SPC;
+			}
 		}
 
-		if (is_snes_bs) {
+		if (snes_file == SNES_FILE_BS) {
 			char *rom_path = (char*)buf;
 			strcpy(rom_path, name);
 			char *offs = strrchr(rom_path, '/');
@@ -2589,7 +2595,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 				sleep(1);
 			}
 		}
-		else if ((index & 0x3F) == 1) {
+		else if (snes_file == SNES_FILE_SPC) {
 			printf("Load SPC ROM.\n");
 			FileReadSec(&f, buf);
 			user_io_file_tx_data(buf, 256);
@@ -2601,7 +2607,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 			FileSeek(&f, 256, SEEK_SET);
 			bytes2send = 64 * 1024;
 		}
-		else if ((index & 0x3F) == 0) {
+		else if (snes_file == SNES_FILE_ROM) {
 			printf("Load SNES ROM.\n");
 			uint8_t* buf = snes_get_header(&f);
 			hexdump(buf, 16, 0);
@@ -2690,7 +2696,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 			uint32_t chunk = (bytes2send > sizeof(buf)) ? sizeof(buf) : bytes2send;
 
 			FileReadAdv(&f, buf, chunk);
-			if (is_snes() && is_snes_bs) snes_patch_bs_header(&f, buf);
+			if (is_snes() && (snes_file == SNES_FILE_BS)) snes_patch_bs_header(&f, buf);
 			user_io_file_tx_data(buf, chunk);
 
 			if (use_progress) ProgressMessage("Loading", f.name, size - bytes2send, size);


### PR DESCRIPTION
This allows for changing the index without breaking older core releases and also to use boot0-3.rom.