### PR TITLE
Adds support for Retroshooter lightguns operating in mouse mode.

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -7275,7 +7275,7 @@ int menu_lightgun_cb(int idx, uint16_t type, uint16_t code, int value)
 
 	if (type == EV_KEY)
 	{
-		if ((code == 0x130 || code == 0x131 || code == 0x120) && menustate == MENU_LGCAL1)
+		if ((code == 0x130 || code == 0x131 || code == 0x120 || code == 0x110) && menustate == MENU_LGCAL1)
 		{
 			gun_idx = idx;
 			if (value == 1) gun_ok = 1;


### PR DESCRIPTION
Gun sends a mix of keyboard presses, mouse button presses and EV_ABS position data.
Added a QUIRK_LIGHTGUN_MOUSE quirk which passes the mouse button presses through the input system like other EV_KEY events instead of using them for mouse updates. This allows the mouse buttons to be mapped like regular joystick or keyboard buttons.
Added the left mouse button as a keycode that is accepted by the lightgun calibration menu.
Assign player if mouse button is pressed.