### PR TITLE
Fix: ignore vga_mode=ypbpr unless direct video is active

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2937,7 +2937,7 @@ void user_io_send_buttons(char force)
 	if (cfg.vga_scaler) map |= CONF_VGA_SCALER;
 	if (cfg.vga_sog) map |= CONF_VGA_SOG;
 	if (cfg.csync) map |= CONF_CSYNC;
-	if ((cfg.vga_mode_int == 1) && (cfg.direct_video == 1)) map |= CONF_YPBPR;
+	if (cfg.vga_mode_int == 1) map |= CONF_YPBPR;
 	if (cfg.forced_scandoubler) map |= CONF_FORCED_SCANDOUBLER;
 	if (cfg.hdmi_audio_96k) map |= CONF_AUDIO_96K;
 	if (cfg.dvi_mode == 1) map |= CONF_DVI;


### PR DESCRIPTION
direct_video=2 is treated as a request and then resolved to:

- 1 when a known HDMI DAC is detected

- 0 for normal HDMI displays

Apply vga_mode=ypbpr only when direct video is actually active (direct_video==1).

Refresh HDMI CSC after direct_video=2 resolution so non-DAC HDMI stays RGB.