### PR TITLE
SNES: enable SuperFX (GSU) detection for HiROM ROMs

### DIFF
--- a/support/snes/snes.cpp
+++ b/support/snes/snes.cpp
@@ -321,7 +321,7 @@ uint8_t* snes_get_header(fileTYPE *f)
 					}
 
 					//GSU 7
-					if (buf[addr + Mapper] == 0x20 && (buf[addr + RomType] == 0x13 || buf[addr + RomType] == 0x14 || buf[addr + RomType] == 0x15 || buf[addr + RomType] == 0x1a))
+					if ((buf[addr + Mapper] == 0x20 || buf[addr + Mapper] == 0x21) && (buf[addr + RomType] == 0x13 || buf[addr + RomType] == 0x14 || buf[addr + RomType] == 0x15 || buf[addr + RomType] == 0x1a))
 					{
 						ramsz = buf[addr - 3];
 						if (ramsz == 0xFF) ramsz = 5; //StarFox


### PR DESCRIPTION
## Summary

One-line change: adds `|| buf[addr + Mapper] == 0x21` (HiROM) to the existing GSU cart type detection in `support/snes/snes.cpp`.

## Context

The GSU detection in `snes_get_header()` only checked `Mapper == 0x20` (LoROM). No commercial SNES game combined HiROM with SuperFX, but homebrew projects targeting the GSU-2 coprocessor can benefit from HiROM's 64KB contiguous bank layout.

The FPGA-side GSU core already supports this — `GSUMap.vhd` enables the GSU when `MAP_CTRL[7:4] == 0x7`, independent of the base mapping mode in the lower nibble. For HiROM+GSU, the type byte becomes `0x71` (upper nibble 7 = GSU, lower nibble 1 = HiROM).

## Test ROM

A standalone 4MB HiROM+GSU+MSU-1 test ROM is available:

**Repository:** https://github.com/astrobleem/SNES-HiRomGsuTest
**Download:** https://github.com/astrobleem/SNES-HiRomGsuTest/releases/tag/v1.2

![Screenshot](https://raw.githubusercontent.com/astrobleem/SNES-HiRomGsuTest/master/mesen_screenshot.png)

Note: I don't have a MiSTer to verify on hardware. The FPGA analysis suggests it should work since the GSU core's address handling is mapping-mode agnostic, but hardware testing would be appreciated.

## Related PRs (same fix, different platforms)

- **Mesen2**: [HiROM+GSU support](https://github.com/SourMesen/Mesen2/pull/89) — emulator core
- **bsnes**: [HiROM+GSU board support](https://github.com/bsnes-emu/bsnes/pull/380) — emulator core
- **sd2snes/FXPak Pro**: [SuperFX FPGA core for HiROM](https://github.com/mrehkopf/sd2snes/pull/289) — flash cartridge firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)