### PR TITLE
conslidate SPD/CSC hdmi packet transmission to reduce overhead

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -137,6 +137,7 @@ static const ini_var_t ini_vars[] =
 	{ "AUTOFIRE_RATES", (void *)(&(cfg.autofire_rates)), STRING, 0, sizeof(cfg.autofire_rates) - 1 },
 	{ "AUTOFIRE_ON_DIRECTIONS", (void *)(&(cfg.autofire_on_directions)), UINT8, 0, 1 },
 	{ "SCREENSHOT_IMAGE_FORMAT", (void *)(&(cfg.screenshot_image_format)), STRING, 0, sizeof(cfg.screenshot_image_format) - 1 },
+	{ "DV1_ENABLE", (void *)(&(cfg.dv1_enable)), UINT8, 0, 1 },
 
 };
 
@@ -602,6 +603,7 @@ void cfg_parse()
 	cfg_error_count = 0;
 	strcpy(cfg.autofire_rates, "10,15,30");
 	strcpy(cfg.screenshot_image_format, "png");
+	cfg.dv1_enable = 1;
 	
 	ini_parse(altcfg(), video_get_core_mode_name(1));
 	if (has_video_sections && !using_video_section)

--- a/cfg.h
+++ b/cfg.h
@@ -105,6 +105,7 @@ typedef struct {
 	char autofire_rates[3072];
 	uint8_t autofire_on_directions;
 	char screenshot_image_format[16];
+	uint8_t dv1_enable;
 
 } cfg_t;
 

