### PR TITLE
PSX: Persistent noreset.txt state until core is reset or reloaded.

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2349,6 +2349,7 @@ void HandleUI(void)
 									if (is_pce() && !bit) pcecd_reset();
 									if (is_saturn() && !bit) saturn_reset();
 									if (is_n64() && !bit) n64_reset();
+									if (is_psx() && !bit) psx_reset();
 
 									user_io_status_set(opt, 1, ex);
 									user_io_status_set(opt, 0, ex);

--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -18,6 +18,7 @@
 static char buf[1024];
 static uint8_t *chd_hunkbuf = NULL;
 static int chd_hunknum;
+static int noreset = 0;
 
 static int sgets(char *out, int sz, char **in)
 {
@@ -710,12 +711,12 @@ void psx_mount_cd(int f_index, int s_index, const char *filename)
 
 				if (!same_game)
 				{
-					reset = 1;
-					if (old_len)
+					if (!noreset && old_len)
 					{
 						strcat(last_dir, "/noreset.txt");
-						reset = !FileExists(last_dir);
+						noreset = FileExists(last_dir);
 					}
+					reset = !noreset;
 
 					strcpy(last_dir, filename);
 					char *p = strrchr(last_dir, '/');
@@ -797,4 +798,9 @@ void psx_mount_cd(int f_index, int s_index, const char *filename)
 void psx_poll()
 {
 	spi_uio_cmd(UIO_CD_GET);
+}
+
+void psx_reset()
+{
+	noreset = 0;
 }

--- a/support/psx/psx.h
+++ b/support/psx/psx.h
@@ -7,5 +7,6 @@ void psx_read_cd(uint8_t *buffer, int lba, int cnt);
 int psx_chd_hunksize();
 const char* psx_get_game_id();
 void psx_poll();
+void psx_reset();
 
 #endif


### PR DESCRIPTION
The current PSX core behaviour is to reset upon loading a CD image in a different directory from the previously loaded CD image. A magic file called noreset.txt can be placed beside a CD image file in it's directory to override this behaviour and force it to not reset upon loading a new disc outside of it's directory. This type of functionality is used for a few games, notably Monster Rancher 1 & 2, and Vib Ribbon. 

However in the case of Monster Rancher 1 & 2 especially, unless the swapped in disc also has a noreset.txt file present in it's directory, you cannot swap back to the original Monster Rancher disc which is required to continue to play the game, without having to do an intermediary step of going into the Miscellaneous menu, and opening the CD lid, inserting a new cd, then closing the lid, continuing with the game, opening the lid, inserting the original disc again, and closing the lid. Trying to swap back to the original disc just resets the core, as the noreset.txt file is checked against the last loaded disc image every time a new disc is loaded, which is extremely likely not to exist in the typical use case of these games.

This change is to improve the user experience for the select few games that use this disc swapping mechanism by indefinitely holding the noreset state when such a game is loaded, allowing the user to easily and quickly swap between discs from the Load CD OSD option on the PSX core main menu and not having to juggle the lid state through the miscellaneous menu. This state persists until the user either reloads the core entirely, or uses the Reset OSD option. 