### PR TITLE
Add support for analog triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ host
 *.user
 .vs
 MiSTer
+
+.DS_Store

--- a/input.h
+++ b/input.h
@@ -31,7 +31,7 @@
 
 #define NUMPLAYERS          6
 
-#define NUMBUTTONS         32
+#define NUMBUTTONS         36
 #define BUTTON_DPAD_COUNT  12 // dpad + 8 buttons
 
 #define SYS_BTN_RIGHT       0
@@ -70,6 +70,11 @@
 
 #define SPIN_LEFT          30
 #define SPIN_RIGHT         31
+
+#define SYS_AXIS_TL2       32
+#define SYS_AXIS_TR2       33
+#define SYS_AXIS_L2        34
+#define SYS_AXIS_R2        35
 
 #define KEY_EMU (KEY_MAX+1)
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -231,8 +231,8 @@ const char *config_autofire_msg[] = { "        AUTOFIRE OFF", "        AUTOFIRE 
 const char *config_joystick_mode[] = { "Digital", "Analog", "CD32", "Analog" };
 const char *config_button_turbo_msg[] = { "OFF", "FAST", "MEDIUM", "SLOW" };
 const char *config_button_turbo_choice_msg[] = { "A only", "B only", "A & B" };
-const char *joy_button_map[] = { "RIGHT", "LEFT", "DOWN", "UP", "BUTTON A", "BUTTON B", "BUTTON X", "BUTTON Y", "BUTTON L", "BUTTON R", "SELECT", "START", "KBD TOGGLE", "MENU", "    Stick 1: Tilt RIGHT", "    Stick 1: Tilt DOWN", "   Mouse emu X: Tilt RIGHT", "   Mouse emu Y: Tilt DOWN" };
-const char *joy_ana_map[] = { "    DPAD test: Press RIGHT", "    DPAD test: Press DOWN", "   Stick 1 Test: Tilt RIGHT", "   Stick 1 Test: Tilt DOWN", "   Stick 2 Test: Tilt RIGHT", "   Stick 2 Test: Tilt DOWN" };
+const char *joy_button_map[] = {"RIGHT", "LEFT", "DOWN", "UP", "BUTTON A", "BUTTON B", "BUTTON X", "BUTTON Y", "BUTTON L", "BUTTON R", "SELECT", "START", "KBD TOGGLE", "MENU", "    Stick 1: Tilt RIGHT", "    Stick 1: Tilt DOWN", "   Left trigger: PRESS", "   Right trigger: PRESS", "   Mouse emu X: Tilt RIGHT", "   Mouse emu Y: Tilt DOWN"};
+const char *joy_ana_map[] = {"    DPAD test: Press RIGHT", "    DPAD test: Press DOWN", "   Stick 1 Test: Tilt RIGHT", "   Stick 1 Test: Tilt DOWN", "   Stick 2 Test: Tilt RIGHT", "   Stick 2 Test: Tilt DOWN", "   Left trigger test: PRESS", "   Right trigger test: PRESS"};
 const char *config_stereo_msg[] = { "0%", "25%", "50%", "100%" };
 const char *config_uart_msg[] = { "      None", "       PPP", "   Console", "      MIDI", "     Modem"};
 const char *config_midilink_mode[] = {"Local", "Local", "  USB", "  UDP", "-----", "-----", "  USB" };
@@ -3896,7 +3896,7 @@ void HandleUI(void)
 			const char* p = 0;
 			if (get_map_button() < 0)
 			{
-				strcpy(s, joy_ana_map[get_map_button() + 6]);
+				strcpy(s, joy_ana_map[get_map_button() + 8]);
 				OsdWrite(7, "   Space/User \x16 Skip");
 			}
 			else if (get_map_button() < DPAD_NAMES)
@@ -6587,8 +6587,8 @@ void HandleUI(void)
 		strcpy(joy_bnames[SYS_BTN_OSD_KTGL - DPAD_NAMES], "Menu");
 		strcpy(joy_bnames[SYS_BTN_CNT_OK - DPAD_NAMES], "Menu: OK");
 		strcpy(joy_bnames[SYS_BTN_CNT_ESC - DPAD_NAMES], "Menu: Back");
-		joy_bcount = 20 + 1; //buttons + OSD/KTGL button
-		start_map_setting(joy_bcount + 6); // + dpad + Analog X/Y
+		joy_bcount = 20 + 2 + 1; //buttons + OSD/KTGL button
+		start_map_setting(joy_bcount + 6 + 2); // + dpad + Analog X/Y + 2 triggers
 		menustate = MENU_JOYDIGMAP;
 		menusub = 0;
 		break;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1735,6 +1735,29 @@ void user_io_r_analog_joystick(unsigned char joystick, char valueX, char valueY)
 	}
 }
 
+
+void user_io_l_trigger_analog_joystick(unsigned char joystick, unsigned char value)
+{
+
+	if (core_type == CORE_TYPE_8BIT)
+	{
+		spi_uio_cmd8_cont(UIO_ATRIGGER_L, joystick);
+		spi8(value);
+		DisableIO();
+	}
+}
+
+void user_io_r_trigger_analog_joystick(unsigned char joystick, unsigned char value)
+{
+
+	if (core_type == CORE_TYPE_8BIT)
+	{
+		spi_uio_cmd8_cont(UIO_ATRIGGER_R, joystick);
+		spi8(value);
+		DisableIO();
+	}
+}
+
 void user_io_digital_joystick(unsigned char joystick, uint32_t map, int newdir)
 {
 	uint8_t joy = (joystick>1 || !joyswap) ? joystick : joystick ^ 1;

--- a/user_io.h
+++ b/user_io.h
@@ -75,6 +75,8 @@
 #define UIO_SET_YC_PAR  0x41
 #define UIO_GET_FR_CNT  0x42  // get frame counter
 #define UIO_GET_F12_MOD 0x43  // get framework menu key modifier
+#define UIO_ATRIGGER_L  0x44
+#define UIO_ATRIGGER_R  0x45
 
 // codes as used by 8bit for file loading from OSD
 #define FIO_FILE_TX     0x53
@@ -209,6 +211,8 @@ int user_io_get_joy_transl();
 void user_io_digital_joystick(unsigned char, uint32_t, int);
 void user_io_l_analog_joystick(unsigned char, char, char);
 void user_io_r_analog_joystick(unsigned char, char, char);
+void user_io_l_trigger_analog_joystick(unsigned char joystick, unsigned char value);
+void user_io_r_trigger_analog_joystick(unsigned char joystick, unsigned char value);
 void user_io_set_joyswap(int swap);
 int user_io_get_joyswap();
 char user_io_osd_is_visible();


### PR DESCRIPTION
WIP, opening draft PR in case some of an unexpected objection/blocker to adding analog triggers, and further discussion.

Plan for PR:

- [x] Add mapping steps for analogue triggers
  - [ ] Simplify mapping (less steps)
- [x] Add runtime use of analogue triggers
- [x] Modify InputTest to support analog triggers ([PR here](https://github.com/MiSTer-devel/InputTest_MiSTer/pull/17))
- [ ] Add support in the gamepad controller db (currently disabled)
- [ ] Add controller input mapping migration v3->v4
- [ ] Account for path of controllers with digital triggers, emulating analogue triggers

- Testing
  - [x] Tested with the modified InputMapper and a Dualsense controller
  - [ ] Test more controllers (digital triggers)
  - [ ] Test more controllers (analogue triggers)
  - [ ] Test cores without changes, that use triggers (PSX, N64?)