### PR TITLE
 docs: Add per-game manual lookup and Manual menu entry

### DIFF
--- a/MiSTer.vcxproj
+++ b/MiSTer.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="DiskImage.cpp" />
     <ClCompile Include="file_io.cpp" />
     <ClCompile Include="fpga_io.cpp" />
+    <ClCompile Include="game_docs.cpp" />
     <ClCompile Include="gamecontroller_db.cpp" />
     <ClCompile Include="hardware.cpp" />
     <ClCompile Include="ide.cpp" />
@@ -134,6 +135,7 @@
     <ClInclude Include="fpga_nic301.h" />
     <ClInclude Include="fpga_reset_manager.h" />
     <ClInclude Include="fpga_system_manager.h" />
+    <ClInclude Include="game_docs.h" />
     <ClInclude Include="gamecontroller_db.h" />
     <ClInclude Include="hardware.h" />
     <ClInclude Include="ide.h" />

--- a/MiSTer.vcxproj.filters
+++ b/MiSTer.vcxproj.filters
@@ -121,6 +121,9 @@
     <ClCompile Include="cheats.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="game_docs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="scaler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -346,6 +349,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="cheats.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="game_docs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="scaler.h">

--- a/cheats.cpp
+++ b/cheats.cpp
@@ -89,106 +89,11 @@ struct CheatComp
 
 static char cheat_zip[1024] = {};
 
-static int find_by_crc(uint32_t romcrc)
+static int cheat_zip_validator(const char *path, void *ctx)
 {
-	if (!romcrc) return 0;
-
-	sprintf(cheat_zip, "%s/cheats/%s", getRootDir(), CoreName2);
-	DIR *d = opendir(cheat_zip);
-	if (!d)
-	{
-		printf("Couldn't open dir: %s\n", cheat_zip);
-		return 0;
-	}
-
-	struct dirent *de;
-	while ((de = readdir(d)))
-	{
-		if (de->d_type == DT_REG)
-		{
-			int len = strlen(de->d_name);
-			if (len >= 14 && de->d_name[len - 14] == '[' && !strcasecmp(de->d_name + len - 5, "].zip"))
-			{
-				uint32_t crc = 0;
-				if (sscanf(de->d_name + len - 14, "[%X].zip", &crc) == 1)
-				{
-					if (crc == romcrc)
-					{
-						strcat(cheat_zip, "/");
-						strcat(cheat_zip, de->d_name);
-						closedir(d);
-						return 1;
-					}
-				}
-			}
-		}
-	}
-
-	closedir(d);
-	return 0;
-}
-
-static int find_in_same_dir(const char *name)
-{
-	sprintf(cheat_zip, "%s/%s", getRootDir(), name);
-	char *p = strrchr(cheat_zip, '/'); //impossible to fail
-	*p = 0;
-
-	DIR *d = opendir(cheat_zip);
-	if (!d)
-	{
-		printf("Couldn't open dir: %s\n", cheat_zip);
-		return 0;
-	}
-
-	struct dirent *de;
-	while ((de = readdir(d)))
-	{
-		if (de->d_type == DT_REG)
-		{
-			int len = strlen(de->d_name);
-			if (len >= 4 && !strcasecmp(de->d_name + len - 4, ".zip"))
-			{
-				strcat(cheat_zip, "/");
-				strcat(cheat_zip, de->d_name);
-				closedir(d);
-				return 1;
-			}
-		}
-	}
-
-	closedir(d);
-	return 0;
-}
-
-
-bool cheat_init_psx(mz_zip_archive* _z, const char *rom_path)
-{
-	// lookup based on file name
-	const char *rom_name = strrchr(rom_path, '/');
-	if (rom_name)
-	{
-		sprintf(cheat_zip, "%s/cheats/%s%s", getRootDir(), CoreName2, rom_name);
-		char *p = strrchr(cheat_zip, '.');
-		if (p) *p = 0;
-		strcat(cheat_zip, ".zip");
-		printf("Trying cheat file: %s\n", cheat_zip);
-
-		memset(_z, 0, sizeof(mz_zip_archive));
-		if (mz_zip_reader_init_file(_z, cheat_zip, 0)) return true;
-	}
-
-	// lookup based on game ID
-	const char *game_id = psx_get_game_id();
-	if (game_id && game_id[0])
-	{
-		sprintf(cheat_zip, "%s/cheats/%s/%s.zip", getRootDir(), CoreName2, psx_get_game_id());
-		printf("Trying cheat file: %s\n", cheat_zip);
-		memset(_z, 0, sizeof(mz_zip_archive));
-		if (mz_zip_reader_init_file(_z, cheat_zip, 0)) return true;
-	}
-
-	return false;
+	mz_zip_archive *z = (mz_zip_archive *)ctx;
+	memset(z, 0, sizeof(mz_zip_archive));
+	return mz_zip_reader_init_file(z, path, 0);
 }
 
 void cheats_init_arcade(int unit_size, int max_active)
