### PR TITLE
video: add hdmi_spd option to disable HDMI SPD InfoFrames

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -25,6 +25,9 @@ hdmi_limited=0         ; 1 - use limited (16..235) color range over HDMI
 direct_video=0         ; 1 - enable core video timing over HDMI, use only with VGA converters.
                        ; 2 - auto-mode for HDMI DACs that report 1024x768 resolution (AG6200, CS5213). 
                        ; Power cycle when switching between HDMI displays and DACs. No hot-plug detection.
+hdmi_spd=1             ; 0 - disable HDMI SPD InfoFrames. Workaround for boards where SPD i2c writes
+                       ; are slow and cause OSD lag. Disabling loses Freesync VRR and direct_video
+                       ; scaler metadata; VESA Forum VRR (vrr_mode=3) still works.
 
 hdr=0                  ; 1 - enable HDR using HLG (recommended for most users)
                        ; 2 - enable HDR using the DCI P3 color space (use color controls to tweak, suggestion: set saturation to 80).

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -137,6 +137,7 @@ static const ini_var_t ini_vars[] =
 	{ "AUTOFIRE_RATES", (void *)(&(cfg.autofire_rates)), STRING, 0, sizeof(cfg.autofire_rates) - 1 },
 	{ "AUTOFIRE_ON_DIRECTIONS", (void *)(&(cfg.autofire_on_directions)), UINT8, 0, 1 },
 	{ "SCREENSHOT_IMAGE_FORMAT", (void *)(&(cfg.screenshot_image_format)), STRING, 0, sizeof(cfg.screenshot_image_format) - 1 },
+	{ "HDMI_SPD", (void *)(&(cfg.hdmi_spd)), UINT8, 0, 1 },
 
 };
 
@@ -602,6 +603,7 @@ void cfg_parse()
 	cfg_error_count = 0;
 	strcpy(cfg.autofire_rates, "10,15,30");
 	strcpy(cfg.screenshot_image_format, "png");
+	cfg.hdmi_spd = 1;
 	
 	ini_parse(altcfg(), video_get_core_mode_name(1));
 	if (has_video_sections && !using_video_section)

--- a/cfg.h
+++ b/cfg.h
@@ -105,6 +105,7 @@ typedef struct {
 	char autofire_rates[3072];
 	uint8_t autofire_on_directions;
 	char screenshot_image_format[16];
+	uint8_t hdmi_spd;
 
 } cfg_t;
 

--- a/video.cpp
+++ b/video.cpp
@@ -2015,6 +2015,7 @@ static void set_vrr_mode()
 	{
 		for (uint8_t i = 1; i < sizeof(vrr_modes) / sizeof(vrr_cap_t); i++)
 		{
+			if (i == VRR_FREESYNC && !cfg.hdmi_spd) continue;
 			if (vrr_modes[i].available)
 			{
 				use_vrr = i;
@@ -2024,7 +2025,7 @@ static void set_vrr_mode()
 	}
 	else if (cfg.vrr_mode == 2)
 	{ //force AMD Freesync
-		use_vrr = VRR_FREESYNC;
+		if (cfg.hdmi_spd) use_vrr = VRR_FREESYNC;
 	}
 	else if (cfg.vrr_mode == 3)
 	{ //force Vesa Forum VRR
@@ -2998,7 +2999,7 @@ static void set_yc_mode()
 
 static void spd_config_update()
 {
-	if (use_freesync_spd) return;
+	if (!cfg.hdmi_spd || use_freesync_spd) return;
 
 	if (cfg.direct_video)
 	{


### PR DESCRIPTION
## Summary

Adds a new `hdmi_spd` option to `MiSTer.ini` (default `1`) that lets users disable HDMI SPD InfoFrame transmission. Workaround for boards — notably QMTech clones — where SPD register writes to the ADV7513 are slow enough to cause visible OSD/menu lag (see #1146).

## Behavior when `hdmi_spd=0`

- `spd_config_update()` early-returns, skipping the DV1 and standard SPD InfoFrame payload construction and i2c writes triggered by video mode changes / OSD toggle.
- In `set_vrr_mode()`, Freesync VRR is treated as unavailable: autodetect (`vrr_mode=1`) falls through to VESA Forum VRR if available; forced Freesync (`vrr_mode=2`) leaves `use_vrr=0`. This keeps `use_vrr == VRR_FREESYNC` from being set when no Freesync signaling can actually reach the display, so the rest of the VRR state stays consistent.
- VESA Forum VRR (`vrr_mode=3`) is unaffected — it uses `hdmi_spare_config`, not SPD.
- `direct_video` still works over HDMI but loses the DV1 scaler metadata carried in the SPD InfoFrame.

Default `hdmi_spd=1` preserves existing behavior for everyone not affected.

## Test plan

- [x] Build passes on the ARM Linux cross toolchain (verified locally with `arm-none-linux-gnueabihf-g++`).
- [x] With `hdmi_spd=1` (default): normal operation on a DE10-Nano, Freesync and direct_video external scalers keep working.
- [ ] With `hdmi_spd=0` on an affected QMTech board: OSD opens responsively when F12 is hammered on the Minimig core; no lag buildup across core switches (Genesis, SNES, PS1, Amiga).
- [ ] With `hdmi_spd=0` and `vrr_mode=1`: autodetect selects VESA Forum VRR if the display supports it.
- [ ] With `hdmi_spd=0` and `vrr_mode=2`: VRR is disabled (no Freesync without SPD transport).

Fixes #1146