### PR TITLE
Lookahead Update

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -36,7 +36,7 @@ video_off=0            ; output black frame in Menu core after timeout (is secon
 video_off_hdmi=0       ; 1 - power down HDMI on video_off timeout (TV can sleep), 0 - keep HDMI active
 osd_rotate=0           ; Display OSD menu rotated,  0 - no rotation, 1 - rotate right (+90°), 2 - rotate left (-90°)                  
 vga_sog=0              ; 1 - enable sync on green (needs analog I/O board v6.0 or newer).
-lookahead=2            ; 0 - off, 1–3 - scroll list up to 3 items ahead of cursor near top/bottom
+lookahead=1            ; 1 - keep cursor centered while scrolling, 0 - only scroll at list edges
 
 
 ; 1 - enables the recent file loaded/mounted.

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -131,7 +131,7 @@ static const ini_var_t ini_vars[] =
 	{ "OSD_LOCK", (void*)(&(cfg.osd_lock)), STRING, 0, sizeof(cfg.osd_lock) - 1 },
 	{ "OSD_LOCK_TIME", (void*)(&(cfg.osd_lock_time)), UINT16, 0, 60 },
 	{ "DEBUG", (void *)(&(cfg.debug)), UINT8, 0, 1 },
-	{ "LOOKAHEAD", (void *)(&(cfg.lookahead)), UINT8, 0, 3 },
+	{ "LOOKAHEAD", (void *)(&(cfg.lookahead)), UINT8, 0, 1 },
 	{ "MAIN", (void*)(&(cfg.main)), STRING, 0, sizeof(cfg.main) - 1 },
 	{ "VFILTER_INTERLACE_DEFAULT", (void*)(&(cfg.vfilter_interlace_default)), STRING, 0, sizeof(cfg.vfilter_interlace_default) - 1 },
 	{ "AUTOFIRE_RATES", (void *)(&(cfg.autofire_rates)), STRING, 0, sizeof(cfg.autofire_rates) - 1 },
@@ -587,7 +587,7 @@ void cfg_parse()
 	cfg.rumble = 1;
 	cfg.wheel_force = 50;
 	cfg.dvi_mode = 2;
-	cfg.lookahead = 2;
+	cfg.lookahead = 1;
 	cfg.hdr = 0;
 	cfg.hdr_max_nits = 1000;
 	cfg.hdr_avg_nits = 250;

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -66,6 +66,42 @@ static int iFirstEntry = 0;
 static char full_path[2100];
 uint8_t loadbuf[LOADBUF_SZ];
 
+static int flist_last_first_entry()
+{
+	int last = (int)DirItem.size() - OsdGetSize();
+	return last > 0 ? last : 0;
+}
+
+static void flist_center_selected()
+{
+	int count = (int)DirItem.size();
+	if (!count || OsdGetSize() <= 0)
+	{
+		iSelectedEntry = 0;
+		iFirstEntry = 0;
+		return;
+	}
+
+	if (iSelectedEntry < 0) iSelectedEntry = 0;
+	if (iSelectedEntry >= count) iSelectedEntry = count - 1;
+
+	if (cfg.lookahead)
+	{
+		iFirstEntry = iSelectedEntry - (OsdGetSize() / 2);
+	}
+	else if (iSelectedEntry < iFirstEntry)
+	{
+		iFirstEntry = iSelectedEntry;
+	}
+	else if (iSelectedEntry >= iFirstEntry + OsdGetSize())
+	{
+		iFirstEntry = iSelectedEntry - OsdGetSize() + 1;
+	}
+
+	if (iFirstEntry < 0) iFirstEntry = 0;
+	if (iFirstEntry > flist_last_first_entry()) iFirstEntry = flist_last_first_entry();
+}
+
 fileTYPE::fileTYPE()
 {
 	filp = 0;
@@ -1756,9 +1792,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if(pos>=0)
 			{
 				iSelectedEntry = pos;
-				if (iSelectedEntry + (OsdGetSize() / 2) >= flist_nDirEntries()) iFirstEntry = flist_nDirEntries() - OsdGetSize();
-				else iFirstEntry = iSelectedEntry - (OsdGetSize() / 2) + 1;
-				if (iFirstEntry < 0) iFirstEntry = 0;
+				flist_center_selected();
 			}
 		}
 		return flist_nDirEntries();
@@ -1771,8 +1805,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 		if (mode == SCANF_END || (mode == SCANF_PREV && iSelectedEntry <= 0))
 		{
 			iSelectedEntry = flist_nDirEntries() - 1;
-			iFirstEntry = iSelectedEntry - OsdGetSize() + 1;
-			if (iFirstEntry < 0) iFirstEntry = 0;
+			flist_center_selected();
 			return 0;
 		}
 		else if (mode == SCANF_NEXT)
@@ -1780,15 +1813,13 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if(iSelectedEntry + 1 < flist_nDirEntries()) // scroll within visible items
 			{
 				iSelectedEntry++;
-				// Start scrolling when cursor is cfg.lookahead positions from bottom
-				if (iSelectedEntry > iFirstEntry + OsdGetSize() - (cfg.lookahead + 1)) iFirstEntry = iSelectedEntry - OsdGetSize() + (cfg.lookahead + 1);
 			}
             else
             {
 				// jump to first visible item
-				iFirstEntry = 0;
 				iSelectedEntry = 0;
             }
+			flist_center_selected();
             return 0;
 		}
 		else if (mode == SCANF_PREV)
