### PR TITLE
input: Fixed QUIRK_WIIMOTE from being applied to Wii U Pro Controllers.

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2301,7 +2301,7 @@ static void update_num_hw(int dev, int num)
 			set_led(led_path, "::sony4", (num == 0 || num == 4 || num == 5 || num == 6));
 		}
 	}
-	else if (input[dev].quirk == QUIRK_WIIMOTE)
+	else if (input[dev].vid == 0x057e && (input[dev].pid == 0x0306 || input[dev].pid == 0x0330))
 	{
 		led_path = get_led_path(dev);
 		if (led_path)
@@ -4839,7 +4839,7 @@ int input_test(int getchar)
 								pool[n].fd = -1;
 								continue;
 							}
-							else
+							else if (!strcasestr(input[n].name, "Pro Controller"))
 							{
 								input[n].quirk = QUIRK_WIIMOTE;
 								input[n].guncal[0] = 0;


### PR DESCRIPTION
The Wii U Pro Controller is handled through the hid-wiimote drivers, it is treated as an singular extension of a wiimote and identifies itself as a Nintendo Wii Remote Pro Controller
It does not come with the IR Sensor, Accelerometer, or the Motion Plus extensions.

https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/484f681720ca5037042a8d3b89158e6d3af09563/drivers/hid/hid-wiimote-modules.c#L1577-L1585
https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/484f681720ca5037042a8d3b89158e6d3af09563/drivers/hid/hid-wiimote-modules.c#L1911

It has VID:PID of 0x057e:0x0330.

Currently, MiSTer applies QUIRK_WIIMOTE to any non-accelerometer, non-motion plus device with VID 0x057e, and PID 0x0306 or 0x0330.

The Wii U Pro Controller's left analog stick y-axis in not inverted in the driver, so MiSTers fix to handle this inversion should not apply to the Wii U Pro Controller.

https://github.com/MiSTer-devel/Main_MiSTer/blob/ae6dc92c15fcbbd0e5b5fc36119cbc2b86047a4d/input.cpp#L5278C1-L5282C13

The Wii U Pro Controller re-uses the nunchuck accelerometer events for the right analog stick, which MiSTer currently throws away making the right analog stick on the Wii U Pro controller unusable.

Wii U Pro Controller:
https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/484f681720ca5037042a8d3b89158e6d3af09563/drivers/hid/hid-wiimote-modules.c#L1709-L1710

Nunchuck:
https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/484f681720ca5037042a8d3b89158e6d3af09563/drivers/hid/hid-wiimote-modules.c#L883-L885

MiSTers quirk:
https://github.com/MiSTer-devel/Main_MiSTer/blob/ae6dc92c15fcbbd0e5b5fc36119cbc2b86047a4d/input.cpp#L5211C1-L5215C11