### PR TITLE
Automatic Direct Video Mode

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -64,7 +64,7 @@ static const ini_var_t ini_vars[] =
 	{ "FB_SIZE", (void*)(&(cfg.fb_size)), UINT8, 0, 4 },
 	{ "FB_TERMINAL", (void*)(&(cfg.fb_terminal)), UINT8, 0, 1 },
 	{ "OSD_TIMEOUT", (void*)(&(cfg.osd_timeout)), INT16, 0, 3600 },
-	{ "DIRECT_VIDEO", (void*)(&(cfg.direct_video)), UINT8, 0, 3 },
+	{ "DIRECT_VIDEO", (void*)(&(cfg.direct_video)), UINT8, 0, 2 },
 	{ "OSD_ROTATE", (void*)(&(cfg.osd_rotate)), UINT8, 0, 2 },
 	{ "DEADZONE", (void*)(&(cfg.controller_deadzone)), STRINGARR, sizeof(cfg.controller_deadzone) / sizeof(*cfg.controller_deadzone), sizeof(*cfg.controller_deadzone) },
 	{ "GAMEPAD_DEFAULTS", (void*)(&(cfg.gamepad_defaults)), UINT8, 0, 1 },


### PR DESCRIPTION
Automatically set Direct video based on HDMI EDID information. Useful for users who swap between HDMI and direct video.

- Use EDID information to automatically toggle direct_video.
  - Relies on generic HDMI resolution (1024x768@60) or whitelist of known DAC make and model.
    - Whitelist devices sets direct_video and hdmi_limited.
      - Continue adding new models to the whitelist
- Supports HDMI hot-plugging
- Adds two new direct_video settings:
  - direct_video=2: Auto-detect HDMI DAC, uses vga_mode and composite_sync settings
  - direct_video=3: Auto-detect HDMI DAC, forces vga_mode=rgb and composite_sync=1 for 15kHz RGB

- Known issues:
  - Menu background doesn't reliably re-scale when switching between HDMI and Direct Video
  - RetroTink 4K: MiSTer starts in Direct Video mode, but switches to standard HDMI after a few seconds