@@ -1796,65 +1827,20 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if (iSelectedEntry > 0) // scroll within visible items
 			{
 				iSelectedEntry--;
-				// Start scrolling when cursor is cfg.lookahead positions from top
-				if (iSelectedEntry < iFirstEntry + cfg.lookahead) iFirstEntry = iSelectedEntry - cfg.lookahead;
-				if (iFirstEntry < 0) iFirstEntry = 0;
+				flist_center_selected();
 			}
             return 0;
 		}
 		else if (mode == SCANF_NEXT_PAGE)
 		{
-			int last_visible = iFirstEntry + OsdGetSize() - 1;
-			if (last_visible >= flist_nDirEntries()) last_visible = flist_nDirEntries() - 1;
-			int page_stop = iFirstEntry + OsdGetSize() - (cfg.lookahead + 1);
-			if (page_stop > last_visible) page_stop = last_visible;
-			if (page_stop < iFirstEntry) page_stop = iFirstEntry;
-
-			if (iSelectedEntry < page_stop)
-			{
-				iSelectedEntry = page_stop;
-			}
-			else
-			{
-				iFirstEntry += OsdGetSize();
-				if (iFirstEntry >= flist_nDirEntries())
-				{
-					iFirstEntry = flist_nDirEntries() - OsdGetSize();
-					if (iFirstEntry < 0) iFirstEntry = 0;
-				}
-				iSelectedEntry = iFirstEntry + OsdGetSize() - (cfg.lookahead + 1);
-				if (iSelectedEntry < iFirstEntry) iSelectedEntry = iFirstEntry;
-				if (iSelectedEntry >= flist_nDirEntries()) iSelectedEntry = flist_nDirEntries() - 1;
-			}
+			iSelectedEntry += OsdGetSize();
+			flist_center_selected();
 			return 0;
 		}
 		else if (mode == SCANF_PREV_PAGE)
 		{
-			int last_visible = iFirstEntry + OsdGetSize() - 1;
-			if (last_visible >= flist_nDirEntries()) last_visible = flist_nDirEntries() - 1;
-			int page_stop = iFirstEntry + cfg.lookahead;
-			if (page_stop > last_visible) page_stop = last_visible;
-
-			if (iSelectedEntry > page_stop)
-			{
-				iSelectedEntry = page_stop;
-			}
-			else
-			{
-				if (iFirstEntry > 0)
-				{
-					iFirstEntry -= OsdGetSize();
-					if (iFirstEntry < 0) iFirstEntry = 0;
-					iSelectedEntry = iFirstEntry + cfg.lookahead;
-					last_visible = iFirstEntry + OsdGetSize() - 1;
-					if (last_visible >= flist_nDirEntries()) last_visible = flist_nDirEntries() - 1;
-					if (iSelectedEntry > last_visible) iSelectedEntry = last_visible;
-				}
-				else
-				{
-					iSelectedEntry = 0;
-				}
-			}
+			iSelectedEntry -= OsdGetSize();
+			flist_center_selected();
 		}
 		else if (mode == SCANF_SET_ITEM)
 		{
@@ -1875,9 +1861,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if(pos>=0)
 			{
 				iSelectedEntry = pos;
-				if (iSelectedEntry + (OsdGetSize() / 2) >= flist_nDirEntries()) iFirstEntry = flist_nDirEntries() - OsdGetSize();
-				else iFirstEntry = iSelectedEntry - (OsdGetSize() / 2) + 1;
-				if (iFirstEntry < 0) iFirstEntry = 0;
+				flist_center_selected();
 			}
 		}
 		else if (mode == SCANF_NEXT_CHAR)
