### PR TITLE
Require at least one video info change before triggering change notification

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -2513,6 +2513,7 @@ int hasAPI1_5()
 static bool get_video_info(bool force, VideoInfo *video_info)
 {
 	static uint16_t nres = 0;
+	static bool vi_seen = false;
 	bool res_changed = false;
 	bool fb_changed = false;
 
@@ -2520,8 +2521,10 @@ static bool get_video_info(bool force, VideoInfo *video_info)
 	uint16_t res = spi_w(0);
 	if ((nres != res) || force)
 	{
+
 		res_changed = (nres != res);
 		nres = res;
+		if (res_changed) vi_seen = true;
 		video_info->width = spi_w(0) | (spi_w(0) << 16);
 		video_info->height = spi_w(0) | (spi_w(0) << 16);
 		video_info->htime = spi_w(0) | (spi_w(0) << 16);
@@ -2558,7 +2561,7 @@ static bool get_video_info(bool force, VideoInfo *video_info)
 	}
 	DisableIO();
 
-	return res_changed || fb_changed;
+	return vi_seen && (res_changed || fb_changed);
 }
 
 static void video_core_description(const VideoInfo *vi, const vmode_custom_t */*vm*/, char *str, size_t len)


### PR DESCRIPTION
When loading an MGL, sometimes the first call to get_video_info() after the load will detect a change via UIO_GET_FB_PAR _before_ it sees the UIO_GET_VRES change. 

This triggers all the code in video_mode_adjust, but with the video info still zero'd out. If the user has direct video enabled it triggers a divide by zero crash because vi->width is zero.

So just wait until the video info has changed before returning true from the function.

I think this mostly happened on psx and saturn. I could frequently but inconsistently trigger it on those cores.