### PR TITLE
F7 = Joypad Map

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -1323,6 +1323,13 @@ void HandleUI(void)
 			}
 			break;
 
+		case KEY_F7: // added: F7 activates joystick map if OSD is visible, or in menu core
+			if (menustate != MENU_SCRIPTS1 || script_finished)
+			{
+				menustate = MENU_JOYDIGMAP;
+			}
+			break;
+
 			// Within the menu the esc key acts as the menu key. problem:
 			// if the menu is left with a press of ESC, then the follwing
 			// break code for the ESC key when the key is released will


### PR DESCRIPTION
Keyboard F7 key at menu core or when OSD is open activates Joypad mapping.