### PR TITLE
Filter more bios files

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1629,6 +1629,8 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 					if (!strcasecmp(de->d_name, "boot0.rom")) continue;
 					if (!strcasecmp(de->d_name, "boot1.rom")) continue;
 					if (!strcasecmp(de->d_name, "boot2.rom")) continue;
+					if (!strcasecmp(de->d_name, "boot3.rom")) continue;
+					if (!strcasecmp(de->d_name, "cd_bios.rom")) continue;
 
 					//check the prefix if given
 					if (prefix && strncasecmp(prefix, de->d_name, strlen(prefix))) continue;


### PR DESCRIPTION
Some cores use more than boot.rom (jaguar uses boot1 and boot2). There is probably a better way to do this, but I didn't want to start futzing with string matching or other things way above my pay grade.