### PR TITLE
Add optional ABS axis to volume mapping via MiSTer.ini

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -134,6 +134,10 @@ static const ini_var_t ini_vars[] =
 	{ "LOOKAHEAD", (void *)(&(cfg.lookahead)), UINT8, 0, 3 },
 	{ "MAIN", (void*)(&(cfg.main)), STRING, 0, sizeof(cfg.main) - 1 },
 	{"VFILTER_INTERLACE_DEFAULT", (void*)(&(cfg.vfilter_interlace_default)), STRING, 0, sizeof(cfg.vfilter_interlace_default) - 1 },
+	{ "VOLUME_ABS_VID", (void*)(&(cfg.volume_abs_vid)), HEX16, 0, 0xFFFF },
+	{ "VOLUME_ABS_PID", (void*)(&(cfg.volume_abs_pid)), HEX16, 0, 0xFFFF },
+	{ "VOLUME_ABS_DOWN", (void*)(&(cfg.volume_abs_down)), UINT8, 0, 255 },
+	{ "VOLUME_ABS_UP", (void*)(&(cfg.volume_abs_up)), UINT8, 0, 255 },
 };
 
 static const int nvars = (int)(sizeof(ini_vars) / sizeof(ini_var_t));

--- a/cfg.h
+++ b/cfg.h
@@ -102,6 +102,10 @@ typedef struct {
 	uint8_t lookahead;
 	char main[1024];
 	char vfilter_interlace_default[1023];
+	uint16_t volume_abs_vid;
+	uint16_t volume_abs_pid;
+	uint8_t volume_abs_down;
+	uint8_t volume_abs_up;
 } cfg_t;
 
 extern cfg_t cfg;

--- a/input.cpp
+++ b/input.cpp
@@ -5370,14 +5370,18 @@ int input_test(int getchar)
 
 								// Volume controls for GRS Ultimate Deck for iiRcade + Viper KVM (XInput Mode)
 								// The KVM board exposes volume buttons as fake ABS axes.
-								if (input[dev].vid == 0x045e && input[dev].pid == 0x028e && ev.type == EV_ABS)
+								if (cfg.volume_abs_vid && cfg.volume_abs_pid &&
+									input[dev].vid == cfg.volume_abs_vid &&
+									input[dev].pid == cfg.volume_abs_pid)
 								{
-									// Volume Down mapped to ABS code 2
-									if (ev.code == 2 && ev.value == 255) set_volume(-1);
-									// Volume Up mapped to ABS code 5
-									if (ev.code == 5 && ev.value == 255) set_volume(1);
+									if (ev.code == cfg.volume_abs_down && ev.value == 255) {
+										set_volume(-1);
+									}
+									else if (ev.code == cfg.volume_abs_up && ev.value == 255) {
+										set_volume(1);
+									}
 								}
-
+								
 								if (is_menu() && !video_fb_state())
 								{
 									/*

--- a/input.cpp
+++ b/input.cpp
@@ -5368,6 +5368,16 @@ int input_test(int getchar)
 									}
 								}
 
+								// Volume controls for GRS Ultimate Deck for iiRcade + Viper KVM (XInput Mode)
+								// The KVM board exposes volume buttons as fake ABS axes.
+								if (input[dev].vid == 0x045e && input[dev].pid == 0x028e && ev.type == EV_ABS)
+								{
+									// Volume Down mapped to ABS code 2
+									if (ev.code == 2 && ev.value == 255) set_volume(-1);
+									// Volume Up mapped to ABS code 5
+									if (ev.code == 5 && ev.value == 255) set_volume(1);
+								}
+
 								if (is_menu() && !video_fb_state())
 								{
 									/*


### PR DESCRIPTION
Some controllers/encoders (e.g. GRS Ultimate Control Deck for iiRcade + Viper KVM)
expose their panel volume buttons as EV_ABS axis events instead of joystick buttons
or consumer keys. In XInput mode this previously meant volume controls were not
usable.

This patch introduces four new MiSTer.ini keys:

```
  volume_abs_vid   = <USB vendor id>
  volume_abs_pid   = <USB product id>
  volume_abs_down  = <ABS code for Volume Down>
  volume_abs_up    = <ABS code for Volume Up>
```

When defined, MiSTer will map those ABS events to set_volume(-1/+1).

Default is disabled (0 / -1), so normal Xbox 360 pads and other controllers are
not affected.
