### PR TITLE
Fix comparison of bootcore= argument

### DIFF
--- a/bootcore.cpp
+++ b/bootcore.cpp
@@ -119,7 +119,6 @@ char* loadLastcore()
 
 char *findCore(const char *name, char *coreName, int indent)
 {
-	char *spl;
 	DIR *dir;
 	struct dirent *entry;
 
@@ -144,16 +143,11 @@ char *findCore(const char *name, char *coreName, int indent)
 				return indir;
 			}
 		}
-		else {
+		else if (!strcmp(entry->d_name, coreName))
+		{
 			snprintf(path, 256, "%s/%s", name, entry->d_name);
-			if (strstr(path, coreName) != NULL) {
-				spl = strrchr(path, '.');
-				if (spl && (!strcmp(spl, ".rbf") || !strcmp(spl, ".mra") || !strcmp(spl, ".mgl")))
-				{
-					closedir(dir);
-					return path;
-				}
-			}
+			closedir(dir);
+			return path;
 		}
 	}
 	closedir(dir);


### PR DESCRIPTION
There's a bug that occurs when a core name assigned to bootcore= differs from another core name only by a prefix.
So if for example the .ini contains bootcore=Rescue.mra, the core Lunar Rescue.mra might be started instead.
The bug occurs or not depending on which file is encountered first when looping through the files.
On my system the cores files happen to be stored alphabetically, so setting bootcore=DonPachi.mra was always starting DoDonPachi.mra instead.
The bug can occur also when bootcore= is set to "lastcore" or "lastexactcore". The file lastcore.dat is initially set correctly to DonPachi.mra, but then DoDonPachi.mra is started instead, and lastcore.dat is then re-written to DoDonPachi.mra.

These are the cores that are currently potentially affected:
```
DonPachi.mra                  ->   DoDonPachi.mra
DonPachi (Japan).mra          ->   DoDonPachi (Japan).mra
Xevious.mra                   ->   Super Xevious.mra
Bagman.mra                    ->   Super Bagman.mra
Rescue.mra                    ->   Lunar Rescue.mra
Tron.mra                      ->   Discs of Tron.mra
Mahou Daisakusen (Japan).mra  ->   Shippu Mahou Daisakusen (Japan).mra
```

The current code compares a core name with all the files in a directory with these steps:
1. prepends the path to the core name
2. checks if the core name contains the file name
3. if so, checks if the core name ends with one of: .rbf .mra .mgl
4. if so, returns the core name

I propose to simply compare with strcmp() to check if the core name matches exactly the file name.
Perhaps the intention behind the strstr() call was to compare disregarding the path that had been prepended, but in that case it's simpler to just compare the file name before prepending the path, like my proposed change does.
If the intention was to have a "fuzzy" comparison, the check for files extension means that the fuzzy comparison is performed only for the beginning of the name rather then for the ending like you would normally expect. So I expect almost nobody was using this kind of fuzzy comparison, and the potential disruption caused by this change should be virtually zero. Moreover, a fuzzy comparison could break at any time anyway as new cores are added to the system, so as it is it's just wrong and should really be fixed.