### PR TITLE
Parse EDID manufacturer even if header invalid. Update dv_dac.txt

### DIFF
--- a/dv_dac.txt
+++ b/dv_dac.txt
@@ -22,3 +22,5 @@
 # Known DACs
 0x48F4,0,0,,CS5213 DAC
 0x04EF,2,0,,AG6200 DAC
+0x48D8,0,0,0,Reflex Prism DAC
+0x2000,0,0,0,Analogue DAC

--- a/video.cpp
+++ b/video.cpp
@@ -100,6 +100,8 @@ static uint8_t last_vrr_mode = 0xFF;
 static float last_vrr_rate = 0.0f;
 static uint32_t last_vrr_vfp = 0;
 static uint8_t edid[256] = {};
+static uint16_t raw_edid_mfg_id = 0;
+static bool raw_edid_mfg_id_valid = false;
 
 struct vmode_t
 {
@@ -1784,11 +1786,18 @@ static int is_edid_valid()
 	return !memcmp(edid, magic, sizeof(magic));
 }
 
+static void cache_raw_edid_mfg_id()
+{
+	raw_edid_mfg_id = (edid[0x08] << 8) | edid[0x09];
+	raw_edid_mfg_id_valid = true;
+}
+
 static int get_active_edid()
 {
 	int fd = i2c_open(0x39, 0);
 	if (fd < 0)
 	{
+		raw_edid_mfg_id_valid = false;
 		printf("EDID: cannot find main i2c device\n");
 		return 0;
 	}
@@ -1798,6 +1807,7 @@ static int get_active_edid()
 	if (hpd_state < 0 || !(hpd_state & 0x20))
 	{
 		i2c_close(fd);
+		raw_edid_mfg_id_valid = false;
 		return 0;
 	}
 
@@ -1811,6 +1821,7 @@ static int get_active_edid()
 	fd = i2c_open(0x3f, 0);
 	if (fd < 0)
 	{
+		raw_edid_mfg_id_valid = false;
 		printf("EDID: cannot find i2c device.\n");
 		return 0;
 	}
@@ -1825,6 +1836,7 @@ static int get_active_edid()
 
 	i2c_close(fd);
 	printf("EDID:\n"); hexdump(edid, sizeof(edid), 0);
+	cache_raw_edid_mfg_id();
 
 	if (!is_edid_valid())
 	{
@@ -2452,10 +2464,16 @@ static int should_auto_enable_direct_video()
 		get_active_edid();
 	}
 
-	if (!is_edid_valid()) return 0;
-
-	// Check manufacturer ID (bytes 0x08-0x09)
-	uint16_t mfg_id = (edid[0x08] << 8) | edid[0x09];
+	uint16_t mfg_id = 0;
+	if (is_edid_valid()) {
+		// Check manufacturer ID (bytes 0x08-0x09)
+		mfg_id = (edid[0x08] << 8) | edid[0x09];
+	} else if (raw_edid_mfg_id_valid) {
+		mfg_id = raw_edid_mfg_id;
+		printf("EDID: Invalid header, using raw manufacturer ID 0x%04X for DAC detection.\n", mfg_id);
+	} else {
+		return 0;
+	}
 
 	// Check against known DACs from config
 	for (int i = 0; i < dac_config_count; i++) {


### PR DESCRIPTION
Some devices have invalid EDID, so manufacturer ID isn't parsed. This is useful for dv_dac.txt lookup.

Regression tested on:
Reflex Prism
Morph 4K
RetroTink 4K
iPad LCD Display
LG CX OLED

Added 2 new devices to dv_dac.txt