### PR TITLE
docs: search USB/CIFS/network for per-core doc folders

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -953,31 +953,35 @@ uint32_t getFileType(const char *name)
 	return st.st_mode;
 }
 
-int findPrefixDir(char *dir, size_t dir_len)
+static int findPrefixDir(const char *prefix, bool no_prefix_check, char *dir, size_t dir_len)
 {
-	// Searches for the core's folder in the following order:
-	// /media/usb<0..5>
-	// /media/usb<0..5>/games
-	// /media/network
-	// /media/network/games
-	// /media/fat/cifs
-	// /media/fat/cifs/games
-	// /media/fat
-	// /media/fat/games/
-	// if the core folder is not found anywhere,
-	// it will be created in /media/fat/games/<dir>
+	// Searches for dir in the following order per storage location:
+	// /media/usb<0..5>/<dir>          (only if no_prefix_check)
+	// /media/usb<0..5>/<prefix>/<dir>
+	// /media/network/<dir>            (only if no_prefix_check)
+	// /media/network/<prefix>/<dir>
+	// /media/fat/cifs/<dir>           (only if no_prefix_check)
+	// /media/fat/cifs/<prefix>/<dir>
+	// /media/fat/<dir>                (only if no_prefix_check)
+	// /media/fat/<prefix>/<dir>
+	//
+	// no_prefix_check enables the legacy layout where system folders lived
+	// directly at the storage root (e.g. /media/fat/SNES). That layout is
+	// no longer recommended; prefer <prefix>/<dir> for new folder types.
 	static char temp_dir[1024];
 
 	// Usb<0..5>
 	for (int x = 0; x < 6; x++) {
-		snprintf(temp_dir, 1024, "%s%d/%s", "../usb", x, dir);
-		if (isPathDirectory(temp_dir)) {
-			printf("Found USB dir: %s\n", temp_dir);
-			strncpy(dir, temp_dir, dir_len);
-			return 1;
+		if (no_prefix_check) {
+			snprintf(temp_dir, 1024, "%s%d/%s", "../usb", x, dir);
+			if (isPathDirectory(temp_dir)) {
+				printf("Found USB dir: %s\n", temp_dir);
+				strncpy(dir, temp_dir, dir_len);
+				return 1;
+			}
 		}
 
-		snprintf(temp_dir, 1024, "%s%d/%s/%s", "../usb", x, GAMES_DIR, dir);
+		snprintf(temp_dir, 1024, "%s%d/%s/%s", "../usb", x, prefix, dir);
 		if (isPathDirectory(temp_dir)) {
 			printf("Found USB dir: %s\n", temp_dir);
 			strncpy(dir, temp_dir, dir_len);
@@ -986,15 +990,17 @@ int findPrefixDir(char *dir, size_t dir_len)
 	}
 
 	// Network share in /media/network/
-	snprintf(temp_dir, 1024, "%s/%s", "../network", dir);
-	if (isPathDirectory(temp_dir)) {
-		printf("Found network dir: %s\n", temp_dir);
-		strncpy(dir, temp_dir, dir_len);
-		return 1;
+	if (no_prefix_check) {
+		snprintf(temp_dir, 1024, "%s/%s", "../network", dir);
+		if (isPathDirectory(temp_dir)) {
+			printf("Found network dir: %s\n", temp_dir);
+			strncpy(dir, temp_dir, dir_len);
+			return 1;
+		}
 	}
 
-	// Network share in /media/network/games
-	snprintf(temp_dir, 1024, "%s/%s/%s", "../network", GAMES_DIR, dir);
+	// Network share in /media/network/<prefix>
+	snprintf(temp_dir, 1024, "%s/%s/%s", "../network", prefix, dir);
 	if (isPathDirectory(temp_dir)) {
 		printf("Found network dir: %s\n", temp_dir);
 		strncpy(dir, temp_dir, dir_len);
@@ -1002,15 +1008,17 @@ int findPrefixDir(char *dir, size_t dir_len)
 	}
 
 	// CIFS_DIR directory in /media/fat/cifs
-	snprintf(temp_dir, 1024, "%s/%s", CIFS_DIR, dir);
-	if (isPathDirectory(temp_dir)) {
-		printf("Found CIFS dir: %s\n", temp_dir);
-		strncpy(dir, temp_dir, dir_len);
-		return 1;
+	if (no_prefix_check) {
+		snprintf(temp_dir, 1024, "%s/%s", CIFS_DIR, dir);
+		if (isPathDirectory(temp_dir)) {
+			printf("Found CIFS dir: %s\n", temp_dir);
+			strncpy(dir, temp_dir, dir_len);
+			return 1;
+		}
 	}
 
-	// CIFS_DIR/GAMES_DIR directory in /media/fat/cifs/games
-	snprintf(temp_dir, 1024, "%s/%s/%s", CIFS_DIR, GAMES_DIR, dir);
+	// CIFS_DIR/<prefix> directory in /media/fat/cifs/<prefix>
+	snprintf(temp_dir, 1024, "%s/%s/%s", CIFS_DIR, prefix, dir);
 	if (isPathDirectory(temp_dir)) {
 		printf("Found CIFS dir: %s\n", temp_dir);
 		strncpy(dir, temp_dir, dir_len);
@@ -1018,13 +1026,13 @@ int findPrefixDir(char *dir, size_t dir_len)
 	}
 
 	// media/fat
-	if (isPathDirectory(dir)) {
+	if (no_prefix_check && isPathDirectory(dir)) {
 		printf("Found existing: %s\n", dir);
 		return 1;
 	}
 
-	// media/fat/GAMES_DIR
-	snprintf(temp_dir, 1024, "%s/%s", GAMES_DIR, dir);
+	// media/fat/<prefix>
+	snprintf(temp_dir, 1024, "%s/%s", prefix, dir);
 	if (isPathDirectory(temp_dir)) {
 		printf("Found dir: %s\n", temp_dir);
 		strncpy(dir, temp_dir, dir_len);
@@ -1034,9 +1042,19 @@ int findPrefixDir(char *dir, size_t dir_len)
 	return 0;
 }
 
+int findGamesDir(char *dir, size_t dir_len)
+{
+	return findPrefixDir(GAMES_DIR, true, dir, dir_len);
+}
+
+int findDocsDir(char *dir, size_t dir_len)
+{
+	return findPrefixDir(DOCS_DIR, false, dir, dir_len);
+}
+
 void prefixGameDir(char *dir, size_t dir_len)
 {
-	if (!findPrefixDir(dir, dir_len))
+	if (!findGamesDir(dir, dir_len))
 	{
 		static char temp_dir[1024];
 

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -955,7 +955,7 @@ uint32_t getFileType(const char *name)
 
 static int findPrefixDir(const char *prefix, bool no_prefix_check, char *dir, size_t dir_len)
 {
-	// Searches for dir in the following order per storage location:
+	// Searches for the core's folder in the following order:
 	// /media/usb<0..5>/<dir>          (only if no_prefix_check)
 	// /media/usb<0..5>/<prefix>/<dir>
 	// /media/network/<dir>            (only if no_prefix_check)

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -967,7 +967,7 @@ static int findPrefixDir(const char *prefix, bool no_prefix_check, char *dir, si
 	//
 	// no_prefix_check enables the legacy layout where system folders lived
 	// directly at the storage root (e.g. /media/fat/SNES). That layout is
-	// no longer recommended; prefer <prefix>/<dir> for new folder types.
+	// no longer recommended; prefer <prefix>/<dir>.
 	static char temp_dir[1024];
 
 	// Usb<0..5>

--- a/file_io.h
+++ b/file_io.h
@@ -129,7 +129,8 @@ void AdjustDirectory(char *path);
 int ScanDirectory(char* path, int mode, const char *extension, int options, const char *prefix = NULL, const char *filter = NULL);
 
 void prefixGameDir(char *dir, size_t dir_len);
-int findPrefixDir(char *dir, size_t dir_len);
+int findGamesDir(char *dir, size_t dir_len);
+int findDocsDir(char *dir, size_t dir_len);
 
 const char *getStorageDir(int dev);
 const char *getRootDir();

--- a/menu.cpp
+++ b/menu.cpp
@@ -2972,10 +2972,13 @@ void HandleUI(void)
 				break;
 
 			case 15:
-				FileCreatePath(DOCS_DIR);
-				snprintf(Selected_tmp, sizeof(Selected_tmp), DOCS_DIR "/%s",user_io_get_core_name());
-				FileCreatePath(Selected_tmp);
-				SelectFile(Selected_tmp, "PDFTXTMD ",  SCANO_DIR | SCANO_TXT  , MENU_DOC_FILE_SELECTED, MENU_COMMON1);
+				snprintf(Selected_tmp, sizeof(Selected_tmp), "%s", user_io_get_core_name());
+				if (!findDocsDir(Selected_tmp, sizeof(Selected_tmp))) {
+					FileCreatePath(DOCS_DIR);
+					snprintf(Selected_tmp, sizeof(Selected_tmp), DOCS_DIR "/%s", user_io_get_core_name());
+					FileCreatePath(Selected_tmp);
+				}
+				SelectFile(Selected_tmp, "PDFTXTMD ", SCANO_DIR | SCANO_TXT, MENU_DOC_FILE_SELECTED, MENU_COMMON1);
 				break;
 
 			case 16:

--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -166,7 +166,7 @@ static void set_arcade_root(const char *path)
 	printf("arcade_root %s\n", arcade_root);
 
 	strcpy(mame_root, "mame");
-	if (findPrefixDir(mame_root, sizeof(mame_root)))
+	if (findGamesDir(mame_root, sizeof(mame_root)))
 	{
 		char *p = strrchr(mame_root, '/');
 		if (p) *p = 0;

--- a/support/sharpmz/sharpmz.cpp
+++ b/support/sharpmz/sharpmz.cpp
@@ -90,7 +90,7 @@ int sharpmz_file_write(fileTYPE *file, const char *fileName)
     char          fullPath[1024];
 
     strcpy(directoryPath,SHARPMZ_CORE_NAME);
-    findPrefixDir(directoryPath, sizeof(directoryPath));
+    findGamesDir(directoryPath, sizeof(directoryPath));
 
 
 


### PR DESCRIPTION
### The problem

Game manuals can be very large. Some users are starting to use manual collections that exceed 20 GB, which can take up too much space on SD cards. This is especially problematic for users with smaller SD cards.

### The solution

This change applies the same search procedure used for game subfolders to docs subfolders.

The only difference is that docs search does not resolve paths such as `/media/fat/NES`, while games search still does.

### Summary of the changes

- Introduces `findDocsDir` and `findGamesDir` functions.
- Replaces the old `findPrefixDir` calls with `findGamesDir`, while preserving the existing games search behavior.
- Makes `findPrefixDir` an internal helper used by both `findGamesDir` and `findDocsDir`; it now contains the shared search implementation.
- Changes menu behavior so the core-scoped docs subdirectory is only created when `findDocsDir` does not find an existing folder in any supported location.