### PR TITLE
Fix error in Rema the Truth Attribute

### DIFF
--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1387,7 +1387,6 @@ void cdrom_handle_pkt(ide_config *ide)
 		break;
 
 	case 0x2B: // seek
-
 		dbg_printf("** Seek\n");
 		drv->playing = 0;
 		drv->paused = 0;
@@ -1425,6 +1424,13 @@ void cdrom_handle_pkt(ide_config *ide)
 			pkt_send(ide, ide_buf, read_toc(drv, cmdbuf));
 		} 
 		else cdrom_nodisk(ide);
+		break;
+	
+	case 0x4E: // stop play/scan
+		dbg_printf("** Stop Play/Scan\n");
+		drv->playing = 0;
+		drv->paused = 0;
+		cdrom_reply(ide, 0);
 		break;
 
 	case 0x12: // inquiry


### PR DESCRIPTION
The Japanese Windows 3.1 game _Rema the Truth Attribute_ crashes at the end of the introductory cut scene due to a failed response to the Stop Play/Scan packet command (4Eh). According to the state machine at [MMC-2 Commands](https://www.t10.org/ftp/t10/document.97/97-117r0.pdf), it appears both the play and pause commands should be cleared and a success returned (seek performs a similar action, therefore the edge command of ignoring 4Eh during a seek is not applicable).
