### PR TITLE
PSX: process save states before sending cue/metadata

### DIFF
--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -782,10 +782,10 @@ void psx_mount_cd(int f_index, int s_index, const char *filename)
 				mask = libCryptMask(&sbi_file);
 			}
 
+			process_ss(filename, name_len != 0);
 			send_cue_and_metadata(&toc, mask, region, reset);
 
 			user_io_set_index(f_index);
-			process_ss(filename, name_len != 0);
 
 			mount_cd(toc.end*CD_SECTOR_LEN, s_index);
 			loaded = 1;


### PR DESCRIPTION
This change goes along with  https://github.com/MiSTer-devel/PSX_MiSTer/commit/75144be73c6da78b76c87ec4141262b07f8e2480