@@ -246,58 +151,24 @@ void cheats_init(const char *rom_path, uint32_t romcrc)
 		user_io_set_download(0);
 	}
 
-	if (!strcasestr(rom_path, ".zip"))
+	char core_dir[1024];
+	snprintf(core_dir, sizeof(core_dir), "%s/cheats/%s", getRootDir(), CoreName2);
+
+	const char *pcecd_dir = NULL;
+	char pcecd_cheats_dir[1024];
+	if (pcecd_using_cd())
 	{
-		sprintf(cheat_zip, "%s/%s", getRootDir(), rom_path);
-		char *p = strrchr(cheat_zip, '.');
-		if (p) *p = 0;
-		strcat(cheat_zip, ".zip");
+		snprintf(pcecd_cheats_dir, sizeof(pcecd_cheats_dir), "%s/cheats/%sCD", getRootDir(), CoreName2);
+		pcecd_dir = pcecd_cheats_dir;
 	}
 
 	mz_zip_archive _z = {};
+	gameAssetValidator validator = { cheat_zip_validator, &_z };
 
-	if (is_psx() && !mz_zip_reader_init_file(&_z, cheat_zip, 0))
+	if (!findGameAsset(cheat_zip, sizeof(cheat_zip), rom_path, romcrc, ".zip", core_dir, pcecd_dir, &validator))
 	{
-		if (!cheat_init_psx(&_z, rom_path))
-		{
-			printf("no cheat file found\n");
-			return;
-		}
-	}
-	else if (!mz_zip_reader_init_file(&_z, cheat_zip, 0))
-	{
-		memset(&_z, 0, sizeof(_z));
-		if (!(pcecd_using_cd() || is_megacd()) || !find_in_same_dir(rom_path) || !mz_zip_reader_init_file(&_z, cheat_zip, 0))
-		{
-			memset(&_z, 0, sizeof(_z));
-			const char *rom_name = strrchr(rom_path, '/');
-			if (rom_name)
-			{
-				sprintf(cheat_zip, "%s/cheats/%s%s%s", getRootDir(), CoreName2, pcecd_using_cd() ? "CD" : "", rom_name);
-				char *p = strrchr(cheat_zip, '.');
-				if (p) *p = 0;
-				if (pcecd_using_cd() || is_megacd()) strcat(cheat_zip, " []");
-				strcat(cheat_zip, ".zip");
-
-				if (!mz_zip_reader_init_file(&_z, cheat_zip, 0))
-				{
-					memset(&_z, 0, sizeof(_z));
-					if (!find_by_crc(romcrc) || !mz_zip_reader_init_file(&_z, cheat_zip, 0))
-					{
-						printf("no cheat file found\n");
-						return;
-					}
-				}
-			}
-			else
-			{
-				if (!find_by_crc(romcrc) || !mz_zip_reader_init_file(&_z, cheat_zip, 0))
-				{
-					printf("no cheat file found\n");
-					return;
-				}
-			}
-		}
+		printf("no cheat file found\n");
+		return;
 	}
 
 	printf("Using cheat file: %s\n", cheat_zip);

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -28,6 +28,7 @@
 #include "user_io.h"
 #include "cfg.h"
 #include "input.h"
+#include "support.h"
 #include "miniz.h"
 #include "scheduler.h"
 #include "video.h"
@@ -2144,4 +2145,169 @@ const char *FileReadLine(fileTextReader *reader)
 		}
 	}
 	return nullptr;
