### PR TITLE
Increase YC Mode Array

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -77,7 +77,7 @@ static VideoInfo current_video_info;
 
 static int support_FHD = 0;
 
-yc_mode yc_modes[10];
+yc_mode yc_modes[20];
 
 struct vrr_cap_t
 {


### PR DESCRIPTION
Current Saturn core extends the requirements beyond 10 to 14 potentially more, increasing the array to 20 to fix the current limitation and allow for some buffer.