@@ -1908,9 +1892,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if (found >= 0)
 			{
 				iSelectedEntry = found;
-				if (iSelectedEntry + (OsdGetSize() / 2) >= flist_nDirEntries()) iFirstEntry = flist_nDirEntries() - OsdGetSize();
-				else iFirstEntry = iSelectedEntry - (OsdGetSize()/2) + 1;
-				if (iFirstEntry < 0) iFirstEntry = 0;
+				flist_center_selected();
 			}
 		}
 		else if (mode == SCANF_PREV_CHAR)
@@ -1949,9 +1931,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 			if (found >= 0)
 			{
 				iSelectedEntry = found;
-				if (iSelectedEntry + (OsdGetSize() / 2) >= flist_nDirEntries()) iFirstEntry = flist_nDirEntries() - OsdGetSize();
-				else iFirstEntry = iSelectedEntry - (OsdGetSize()/2) + 1;
-				if (iFirstEntry < 0) iFirstEntry = 0;
+				flist_center_selected();
 			}
 		}
 		else
@@ -1985,9 +1965,7 @@ int ScanDirectory(char* path, int mode, const char *extension, int options, cons
 				if (found >= 0)
 				{
 					iSelectedEntry = found;
-					if (iSelectedEntry + (OsdGetSize() / 2) >= flist_nDirEntries()) iFirstEntry = flist_nDirEntries() - OsdGetSize();
-					else iFirstEntry = iSelectedEntry - (OsdGetSize()/2) + 1;
-					if (iFirstEntry < 0) iFirstEntry = 0;
+					flist_center_selected();
 				}
 			}
 		}
@@ -2013,7 +1991,7 @@ int flist_iFirstEntry()
 
 void flist_iFirstEntryInc()
 {
-	iFirstEntry++;
+	if (iFirstEntry < flist_last_first_entry()) iFirstEntry++;
 }
 
 int flist_iSelectedEntry()

--- a/menu.cpp
+++ b/menu.cpp
@@ -7685,9 +7685,9 @@ void PrintDirectory(int expand)
 	if (expand)
 	{
 		int k = flist_iFirstEntry() + OsdGetSize() - 1;
-		if (flist_nDirEntries() && k == flist_iSelectedEntry() && k <= flist_nDirEntries()
+		if (flist_nDirEntries() && k == flist_iSelectedEntry() && k < flist_nDirEntries()
 			&& strlen(flist_DirItem(k)->altname) > 28 && !(!cfg.rbf_hide_datecode && flist_DirItem(k)->datecode[0])
-			&& flist_DirItem(k)->de.d_type != DT_DIR)
+			&& flist_DirItem(k)->de.d_type != DT_DIR && k < flist_nDirEntries() - 1)
 		{
 			//make room for last expanded line
 			flist_iFirstEntryInc();
@@ -7790,7 +7790,7 @@ void PrintDirectory(int expand)
 		OsdWriteOffset(i, s, sel, 0, 0, leftchar);
 		i++;
 
-		if (sel && len2)
+		if (sel && len2 && i < OsdGetSize())
 		{
 			len = strlen(flist_DirItem(k)->altname);
 			strcpy(s+1, flist_DirItem(k)->altname + len - len2);


### PR DESCRIPTION
Lookahead now scrolls from the center list item instead of 2-3 positions from the top/bottom entry. MiSTer.ini has a 0/1 setting to disable/enable lookahead. Please test before accepting if you have concerns.