+}
+
+static int validAsset(const char *path, gameAssetValidator *validator)
+{
+	if (validator)
+	{
+		if (!validator->fn(path, validator->ctx)) return 0;
+	}
+	else if (!FileExists(path, 0))
+	{
+		return 0;
+	}
+
+	return 1;
+}
+
+static int findAssetByCrc(char *path, size_t path_len, uint32_t romcrc, const char *ext, const char *core_dir)
+{
+	if (!romcrc) return 0;
+
+	snprintf(path, path_len, "%s", core_dir);
+	DIR *d = opendir(path);
+	if (!d) {
+		printf("Couldn't open dir: %s\n", path);
+		return 0;
+	}
+
+	int ext_len = strlen(ext);
+	struct dirent *de;
+	while ((de = readdir(d)))
+	{
+		if (de->d_type == DT_REG) {
+			int len = strlen(de->d_name);
+			if (len < 10 + ext_len || strcasecmp(de->d_name + len - ext_len, ext)) continue;
+
+			int bracket_pos = len - 10 - ext_len;
+			if (de->d_name[bracket_pos] == '[' && de->d_name[len - ext_len - 1] == ']')
+			{
+				uint32_t crc = 0;
+				if (sscanf(de->d_name + bracket_pos + 1, "%8X", &crc) == 1)
+				{
+					if (crc == romcrc) {
+						strcat(path, "/");
+						strcat(path, de->d_name);
+						closedir(d);
+						return 1;
+					}
+				}
+			}
+		}
+	}
+
+	closedir(d);
+	return 0;
+}
+
+static int findAssetInSameDir(char *path, size_t path_len, const char *rom_path, const char *ext)
+{
+	snprintf(path, path_len, "%s", getFullPath(rom_path));
+	char *p = strrchr(path, '/'); // impossible to fail
+	*p = 0;
+
+	DIR *d = opendir(path);
+	if (!d)
+	{
+		printf("Couldn't open dir: %s\n", path);
+		return 0;
+	}
+
+	struct dirent *de;
+	while ((de = readdir(d)))
+	{
+		if (de->d_type == DT_REG)
+		{
+			int len = strlen(de->d_name);
+			if (len >= 4 && !strcasecmp(de->d_name + len - 4, ext))
+			{
+				strcat(path, "/");
+				strcat(path, de->d_name);
+				closedir(d);
+				return 1;
+			}
+		}
+	}
+
+	closedir(d);
+	return 0;
+}
+
+static bool findPsxAsset(char *path, size_t path_len, const char *rom_path, const char *ext, const char *core_dir, gameAssetValidator *validator)
+{
+	// lookup based on file name
+	const char *rom_name = strrchr(rom_path, '/');
+	if (rom_name)
+	{
+		snprintf(path, path_len, "%s%s", core_dir, rom_name);
+		char *p = strrchr(path, '.');
+		if (p) *p = 0;
+		strcat(path, ext);
+
+		if (validAsset(path, validator)) return true;
+	}
+
+	// lookup based on game ID
+	const char *game_id = psx_get_game_id();
+	if (game_id && game_id[0])
+	{
+		snprintf(path, path_len, "%s/%s%s", core_dir, game_id, ext);
+		if (validAsset(path, validator)) return true;
+	}
+
+	return false;
+}
+
+int findGameAsset(char *path, size_t path_len, const char *rom_path, uint32_t romcrc, const char *ext, const char *core_dir, const char *pcecd_dir, gameAssetValidator *validator)
+{
+	path[0] = 0;
+
+	if (!strcasestr(rom_path, ".zip"))
+	{
+		snprintf(path, path_len, "%s", getFullPath(rom_path));
+		char *p = strrchr(path, '.');
+		if (p) *p = 0;
+		strcat(path, ext);
+	}
+
+	if (is_psx() && !validAsset(path, validator))
+	{
+		if (!findPsxAsset(path, path_len, rom_path, ext, core_dir, validator))
+		{
+			return 0;
+		}
+	}
+	else if (!validAsset(path, validator))
+	{
+		if (!(pcecd_using_cd() || is_megacd()) || !findAssetInSameDir(path, path_len, rom_path, ext) || !validAsset(path, validator))
+		{
+			const char *rom_name = strrchr(rom_path, '/');
+			if (rom_name)
+			{
+				snprintf(path, path_len, "%s%s", pcecd_using_cd() ? pcecd_dir : core_dir, rom_name);
+				char *p = strrchr(path, '.');
+				if (p) *p = 0;
+				if (pcecd_using_cd() || is_megacd()) strcat(path, " []");
+				strcat(path, ext);
+
+				if (!validAsset(path, validator))
+				{
+					if (!findAssetByCrc(path, path_len, romcrc, ext, core_dir) || !validAsset(path, validator))
+					{
+						return 0;
+					}
+				}
+			}
+			else
+			{
+				if (!findAssetByCrc(path, path_len, romcrc, ext, core_dir) || !validAsset(path, validator))
+				{
+					return 0;
+				}
+			}
+		}
+	}
+
+	return 1;
 }

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -2271,40 +2271,48 @@ int findGameAsset(char *path, size_t path_len, const char *rom_path, uint32_t ro
 		strcat(path, ext);
 	}
 
