### PR TITLE
Mount saturn saves on index 1, allow selecting a save file

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2221,8 +2221,9 @@ void HandleUI(void)
 						memcpy(Selected_tmp, Selected_S[(int)ioctl_index], sizeof(Selected_tmp));
 						if (is_x86() || is_pcxt()) strcpy(Selected_tmp, x86_get_image_path(ioctl_index));
 						if (is_psx() && (ioctl_index == 2 || ioctl_index == 3)) fs_Options |= SCANO_SAVES;
+						if (is_saturn() && (ioctl_index == 1)) fs_Options |= SCANO_SAVES;
 
-						if (is_saturn() || is_pce() || is_megacd() || is_x86() || is_cdi() || (is_psx() && !(fs_Options & SCANO_SAVES)) || is_neogeo())
+						if ((is_saturn() && !(fs_Options & SCANO_SAVES)) || is_pce() || is_megacd() || is_x86() || is_cdi() || (is_psx() && !(fs_Options & SCANO_SAVES)) || is_neogeo())
 						{
 							//look for CHD too
 							if (!strcasestr(ext, "CHD"))
@@ -2494,7 +2495,12 @@ void HandleUI(void)
 			}
 			else if (is_saturn())
 			{
-				saturn_set_image(ioctl_index, selPath);
+				if (!ioctl_index)
+				{
+					saturn_set_image(ioctl_index, selPath);
+				} else {
+					saturn_mount_save(selPath);
+				}
 			}
 			else if (is_neogeo())
 			{

--- a/support/saturn/saturn.cpp
+++ b/support/saturn/saturn.cpp
@@ -114,22 +114,27 @@ static void saturn_get_save_without_disk(char *buf)
 	}
 }
 
-static void saturn_mount_save(const char *filename)
+void saturn_mount_save(const char *filename, bool is_auto)
 {
 	user_io_set_index(SAVE_IO_INDEX);
 	user_io_set_download(1);
 	if (strlen(filename))
 	{
-		FileGenerateSavePath(filename, buf);
-		saturn_get_save_without_disk(buf);
+		if (is_auto)
+		{
+			FileGenerateSavePath(filename, buf);
+			saturn_get_save_without_disk(buf);
+		} else {
+			strncpy(buf, filename, sizeof(buf));
+		}
 #ifdef SATURN_DEBUG
 		printf("Saturn save filename = %s\n", buf);
 #endif // SATURN_DEBUG
-		user_io_file_mount(buf, 0, 1);
+		user_io_file_mount(buf, 1, 1);
 	}
 	else
 	{
-		user_io_file_mount("");
+		user_io_file_mount("", 1);
 	}
 	user_io_set_download(0);
 }
@@ -164,7 +169,7 @@ void saturn_set_image(int num, const char *filename)
 
 	if (!same_game)
 	{
-		saturn_mount_save("");
+		saturn_mount_save("", true);
 
 		user_io_status_set("[0]", 1);
 		saturn_reset();
@@ -193,7 +198,7 @@ void saturn_set_image(int num, const char *filename)
 			if (!same_game)
 			{
 				//saturn_load_rom(filename, "cart.rom", 1);
-				saturn_mount_save(filename);
+				saturn_mount_save(filename, true);
 				//cheats_init(filename, 0);
 			}
 

--- a/support/saturn/saturn.h
+++ b/support/saturn/saturn.h
@@ -119,5 +119,6 @@ void saturn_set_image(int num, const char *filename);
 void saturn_reset();
 void saturn_fill_blanksave(uint8_t *buffer, uint32_t lba);
 int saturn_send_data(uint8_t* buf, int len, uint8_t index);
+void saturn_mount_save(const char *filename, bool is_auto = false);
 
 #endif

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2085,7 +2085,7 @@ int user_io_file_mount(const char *name, unsigned char index, char pre, int pre_
 	}
 
 	buffer_lba[index] = -1;
-	if (!index || is_cdi()) use_save = pre;
+	if (!index || is_cdi() || (is_saturn() && index==1)) use_save = pre;
 
 	if (!ret)
 	{


### PR DESCRIPTION
Changes to allow Saturn core to change the backup cart at runtime.

Requires: https://github.com/MiSTer-devel/Saturn_MiSTer/pull/458

Ref: https://github.com/MiSTer-devel/Saturn_MiSTer/issues/443