### PR TITLE
Arcade cheat support

### DIFF
--- a/cheats.h
+++ b/cheats.h
@@ -9,4 +9,8 @@ void cheats_print();
 void cheats_toggle();
 int cheats_loaded();
 
+void cheats_init_arcade(int unit_size, int max_active);
+void cheats_add_arcade(const char *name, const char *cheatData, int cheatSize);
+void cheats_finalize_arcade();
+
 #endif

--- a/support/arcade/mra_loader.h
+++ b/support/arcade/mra_loader.h
@@ -55,10 +55,10 @@ struct mgl_struct
 	int  done;
 };
 
-sw_struct *arcade_sw(int n);
-void arcade_sw_send(int n);
-void arcade_sw_save(int n);
-void arcade_sw_load(int n);
+sw_struct *arcade_sw();
+void arcade_sw_send();
+void arcade_sw_save();
+void arcade_sw_load();
 
 // Read any mra info necessary for ini processing
 void arcade_pre_parse(const char *xml);


### PR DESCRIPTION
Remove dip switch based cheat support which was unused by any core. MRA files can now specify cheat data directly. The MRA cheat data is loaded into the existing cheats system and works in much the same way. The cheat data itself is defined by the core, the size (the unit size of cheat data) and the maximum number of active cheats support can be specified as parameters to the cheat node.

```xml
    <cheats size="16" max="32">
        <cheat name="P1 Infinite Lives"      >000000 10 000E229A 00000000 00000006</cheat>
        <cheat name="P1 Maximum Power Charge">000000 10 000E2855 00000000 00000038</cheat>
        <cheat name="P1 Maximum Speed">
            000000 10 000E282A 00000000 0000000A
            000000 10 000E282C 00000000 0000005A
        </cheat>
        <cheat name="P1 Invincibility">
            000000 10 000E286A 00000000 00000060
            000001 10 000E27FD 00000000 00000080
        </cheat>
        <cheat name="P1 No Extra Fire"   >000000 10 000E2842 00000000 00000000</cheat>
        <cheat name="P1 Red Extra Fire"  >000000 10 000E2842 00000000 00000001</cheat>
        <cheat name="P1 Green Extra Fire">000000 10 000E2842 00000000 00000002</cheat>
        <cheat name="P1 Blue Extra Fire" >000000 10 000E2842 00000000 00000003</cheat>
        <cheat name="P1 Rapid Fire">
            000002 10 000E000A 00000000 0000007F
            000000 10 000E2840 00000000 00000000
            000000 10 000E2936 00000000 00000000
            000000 10 000E29B6 00000000 00000000
        </cheat>
   </cheats>
```

### Changes
- `cheats.cpp`: Add external functions `cheats_init_arcade`, `cheats_finalize_arcade` and `cheats_add_arcade` which are called from the MRA parsing code. Simplify memory management in the cheat system itself, don't delete cheats when they are deactivated. Make the cheat size and maximum number of cheats configurable.
- `menu.cpp`: Remove support for the arcade-specific cheat system, everything is handled through the existing cheat system
- `mra_loader.cpp`: Add support for the new cheats section. Remove the arcade specific system and modify the dipswitch functions so they no longer take a parameter.