### PR TITLE
Fixes pause on CD+G (TurboGrafx16_MiSTer#189)

### DIFF
--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -997,7 +997,7 @@ void pcecdd_t::ReadSubcode(int lba, uint8_t* buf)
 			subc[22] = msb ^ 0xff;
 			subc[23] = lsb ^ 0xff;
 
-			printf("\x1b[32mPCECD: SYNTH - Subcode sector lba = %i\n\x1b[0m", lba);
+			// printf("\x1b[32mPCECD: SYNTH - Subcode sector lba = %i\n\x1b[0m", lba);
 		}
 	}
 	last_lba = lba;


### PR DESCRIPTION
Fix pause on GRAPHICS playback screen by continuously sending subcode data. Also, synthesize subcode data when subcode file not found, so that regular CDs don't have issues in that function.