### PR TITLE
ao486: Add ATA-1 Identify Drive words 4 and 5 for ao486 BIOS

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -483,12 +483,12 @@ void ide_img_set(uint32_t drvnum, fileTYPE *f, int cd, int sectors, int heads, i
 		uint16_t identify[256] =
 		{
 			0x0040, 											//word 0
-			drive->cylinders,									//word 1
+			drive->cylinders,									//word 1 cylinders         (used by e.g. ao486)
 			0x0000,												//word 2 reserved
-			drive->heads,										//word 3
-			0x0000,												//word 4 obsolete
-			0x0000,												//word 5 obsolete
-			drive->spt,											//word 6
+			drive->heads,										//word 3 heads             (used by e.g. ao486)
+			(uint16_t)(512 * drive->spt),						//word 4 bytes per track
+			512,												//word 5 bytes per sector  (used by e.g. ao486)
+			drive->spt,											//word 6 sectors per track (used by e.g. ao486)
 			0x0000,												//word 7 vendor specific
 			0x0000,												//word 8 vendor specific
 			0x0000,												//word 9 vendor specific


### PR DESCRIPTION
Set legacy word 5 (bytes per sector) to 512 in the drive information returned by the ATA-1 Identify Drive command. For completeness, also set legacy word 4 (bytes per track).

The ao486 BIOS relies on the value in word 5 to correctly configure the number of bytes per sector of detected ATA hard drives.

The relevant ao486 BIOS code can be found here:
https://github.com/MiSTer-devel/ao486_MiSTer/blob/4f99df0fba62919adaaa231ca40f82a64d027268/sw/sysbios/rombios.c#L2624

Fixes MiSTer-devel/ao486_MiSTer#195