### PR TITLE
N64: Tiny fix

### DIFF
--- a/support/n64/n64.cpp
+++ b/support/n64/n64.cpp
@@ -532,7 +532,7 @@ static void trim(char* out, size_t max_len, const char* str)
 	}
 
 	// Trim trailing space
-	end = str + strnlen(str, max_len) - 1;
+	end = str + strnlen(str, out_size) - 1;
 	while (end > str && isspace(*end)) {
 		end--;
 	}


### PR DESCRIPTION
There was an "off by one" error that made internal titles cut short to 19 characters instead of 20.
"DUKE NUKEM ZERO HOUR" became "DUKE NUKEM ZERO HOU", for example.