### PR TITLE
Power down unused ADV7513 CEC block

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -1516,6 +1516,7 @@ static void hdmi_config_init()
 
 		0xBB, 0x00,				// ADI required Write.
 		0xDE, 0x9C,				// ADI required Write.
+		0xE2, 0x01,				// Power down the CEC.
 		0xE4, 0x60,				// ADI required Write.
 		0xFA, 0x7D,				// Nbr of times to search for good phase
 
@@ -4110,5 +4111,4 @@ int video_get_rotated()
 {
   return current_video_info.rotated;
 }
-
 


### PR DESCRIPTION
Explicitly power down (disable) the HDMI CEC block/pin.

The [ADV7513 docs](https://www.analog.com/media/en/technical-documentation/user-guides/adv7513_programming_guide.pdf) suggest powering down the pin if it's not used:
> If CEC is not being used, then the CEC Power Down bit (0xE2[0]), can be set to 1.

In addition to potential minor power saving, this may also fix CEC weirdness on some hardware.

Please note that this PR does not [add CEC support](https://github.com/MiSTer-devel/Main_MiSTer/pull/1098). It shuts down CEC to avoid interfering with other CEC devices (like AV systems) connected to the TV.

- [x] Compiled and tested by author on a Superstation One, successfully boots as MiSTer v260413