### PR TITLE
file_io: Expanded ScanDirectory file skipping to include boot#.rom files

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1625,7 +1625,14 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 					//skip non-selectable files
 					if (!strcasecmp(de->d_name, "menu.rbf")) continue;
 					if (!strncasecmp(de->d_name, "menu_20", 7)) continue;
-					if (!strcasecmp(de->d_name, "boot.rom")) continue;
+					if (!strncasecmp(de->d_name, "boot", 4))
+					{
+						int len = strlen(de->d_name);
+						if ((len == 8 || (len == 9 && de->d_name[4] >= '0' && de->d_name[4] <= '9')) && !strcasecmp(de->d_name + len - 4, ".rom"))
+						{
+							continue;
+						}
+					}
 
 					//check the prefix if given
 					if (prefix && strncasecmp(prefix, de->d_name, strlen(prefix))) continue;


### PR DESCRIPTION
Some cores such as the Intellivision and Atari Jaguar have multiple bios files they can automatically load labelled boot0.rom, boot1.rom, etc. These cores also support loading ROM files with the .rom extension. The file skipping already skips any files named boot.rom, but these extra bios files are not skipped and still display in the file loading menus for these cores.

This expands the existing file skipping rule to include these numbered boot.rom files, from 0-9.