### PR TITLE
Skipped destination bytes in maps parsed correctly. Fixes #1033

### DIFF
--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -250,12 +250,19 @@ static int rom_data(const uint8_t *buf, int chunk, int map, struct MD5Context *m
 		return 0;
 
 	map_reg = map;
+	bool first = true;
+	int gaps = 0;
 	for (int i = 0; i < unitlen; i++)
 	{
 		if (map_reg & 0xf)
 		{
-			offsets[bytes_in_iter] = idx + (map_reg & 0xf) - 1;
+			offsets[bytes_in_iter] = idx + (map_reg & 0xf) - 1 + gaps;
 			bytes_in_iter++;
+			first = false;
+		}
+		else if(!first)
+		{
+			gaps++;
 		}
 		map_reg >>= 4;
 	}


### PR DESCRIPTION
Adds the capability to skip bytes in the destination map. Like `map="0201"` or `map="2001"`

The following combinations have been tested against a buffer containing `01234567`, the first number is the map and the string is the expected result. All these tests pass.

```
unitlen=2;
test_map(0x01,"00102030");
test_map(0x10,"00010203");
test_map(0x21,"01234567");
test_map(0x12,"10325476");
unitlen=4;
test_map(0x0001,"00001000");
test_map(0x4321,"01234567");
test_map(0x0012,"10003200");
test_map(0x1234,"32107654");
test_map(0x1200,"00100032");
test_map(0x2100,"00010023");
test_map(0x0021,"01002300");
test_map(0x0201,"00102030");
test_map(0x2001,"00012003");
unitlen=8;
test_map(0x0000'0001,"00000000");
test_map(0x0000'0021,"01000000");
test_map(0x0000'4321,"01230000");
test_map(0x8765'4321,"01234567");
test_map(0x0043'0021,"01002300");
test_map(0x4300'0021,"01000023");
test_map(0x0403'0201,"00102030");
```
The test is in a different [branch](https://github.com/jotego/Main_MiSTer/tree/romdata/support/arcade) that you can check for reference. I do not see tests in the original repository so I am not including the test in the PR.