### PR TITLE
New feature signaling F12 key should be passed to core

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1095,6 +1095,12 @@ void MakeFile(const char *filename, const char *data)
 	fclose(file);
 }
 
+uint16_t f12_mod;
+char is_f12_mod_needed()
+{
+	return (is_x86() || is_pcxt() || is_archie() || (f12_mod != 0));
+}
+
 int GetUARTMode()
 {
 	struct stat filestat;
@@ -1671,6 +1677,8 @@ void user_io_init(const char *path, const char *xml)
 	if (uartmode < 3 || uartmode > 4) midilink = 0;
 	SetMidiLinkMode(midilink);
 	SetUARTMode(uartmode);
+
+	f12_mod = spi_uio_cmd(UIO_GET_F12_MOD);
 
 	if (!mgl_get()->count || is_menu() || is_st() || is_archie() || user_io_core_type() == CORE_TYPE_SHARPMZ)
 	{
@@ -4091,7 +4099,7 @@ void user_io_kbd(uint16_t key, int press)
 			{
 				if (is_menu() && !video_fb_state()) printf("PS2 code(make)%s for core: %d(0x%X)\n", (code & EXT) ? "(ext)" : "", code & 255, code & 255);
 				if (!osd_is_visible && !is_menu() && key == KEY_MENU && press == 3) open_joystick_setup();
-				else if ((has_menu() || osd_is_visible || (get_key_mod() & (LALT | RALT | RGUI | LGUI))) && (((key == KEY_F12) && ((!is_x86() && !is_pcxt() && !is_archie()) || (get_key_mod() & (RGUI | LGUI)))) || key == KEY_MENU))
+				else if ((has_menu() || osd_is_visible || (get_key_mod() & (LALT | RALT | RGUI | LGUI))) && (((key == KEY_F12) && (!is_f12_mod_needed() || (get_key_mod() & (RGUI | LGUI)))) || key == KEY_MENU))
 				{
 					block_F12 = 1;
 					if (press == 1) menu_key_set(KEY_F12);

--- a/user_io.h
+++ b/user_io.h
@@ -74,6 +74,7 @@
 #define UIO_GET_FB_PAR  0x40
 #define UIO_SET_YC_PAR  0x41
 #define UIO_GET_FR_CNT  0x42  // get frame counter
+#define UIO_GET_F12_MOD 0x43  // get framework menu key modifier
 
 // codes as used by 8bit for file loading from OSD
 #define FIO_FILE_TX     0x53


### PR DESCRIPTION
This patch allow core to signal to framework that F12 should be passed to core (as is done for 486, PCXT or Archie cores). Signaling is done without need to modify MiSTer main. I do believe this is cleaner solution. Currently I do have one core that needs F12 in a core (PMD85) and in future I might have one or two more....

There is linked pull request on a Template repository

Below there is an example how core can request for F12. If this "line" is not present default behavior is same as now.
Please mind there is a hard-coded exception for recent cores that need F12 (no need to update them).
`hps_io #(.CONF_STR(CONF_STR)) hps_io
(
....
	.f12_key_menu_mod(1)
);`