### PR TITLE
change zip sorting again

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1224,12 +1224,6 @@ struct DirentComp
 		if ((de1.de.d_type == DT_DIR) && (de2.de.d_type != DT_DIR)) return true;
 		if ((de1.de.d_type != DT_DIR) && (de2.de.d_type == DT_DIR)) return false;
 
-		if ((de1.de.d_type == DT_DIR) && (de2.de.d_type == DT_DIR))
-		{
-			if (!(de1.flags & DT_EXT_ZIP) && (de2.flags & DT_EXT_ZIP)) return true;
-			if ((de1.flags & DT_EXT_ZIP) && !(de2.flags & DT_EXT_ZIP)) return false;
-		}
-
 		int len1 = strlen(de1.altname);
 		int len2 = strlen(de2.altname);
 		if ((len1 > 4) && (de1.altname[len1 - 4] == '.')) len1 -= 4;

--- a/menu.cpp
+++ b/menu.cpp
@@ -7107,6 +7107,10 @@ void PrintDirectory(int expand)
 			{
 				strncpy(s + 1, flist_DirItem(k)->altname+1, len-1);
 			}
+			else if (flist_DirItem(k)->flags & DT_EXT_ZIP)
+			{
+				strncpy(s + 1, flist_DirItem(k)->altname, len-4); // strip .zip extension, see below
+			}
 			else
 			{
 				strncpy(s + 1, flist_DirItem(k)->altname, len); // display only name
@@ -7122,7 +7126,7 @@ void PrintDirectory(int expand)
 				else
 				{
 					if (flist_DirItem(k)->flags & DT_EXT_ZIP) // mark ZIP archive with different suffix
-						strcpy(&s[22], " <zip>");
+						strcpy(&s[22], " <ZIP>");
 					else
 						strcpy(&s[22], " <DIR>");
 				}


### PR DESCRIPTION
i've just updated after several months and found that the 'zip folder' ux is suddenly frustrating. that's a consequence of #900, which changed the way zips are sorted so that they appear *in between* directories and other files

i don't really understand the purpose of that. @TpaBkaY said it's to better distinguish them from directories -- that much is obvious -- but why? afaik the mister ui treats zips as directories in almost every other respect, so what is the benefit to separating them out like this?

i don't mean to start a fight over it but i would actually propose that it work like this instead (see diff)

however if having the zips sorted differently has some benefit i'm not considering, maybe it could be an ini setting? it could even toggle the 'zips as directories' mechanic off entirely (sort them with regular files, auto-select the file inside instead of descending if it's the only one in the archive). would that be desirable?