### PR TITLE
Detect PCXT variants in is_pcxt

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -283,7 +283,16 @@ char is_archie()
 static int is_pcxt_type = 0;
 char is_pcxt()
 {
-	if (!is_pcxt_type) is_pcxt_type = strcasecmp(orig_name, "PCXT") ? 2 : 1;
+	if (!is_pcxt_type)
+	{
+		if (!strcasecmp(orig_name, "PCXT") ||
+		    !strcasecmp(orig_name, "Tandy1000") ||
+			!strcasecmp(orig_name, "PCjr")
+		   )
+			is_pcxt_type = 1;
+		else
+			is_pcxt_type = 2;
+	}
 	return (is_pcxt_type == 1);
 }
 


### PR DESCRIPTION
Expand is_pcxt() to recognize Tandy1000 and PCjr as PCXT-class systems, while keeping the cached detection behavior.

I am working on splitting the current PCXT core into two (PCXT and Tandy1000) and in the future I will try to add the PCjr system. This change is essential for the identification of these systems to work correctly.