### PR TITLE
guard division by zero in spd_config_dv

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -1570,6 +1570,8 @@ static void spd_config(uint8_t *data)
 static void spd_config_dv()
 {
 	VideoInfo *vi = &current_video_info;
+	if (!vi->width)
+		return;
 
 	uint8_t data[32] = {
 		0x83, 0x01, 25, 0,


### PR DESCRIPTION
Some users are still getting main crashes when loading MGLs externally. 

I can't locally reproduce it, but I suspect it is some bad timing involving video_mode_adjust() being called before the core reports a valid video mode but menu_present() is true.  It may be specific to the PSX core (see https://github.com/MiSTer-devel/PSX_MiSTer/issues/306 the 'fix' in there is basically this PR).

Maybe modifying menu_present() to not return true during MGL processing would be a good idea too.

Regardless, guarding against a divide by zero is probably a good idea. 