-	if (is_psx() && !validAsset(path, validator))
+	if (validAsset(path, validator)) {
+		return 1;
+	}
+	else if (is_psx())
 	{
 		if (!findPsxAsset(path, path_len, rom_path, ext, core_dir, validator))
 		{
 			return 0;
 		}
 	}
-	else if (!validAsset(path, validator))
+	else
 	{
-		if (!(pcecd_using_cd() || is_megacd()) || !findAssetInSameDir(path, path_len, rom_path, ext) || !validAsset(path, validator))
+		if (pcecd_using_cd() || is_megacd())
 		{
-			const char *rom_name = strrchr(rom_path, '/');
-			if (rom_name)
+			if (findAssetInSameDir(path, path_len, rom_path, ext) && validAsset(path, validator))
 			{
-				snprintf(path, path_len, "%s%s", pcecd_using_cd() ? pcecd_dir : core_dir, rom_name);
-				char *p = strrchr(path, '.');
-				if (p) *p = 0;
-				if (pcecd_using_cd() || is_megacd()) strcat(path, " []");
-				strcat(path, ext);
-
-				if (!validAsset(path, validator))
-				{
-					if (!findAssetByCrc(path, path_len, romcrc, ext, core_dir) || !validAsset(path, validator))
-					{
-						return 0;
-					}
-				}
+				return 1;
 			}
-			else
+		}
+
+		const char *rom_name = strrchr(rom_path, '/');
+		if (rom_name)
+		{
+			snprintf(path, path_len, "%s%s", pcecd_using_cd() ? pcecd_dir : core_dir, rom_name);
+			char *p = strrchr(path, '.');
+			if (p) *p = 0;
+			if (pcecd_using_cd() || is_megacd()) strcat(path, " []");
+			strcat(path, ext);
+
+			if (!validAsset(path, validator))
 			{
 				if (!findAssetByCrc(path, path_len, romcrc, ext, core_dir) || !validAsset(path, validator))
 				{
 					return 0;
 				}
+			}
+		}
+		else
+		{
+			if (!findAssetByCrc(path, path_len, romcrc, ext, core_dir) || !validAsset(path, validator))
+			{
+				return 0;
 			}
 		}
 	}

--- a/file_io.h
+++ b/file_io.h
@@ -132,6 +132,22 @@ void prefixGameDir(char *dir, size_t dir_len);
 int findGamesDir(char *dir, size_t dir_len);
 int findDocsDir(char *dir, size_t dir_len);
 
+struct gameAssetValidator
+{
+	int (*fn)(const char *path, void *ctx);
+	void *ctx;
+};
+
+// If validator is NULL, candidates are accepted with FileExists(path, 0).
+int findGameAsset(char *path,
+	size_t path_len,
+	const char *rom_path,
+	uint32_t crc,
+	const char *ext,
+	const char *core_dir,
+	const char *pcecd_dir,
+	gameAssetValidator *validator);
+
 const char *getStorageDir(int dev);
 const char *getRootDir();
 const char *getFullPath(const char *name);