--- a/video.cpp
+++ b/video.cpp
@@ -2991,7 +2991,7 @@ static void spd_config_update()
 {
 	if (use_freesync_spd) return;
 
-	if (cfg.direct_video)
+	if (cfg.direct_video && cfg.dv1_enable)
 	{
 		// Custom SPD IF for additional DV1 metadata
 		VideoInfo *vi = &current_video_info;

--- a/video.cpp
+++ b/video.cpp
@@ -1147,10 +1147,10 @@ static void hdmi_packet_set_data(uint8_t mask, uint8_t offset, uint8_t *data, in
 		}
 		else
 		{
-			for (int i = 0; i < size; i++)
+			res = i2c_smbus_write_block_data(fd, offset, size, data);
+			if (res < 0)
 			{
-				res = i2c_smbus_write_byte_data(fd, offset + i, data[i]);
-				if (res < 0) printf("i2c: SPD register write error (%02X %02x): %d\n", offset + i, data[i], res);
+				printf("i2c: packet block write error (%02X len=%d): %d\n", offset, size, res);
 			}
 
 			res = i2c_smbus_write_byte_data(fd, offset + 0x1F, 0x00);
@@ -1351,7 +1351,7 @@ static void hdmi_config_set_csc()
 	uint16_t clipMax = (!ypbpr && hdmi_limited_1) ? 0xEB0 : 0xFFF;
 
 	// pass to HDMI, use 0xA0 to set a mode of [-2 .. 2] per ADV7513 programming guide
-	uint8_t csc_data[] = {
+	uint8_t csc_coeff_data[] = {
 		0x18, (uint8_t)(ypbpr ? 0x86 : (0b10100000 | (((csc_int16[0] >> 8) & 0b00011111)))),  // csc Coefficients, Channel A
 		0x19, (uint8_t)(ypbpr ? 0xDF : (csc_int16[0] & 0xff)),
 		0x1A, (uint8_t)(ypbpr ? 0x1A : (csc_int16[1] >> 8)),
@@ -1377,8 +1377,10 @@ static void hdmi_config_set_csc()
 		0x2C, (uint8_t)(ypbpr ? 0x06 : (csc_int16[10] >> 8)),
 		0x2D, (uint8_t)(ypbpr ? 0xDF : (csc_int16[10] & 0xff)),
 		0x2E, (uint8_t)(ypbpr ? 0x07 : (csc_int16[11] >> 8)),
-		0x2F, (uint8_t)(ypbpr ? 0xE7 : (csc_int16[11] & 0xff)),
+		0x2F, (uint8_t)(ypbpr ? 0xE7 : (csc_int16[11] & 0xff))
+	};
 
+	uint8_t csc_clamp_data[] = {
 		0xC0, (uint8_t)(clipMin >> 8), // HDMI limited clamps
 		0xC1, (uint8_t)(clipMin & 0xff),
 		0xC2, (uint8_t)(clipMax >> 8),
@@ -1388,17 +1390,25 @@ static void hdmi_config_set_csc()
 	int fd = i2c_open(0x39, 0);
 	if (fd >= 0)
 	{
-		for (uint i = 0; i < sizeof(csc_data); i += 2)
+		int res;
+
+		// CSC matrix coefficients (0x18–0x2F)
+		res = i2c_smbus_write_block_data(fd, 0x18, sizeof(csc_coeff_data), csc_coeff_data);
+		if (res < 0)
 		{
-			int res = i2c_smbus_write_byte_data(fd, csc_data[i], csc_data[i + 1]);
-			if (res < 0) printf("i2c: write error (%02X %02X): %d\n", csc_data[i], csc_data[i + 1], res);
+			printf("i2c: CSC coeff write error (0x18 len=%zu): %d\n",
+				sizeof(csc_coeff_data), res);
+		}
+
+		// CSC clamp values (0xC0–0xC3)
+		res = i2c_smbus_write_block_data(fd, 0xC0, sizeof(csc_clamp_data), csc_clamp_data);
+		if (res < 0)
+		{
+			printf("i2c: CSC clamp write error (0xC0 len=%zu): %d\n",
+				sizeof(csc_clamp_data), res);
 		}
 
 		i2c_close(fd);
-	}
-	else
-	{
-		printf("*** ADV7513 not found on i2c bus! HDMI won't be available!\n");
 	}
 }
 

--- a/video.cpp
+++ b/video.cpp
@@ -1352,39 +1352,39 @@ static void hdmi_config_set_csc()
 
 	// pass to HDMI, use 0xA0 to set a mode of [-2 .. 2] per ADV7513 programming guide
 	uint8_t csc_coeff_data[] = {
-		0x18, (uint8_t)(ypbpr ? 0x86 : (0b10100000 | (((csc_int16[0] >> 8) & 0b00011111)))),  // csc Coefficients, Channel A
-		0x19, (uint8_t)(ypbpr ? 0xDF : (csc_int16[0] & 0xff)),
-		0x1A, (uint8_t)(ypbpr ? 0x1A : (csc_int16[1] >> 8)),
-		0x1B, (uint8_t)(ypbpr ? 0x3F : (csc_int16[1] & 0xff)),
-		0x1C, (uint8_t)(ypbpr ? 0x1E : (csc_int16[2] >> 8)),
-		0x1D, (uint8_t)(ypbpr ? 0xE2 : (csc_int16[2] & 0xff)),
-		0x1E, (uint8_t)(ypbpr ? 0x07 : (csc_int16[3] >> 8)),
-		0x1F, (uint8_t)(ypbpr ? 0xE7 : (csc_int16[3] & 0xff)),
+		(uint8_t)(ypbpr ? 0x86 : (0b10100000 | (((csc_int16[0] >> 8) & 0b00011111)))),  // csc Coefficients, Channel A
+		(uint8_t)(ypbpr ? 0xDF : (csc_int16[0] & 0xff)),
+		(uint8_t)(ypbpr ? 0x1A : (csc_int16[1] >> 8)),
+		(uint8_t)(ypbpr ? 0x3F : (csc_int16[1] & 0xff)),
+		(uint8_t)(ypbpr ? 0x1E : (csc_int16[2] >> 8)),
+		(uint8_t)(ypbpr ? 0xE2 : (csc_int16[2] & 0xff)),
+		(uint8_t)(ypbpr ? 0x07 : (csc_int16[3] >> 8)),
+		(uint8_t)(ypbpr ? 0xE7 : (csc_int16[3] & 0xff)),
 
-		0x20, (uint8_t)(ypbpr ? 0x04 : (csc_int16[4] >> 8)),  // csc Coefficients, Channel B
-		0x21, (uint8_t)(ypbpr ? 0x1C : (csc_int16[4] & 0xff)),
-		0x22, (uint8_t)(ypbpr ? 0x08 : (csc_int16[5] >> 8)),
-		0x23, (uint8_t)(ypbpr ? 0x11 : (csc_int16[5] & 0xff)),
-		0x24, (uint8_t)(ypbpr ? 0x01 : (csc_int16[6] >> 8)),
-		0x25, (uint8_t)(ypbpr ? 0x91 : (csc_int16[6] & 0xff)),
-		0x26, (uint8_t)(ypbpr ? 0x01 : (csc_int16[7] >> 8)),
-		0x27, (uint8_t)(ypbpr ? 0x00 : (csc_int16[7] & 0xff)),
+		(uint8_t)(ypbpr ? 0x04 : (csc_int16[4] >> 8)),  // csc Coefficients, Channel B
+		(uint8_t)(ypbpr ? 0x1C : (csc_int16[4] & 0xff)),
+		(uint8_t)(ypbpr ? 0x08 : (csc_int16[5] >> 8)),
+		(uint8_t)(ypbpr ? 0x11 : (csc_int16[5] & 0xff)),
+		(uint8_t)(ypbpr ? 0x01 : (csc_int16[6] >> 8)),
+		(uint8_t)(ypbpr ? 0x91 : (csc_int16[6] & 0xff)),
+		(uint8_t)(ypbpr ? 0x01 : (csc_int16[7] >> 8)),
+		(uint8_t)(ypbpr ? 0x00 : (csc_int16[7] & 0xff)),
 
-		0x28, (uint8_t)(ypbpr ? 0x1D : (csc_int16[8] >> 8)),  // csc Coefficients, Channel C
-		0x29, (uint8_t)(ypbpr ? 0xAE : (csc_int16[8] & 0xff)),
-		0x2A, (uint8_t)(ypbpr ? 0x1B : (csc_int16[9] >> 8)),
-		0x2B, (uint8_t)(ypbpr ? 0x73 : (csc_int16[9] & 0xff)),
-		0x2C, (uint8_t)(ypbpr ? 0x06 : (csc_int16[10] >> 8)),
-		0x2D, (uint8_t)(ypbpr ? 0xDF : (csc_int16[10] & 0xff)),
-		0x2E, (uint8_t)(ypbpr ? 0x07 : (csc_int16[11] >> 8)),
-		0x2F, (uint8_t)(ypbpr ? 0xE7 : (csc_int16[11] & 0xff))
+		(uint8_t)(ypbpr ? 0x1D : (csc_int16[8] >> 8)),  // csc Coefficients, Channel C
+		(uint8_t)(ypbpr ? 0xAE : (csc_int16[8] & 0xff)),
+		(uint8_t)(ypbpr ? 0x1B : (csc_int16[9] >> 8)),
+		(uint8_t)(ypbpr ? 0x73 : (csc_int16[9] & 0xff)),
+		(uint8_t)(ypbpr ? 0x06 : (csc_int16[10] >> 8)),
+		(uint8_t)(ypbpr ? 0xDF : (csc_int16[10] & 0xff)),
+		(uint8_t)(ypbpr ? 0x07 : (csc_int16[11] >> 8)),
+		(uint8_t)(ypbpr ? 0xE7 : (csc_int16[11] & 0xff))
 	};
 
 	uint8_t csc_clamp_data[] = {
-		0xC0, (uint8_t)(clipMin >> 8), // HDMI limited clamps
-		0xC1, (uint8_t)(clipMin & 0xff),
-		0xC2, (uint8_t)(clipMax >> 8),
-		0xC3, (uint8_t)(clipMax & 0xff)
+		(uint8_t)(clipMin >> 8), // HDMI limited clamps
+		(uint8_t)(clipMin & 0xff),
+		(uint8_t)(clipMax >> 8),
+		(uint8_t)(clipMax & 0xff)
 	};
 
 	int fd = i2c_open(0x39, 0);


### PR DESCRIPTION
Consolidate sending of SPD and CSC data into sending a few packets with a block of data vs a packet for every byte of data. This should speed up transmission of those packets (and reduce blocking in main) by reducing overhead.

This might help with issue #1146 if it is related to SPD. It also partially resolves #1127 