### PR TITLE
Initialize empty n64 save file with all 0xFF instead of zero (fixes s…

### DIFF
--- a/support/n64/n64.cpp
+++ b/support/n64/n64.cpp
@@ -412,7 +412,7 @@ struct N64SaveFile {
 		}
 
 		auto sz = this->get_size();
-		memset(save_file_buf, 0, sz);
+		memset(save_file_buf, 0xFF, sz);
 		bool found_old_data = false;
 
 		if (sz && FileExists(old_path, 0)) {


### PR DESCRIPTION
…ome game hangs)