--- a/game_docs.cpp
+++ b/game_docs.cpp
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "game_docs.h"
+#include "file_io.h"
+#include "user_io.h"
+#include "support.h"
+
+static char manual_path[1024] = {};
+
+void game_docs_init(const char *rom_path, uint32_t romcrc)
+{
+	manual_path[0] = 0;
+
+	char manuals_dir[1024];
+	snprintf(manuals_dir, sizeof(manuals_dir), "%s", user_io_get_core_name2());
+	findDocsDir(manuals_dir, sizeof(manuals_dir));
+	strcat(manuals_dir, "/Manuals");
+
+	const char *pcecd_dir = NULL;
+	char pcecd_manuals_dir[1024];
+	if (pcecd_using_cd())
+	{
+		snprintf(pcecd_manuals_dir, sizeof(pcecd_manuals_dir), "%sCD", user_io_get_core_name2());
+		findDocsDir(pcecd_manuals_dir, sizeof(pcecd_manuals_dir));
+		strcat(pcecd_manuals_dir, "/Manuals");
+		pcecd_dir = pcecd_manuals_dir;
+	}
+
+	if (findGameAsset(manual_path, sizeof(manual_path), rom_path, romcrc, ".pdf", manuals_dir, pcecd_dir, NULL))
+	{
+		printf("Using manual file: %s\n", manual_path);
+	} else {
+		manual_path[0] = 0;
+		printf("No manual file found.\n");
+	}
+}
+
+int game_docs_manual_available()
+{
+	return manual_path[0] != 0;
+}
+
+const char *game_docs_get_manual()
+{
+	return manual_path;
+}

--- a/game_docs.h
+++ b/game_docs.h
@@ -1,0 +1,10 @@
+#ifndef GAME_DOCS_H
+#define GAME_DOCS_H
+
+#include <stdint.h>
+
+void game_docs_init(const char *rom_path, uint32_t romcrc);
+int game_docs_manual_available();
+const char *game_docs_get_manual();
+
+#endif

--- a/menu.cpp
+++ b/menu.cpp
@@ -56,6 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "input.h"
 #include "battery.h"
 #include "cheats.h"
+#include "game_docs.h"
 #include "video.h"
 #include "audio.h"
 #include "joymapping.h"
@@ -1115,6 +1116,7 @@ void HandleUI(void)
 	static unsigned long flash_timer = 0;
 	static int flash_state = 0;
 	static uint32_t dip_submenu;
+	static uint32_t manual_submenu;
 	static int need_reset = 0;
 	static int flat = 0;
 	static int menusub_parent = 0;
@@ -1850,6 +1852,7 @@ void HandleUI(void)
 			OsdSetTitle(page ? title : user_io_get_core_name());
 
 			dip_submenu = -1;
+			manual_submenu = -1;
 
 			int last_space = 0;
 
