### PR TITLE
N64: Save file fix and refactoring.

### DIFF
--- a/support/n64/n64.h
+++ b/support/n64/n64.h
@@ -14,9 +14,8 @@ struct N64SaveFile;
 
 void n64_reset();
 void n64_poll();
-void n64_cheats_send(const void* buf_addr, const uint32_t size);
-int n64_rom_tx(const char* name, unsigned char index, uint32_t load_addr, uint32_t& file_crc);
-void n64_load_savedata(uint64_t lba, int ack, uint64_t& buffer_lba, uint8_t* buffer, uint32_t buffer_size, uint32_t blksz, uint32_t sz);
-void n64_save_savedata(uint64_t lba, int ack, uint64_t& buffer_lba, uint8_t* buffer, uint32_t blksz, uint32_t sz);
+void n64_cheats_send(const void* buf_ptr, const uint32_t size);
+int n64_rom_tx(const char* name, const unsigned char index, const uint32_t load_addr, uint32_t& file_crc);
+bool n64_process_save(const bool use_save, const int op, const uint64_t sector_index, const uint32_t sector_size, const int ack_flags, uint64_t& confirmed_sector, uint8_t* buffer, const uint32_t buffer_capacity, uint32_t chunk_size);
 
 #endif

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3069,7 +3069,7 @@ void user_io_poll()
 			int ack = 0;
 			int op = 0;
 			static uint8_t buffer[16][16384];
-			uint64_t lba;
+			uint64_t lba = 0;
 			uint32_t blksz, blks, sz;
 
 			if (is_uneon() && i == 3)
@@ -3161,9 +3161,11 @@ void user_io_poll()
 				else if (op & 1) c64_readGCR(disk, lba, blks-1);
 				else break;
 			}
-			else if ((op == 2) && is_n64() && use_save)
+			else if (is_n64() && n64_process_save(use_save, op, lba, blksz, ack, buffer_lba[disk], buffer[disk], sizeof(*buffer), sz))
 			{
-				n64_save_savedata(lba, ack, buffer_lba[disk], buffer[disk], blksz, sz);
+				// Handled by N64 core logic.
+				// If n64_process_save returns false (e.g. use_save is off, or unsupported op), 
+				// it will fall through to the generic handler below.
 			}
 			else if (op == 2)
 			{
@@ -3214,10 +3216,6 @@ void user_io_poll()
 						}
 					}
 				}
-			}
-			else if ((op & 1) && is_n64() && use_save)
-			{
-				n64_load_savedata(lba, ack, buffer_lba[disk], buffer[disk], sizeof(*buffer), blksz, sz);
 			}
 			else if (op & 1)
 			{


### PR DESCRIPTION
Got rid of the annoying message you get when opening the menu in a game that uses cpak. It said "Saving..." even when there wasn't anything to save. Cleaned up and refactored the save file code. Much easier to follow now.