### PR TITLE
Add decoding of VHD cookie, validation, and parsing

### DIFF
--- a/support/vhd/mister_vhd.cpp
+++ b/support/vhd/mister_vhd.cpp
@@ -1,0 +1,91 @@
+#include <stddef.h>
+#include <string.h>
+#include <byteswap.h>
+
+#include "mister_vhd.h"
+
+vhd_error validate_vhd_checksum(vhd_footer *footer)
+{
+    uint32_t checksum = 0;
+    const uint8_t *fp = (const uint8_t *)footer;
+    uint16_t checksum_offset = offsetof(vhd_footer, checksum);
+
+    for (uint16_t i = 0; i < sizeof(vhd_footer); i++)
+    {
+        if (i >= checksum_offset && i < checksum_offset + sizeof(footer->checksum)) 
+        {
+            continue;
+        }
+        checksum += fp[i];
+    }
+    checksum = ~checksum;
+    if (checksum != bswap_32(footer->checksum)) 
+    {
+        return VHDERR_CHECKSUM;
+    }
+    else
+    {
+        return VHDERR_NONE;
+    }
+}
+
+// parse_vhd_geometry will 
+vhd_error parse_vhd_geometry(fileTYPE *f, vhd_geometry *geometry) 
+{
+    vhd_footer footer;
+    int offset = sizeof(footer);
+
+    // verify input
+    if ((f->filp == NULL && f->zip == NULL) || !f->opened() || geometry == NULL)
+    {
+        return VHDERR_INVALID_INPUT;
+    }
+
+    int f_offset = f->offset;
+
+
+    // verify the file is large enough to contain the footer
+    if (f->size < offset) 
+    {
+        return VHDERR_INVALID_FILESIZE;
+    }
+
+    // set the file pointer to `offset` bytes before the end and read the footer structure
+    FileSeek(f, -offset, SEEK_END);
+    FileReadAdv(f, &footer, offset);
+
+    // verify the magic cookie
+    if (!memcmp(footer.cookie, VHD_COOKIE, 8)==0) 
+    {
+        return VHDERR_INVALID_COOKIE;
+    }
+
+    // only fixed type is supported
+    switch (bswap_32(footer.type))
+    {
+    case VHD_TYPE_FIXED:
+        break;
+    case VHD_TYPE_NONE:
+    case VHD_TYPE_DYNAMIC:
+    case VHD_TYPE_DIFFERENTIAL:
+    default:
+        return VHDERR_UNSUPPORTED_TYPE;
+    }
+
+    if (!validate_vhd_checksum(&footer)==VHDERR_NONE)
+    {
+        return VHDERR_CHECKSUM;
+    }
+
+    // set the geometry values
+    geometry->size = bswap_64(footer.current_size);
+    geometry->cylinders = bswap_16(footer.cylinders);
+    geometry->heads = footer.heads;
+    geometry->spt = footer.spt;
+
+    // reset offset to where we found it
+    FileSeek(f, f_offset, SEEK_SET);
+
+    printf("Real VHD detected: size %lli, cyl %d, head %d, spt %d\n",geometry->size, geometry->cylinders, geometry->heads, geometry->spt);
+    return VHDERR_NONE;
+}

--- a/support/vhd/mister_vhd.h
+++ b/support/vhd/mister_vhd.h
@@ -1,0 +1,60 @@
+#ifndef MISTER_VHD_H
+#define MISTER_VHD_H
+
+#include <inttypes.h>
+#include "../../file_io.h"
+
+#define VHD_COOKIE "conectix"
+
+struct vhd_geometry
+{
+	uint64_t size;
+	uint16_t cylinders;
+	uint8_t heads;
+	uint8_t spt;
+};
+
+struct vhd_footer
+{
+	char cookie[8];
+	uint32_t features;
+	uint32_t version;
+	uint64_t offset;
+	uint32_t timestamp;
+	char creator[4];
+	uint32_t creator_version;
+	uint32_t creator_host_os;
+	uint64_t original_size;
+	uint64_t current_size;
+	uint16_t cylinders;
+	uint8_t heads;
+	uint8_t spt;
+	uint32_t type;
+	uint32_t checksum;
+	char unique_id[16];
+	uint8_t saved_state;
+	char reserved[427];
+};
+
+enum vhd_disk_types
+{
+	VHD_TYPE_NONE,
+	VHD_TYPE_FIXED = 2,
+	VHD_TYPE_DYNAMIC,
+	VHD_TYPE_DIFFERENTIAL
+};
+
+/* error types */
+enum vhd_error
+{
+	VHDERR_NONE,
+	VHDERR_INVALID_INPUT,
+	VHDERR_INVALID_FILESIZE,
+	VHDERR_INVALID_COOKIE,
+	VHDERR_UNSUPPORTED_TYPE,
+	VHDERR_CHECKSUM
+};
+
+vhd_error parse_vhd_geometry(fileTYPE *f, vhd_geometry *geometry);
+
+#endif


### PR DESCRIPTION
# Problem
I am attempting to install Openstep 4.2 but the first major issue is that the IDE driver suffers an overflow with larger SPT values. I would like to manually set the hard drive specifications to allow for the operating system to access the hard drive.

# Implementation
The VHD specification allows for hard drive metadata to be specified on a per file basis. I have added support files that provides the initial VHD footer parsing to allow for the metadata to be extracted for fixed size VHDs. I use this data in the hard drive loading path for pcxt and ao486 to allow for the file to define the CHS values.

I have created a support directory for this functionality in the case that VHD support is extended in the future to support DYNAMIC or DIFFERENTIAL types.

In the case that a VHD footer cannot be properly parsed, the functionality falls back to the current state of treating the file like a standard raw image.
 
