### PR TITLE
Add support for save states in arcade cores

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -904,9 +904,11 @@ void FileGenerateSavePath(const char *name, char* out_name, int ext_replace)
 
 void FileGenerateSavestatePath(const char *name, char* out_name, int sufx)
 {
-	create_path(SAVESTATE_DIR, CoreName2);
+	const char *subdir = is_arcade() ? "Arcade" : CoreName2;
 
-	sprintf(out_name, "%s/%s/", SAVESTATE_DIR, CoreName2);
+	create_path(SAVESTATE_DIR, subdir);
+
+	sprintf(out_name, "%s/%s/", SAVESTATE_DIR, subdir);
 	char *fname = out_name + strlen(out_name);
 
 	const char *p = strrchr(name, '/');

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1478,6 +1478,7 @@ void user_io_init(const char *path, const char *xml)
 				if (xml && isXmlName(xml) == 1)
 				{
 					arcade_send_rom(xml);
+					if (ss_base) process_ss(xml);
 				}
 				else if (is_minimig())
 				{


### PR DESCRIPTION
Initialize the save state system after processing the MRA if the ss_base address is set. Use the savestates/Arcade directory for arcade savestates