@@ -2022,6 +2025,17 @@ void HandleUI(void)
 						// check for 'C'heats
 						if (p[0] == 'C')
 						{
+							if (game_docs_manual_available())
+							{
+								manual_submenu = selentry;
+								MenuWrite(entry, " Manual", menusub == selentry, 0);
+
+								// add bit in menu mask
+								menumask = (menumask << 1) | 1;
+								entry++;
+								selentry++;
+							}
+
 							substrcpy(s, p, 1);
 							if (strlen(s))
 							{
@@ -2228,7 +2242,15 @@ void HandleUI(void)
 				select = 1;
 			}
 
-			if (dip_submenu == menusub && select)
+			if (manual_submenu == menusub)
+			{
+				if (select)
+				{
+					snprintf(selPath, sizeof(selPath), "%s", game_docs_get_manual());
+					menustate = MENU_DOC_FILE_SELECTED;
+				}
+			}
+			else if (dip_submenu == menusub && select)
 			{
 				menustate = MENU_ARCADE_DIP1;
 				menusub = 0;
@@ -2285,6 +2307,12 @@ void HandleUI(void)
 					{
 						strcpy(addon, p);
 						continue;
+					}
+
+					if (p[0] == 'C' && game_docs_manual_available())
+					{
+						if (entry == menusub) break;
+						entry++;
 					}
 
 					if (entry == menusub) break;
@@ -2586,8 +2614,11 @@ void HandleUI(void)
 						uint32_t n64_crc;
 						if (!n64_rom_tx(selPath, idx, load_addr, n64_crc)) 
                 Info("failed to load ROM");
-						else if (user_io_use_cheats() && !store_name) 
-                cheats_init(selPath, n64_crc);
+						else if (!store_name)
+						{
+							game_docs_init(selPath, n64_crc);
+							if (user_io_use_cheats()) cheats_init(selPath, n64_crc);
+						}
 					}
 					else if (is_c64() || is_c128())
 					{
@@ -2628,7 +2659,11 @@ void HandleUI(void)
 					else
 					{
 						user_io_file_tx(selPath, idx, opensave, 0, 0, load_addr);
-						if (user_io_use_cheats() && !store_name) cheats_init(selPath, user_io_get_file_crc());
+						if (!store_name)
+						{
+							game_docs_init(selPath, user_io_get_file_crc());
+							if (user_io_use_cheats()) cheats_init(selPath, user_io_get_file_crc());
+						}
 					}
 				}
 
@@ -2688,15 +2723,18 @@ void HandleUI(void)
 			else if (is_megacd())
 			{
 				mcd_set_image(ioctl_index, selPath);
+				game_docs_init(selPath, 0);
 			}
 			else if (is_pce())
 			{
 				pcecd_set_image(ioctl_index, selPath);
+				game_docs_init(selPath, 0);
 				cheats_init(selPath, 0);
 			}
 			else if (is_psx() && ioctl_index == 1)
 			{
 				psx_mount_cd(user_io_ext_idx(selPath, fs_pFileExt) << 6 | (menusub + 1), ioctl_index, selPath);
+				game_docs_init(selPath, 0);
 				cheats_init(selPath, 0);
 			}
 			else if (is_cdi())

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -28,6 +28,7 @@
 #include "scaler.h"
 #include "miniz.h"
 #include "cheats.h"
+#include "game_docs.h"
 #include "video.h"
 #include "audio.h"
 #include "shmem.h"
@@ -956,10 +957,12 @@ static void parse_config()
 					else if (is_megacd())
 					{
 						mcd_set_image(idx, str);
+						game_docs_init(str, 0);
 					}
 					else if (is_pce())
 					{
 						pcecd_set_image(idx, str);
+						game_docs_init(str, 0);
 						cheats_init(str, 0);
 					}
 					else
@@ -1595,7 +1598,8 @@ void user_io_init(const char *path, const char *xml)
 							}
 						}
 
-						// cheats for boot file
+						// cheats & game docs for boot file
+						game_docs_init("", user_io_get_file_crc());
 						if (user_io_use_cheats()) cheats_init("", user_io_get_file_crc());
 					}
 


### PR DESCRIPTION
**TL;DR**: Reuses the existing Cheats lookup to find a per-game PDF under `docs/<core>/Manuals/` and adds a "Manual" row above "Cheats" when one exists. Cheats behavior is unchanged.

Today, opening a game's manual means navigating to the OSD's second screen, finding the Helps menu, and searching the game by hand. This PR adds a one-click route from the running core: when a matching manual exists, a "Manual" row appears at the main OSD screen to load it directly.

Demo:
[https://youtu.be/AMzokF0NuE8](https://youtu.be/AMzokF0NuE8)

## Implementation

`cheats.cpp` shrinks by ~140 lines. Its lookup is now a shared helper, `findGameAsset()` in `file_io.cpp`. New `game_docs.cpp` calls `findGameAsset` with `.pdf` and the manuals dirs. `menu.cpp` adds one synthetic row gated on `game_docs_manual_available()` that opens the manual in the PDF viewer; `user_io.cpp` calls `game_docs_init()` at game/image load. Folder discovery reuses `findDocsDir` from #1164.

Two separated commits to facilitate review. First one contains most of the implementation.

**Commit 1** — extract + Manual entry. Cheats' lookup is extracted into `findGameAsset` and lightly generalized to accept an extension and an optional asset-specific validator. There is a 1:1 code equivalence in that function to previous cheat lookup code to facilitate the code comparison during the review. The Cheats call site passes parameters that reproduce its prior behavior: same matching order (filename → CRC → PSX → Mega CD / PC Engine CD), same fallback. The Manual row only appears when a PDF resolves. No menu clutter on cores/games without manuals.

**Commit 2** — simplifies `findGameAsset` itself (early returns, drops a redundant pass, clearer branching). Same simplification benefits Cheats.
