### PR TITLE
Joypad Mapping v4 with Analog Trigger Support

### DIFF
--- a/gamecontroller_db.cpp
+++ b/gamecontroller_db.cpp
@@ -45,6 +45,10 @@ static const char *sdlname_to_mister_idx[] = {
 	"asysy",
 	NULL,
 	NULL,
+	"lefttrigger",
+	"righttrigger",
+	"leftstick",
+	"rightstick",
 };
 
 typedef struct {
@@ -100,7 +104,7 @@ static bool cdb_entry_matches(char *db_str)
 static int find_mister_button_num(char *sdl_name, bool *idx_high)
 {
 	*idx_high = false;
-	for(size_t i = 0; i < sizeof(sdlname_to_mister_idx)/sizeof(char *); i++)
+	for(size_t i = 0; i < sizeof(sdlname_to_mister_idx)/sizeof(sdlname_to_mister_idx[0]); i++)
 	{
 		const char *map_str = sdlname_to_mister_idx[i];
 		if (map_str && !strcmp(map_str, sdl_name)) return i;
@@ -117,6 +121,78 @@ static int find_mister_button_num(char *sdl_name, bool *idx_high)
 		return SYS_BTN_MENU_FUNC;
 	}
 	return -1;
+}
+
+static bool is_axis_token(const char *btn_name)
+{
+	if (!btn_name || !btn_name[0]) return false;
+	if (btn_name[0] == 'a') return true;
+	return (btn_name[0] == '-' || btn_name[0] == '+') && btn_name[1] == 'a';
+}
+
+static uint16_t axis_from_mapped_code(int mapped_code)
+{
+	return (mapped_code >= KEY_EMU) ? ((mapped_code - KEY_EMU) >> 1) : (uint16_t)mapped_code;
+}
+
+static int trigger_axis_released_near_max(int dev_fd, uint16_t axis)
+{
+	if (dev_fd < 0 || axis > ABS_MAX) return 0;
+
+	input_absinfo absinfo = {};
+	if (ioctl(dev_fd, EVIOCGABS(axis), &absinfo) < 0) return 0;
+
+	const int range = absinfo.maximum - absinfo.minimum;
+	if (range <= 1) return 0;
+
+	const int edge_threshold = (range / 8) > 4 ? (range / 8) : 4;
+	return absinfo.value >= (absinfo.maximum - edge_threshold);
+}
+
+static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_code, int dev_fd)
+{
+	if (!is_axis_token(btn_name)) return 0;
+
+	const uint16_t axis = axis_from_mapped_code(mapped_code);
+	if (axis > ABS_MAX) return 0;
+
+	uint32_t map = axis | MAP_FLAG_ANALOG | MAP_FLAG_TRIGGER;
+	if (btn_name[0] == '-' || btn_name[0] == '+')
+	{
+		map |= MAP_FLAG_CENTERED;
+		if (btn_name[0] == '-') map |= MAP_FLAG_NEGATIVE;
+	}
+	else if (trigger_axis_released_near_max(dev_fd, axis))
+	{
+		map |= MAP_FLAG_NEGATIVE;
+	}
+	return map;
+}
+
+static int trigger_button_code_from_axis_map(uint32_t axis_map)
+{
+	if (!axis_map) return -1;
+	return KEY_EMU + ((axis_map & MAP_AXIS_MASK) << 1) + ((axis_map & MAP_FLAG_NEGATIVE) ? 0 : 1);
+}
+
+static bool print_axis_mapping(const char *sdlname, uint32_t axis_map, uint16_t *abs_map)
+{
+	if (!axis_map) return false;
+
+	const uint16_t axis_idx = axis_map & MAP_AXIS_MASK;
+	for (unsigned int j = 0; j < ABS_MAX; j++)
+	{
+		if (abs_map[j] == axis_idx)
+		{
+			if (axis_map & MAP_FLAG_CENTERED)
+				printf("%s:%ca%d,", sdlname, (axis_map & MAP_FLAG_NEGATIVE) ? '-' : '+', j);
+			else
+				printf("%s:a%d,", sdlname, j);
+			return true;
+		}
+	}
+
+	return false;
 }
 
 
@@ -281,10 +357,17 @@ void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid,
 	printf("Gamecontrollerdb for mapping: %s,%s,", guid_str, name);
 	for(int i=0; i < NUMBUTTONS; i++)
 	{
-			if (i > SYS_BTN_START && i < SYS_BTN_OSD_KTGL) continue; //Skip mouse buttons
+			if (i >= SYS_MS_RIGHT && i <= SYS_MS_BTN_EMU) continue; //Skip mouse buttons
 			if (i == SYS_BTN_OSD_KTGL+2 && (cur_map[i] == cur_map[i-1])) continue;
+			if (i >= (int)(sizeof(sdlname_to_mister_idx)/sizeof(sdlname_to_mister_idx[0]))) continue;
 			const char *sdlname = sdlname_to_mister_idx[i];
 			if (!sdlname) continue;
+			if (i == SYS_BTN_L2 || i == SYS_BTN_R2)
+			{
+				const int trigger_axis_idx = SYS_AXIS_L2 + (i - SYS_BTN_L2);
+				if (print_axis_mapping(sdlname, cur_map[trigger_axis_idx], abs_map))
+					continue;
+			}
 			if (cur_map[i])
 			{
 				uint32_t i_code = cur_map[i] & 0xFFFF;
@@ -321,7 +404,7 @@ void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid,
 								}
 							}
 						}
-			 	} else if (cur_map[i] & 0x20000) { //Analog
+				} else if (cur_map[i] & MAP_FLAG_ANALOG) { //Analog
 					for(unsigned int j=0; j < sizeof(abs_map)/sizeof(uint16_t); j++)
 					{
 							if (abs_map[j] == i_code)
@@ -402,10 +485,20 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 				if (m_button_num != -1 && l_button_code != -1)
 				{
 					map_parsed = true;
-					fill_map[m_button_num] =  m_button_high ? ((l_button_code << 16) | fill_map[m_button_num]) : ((l_button_code & 0xFFFF)  | fill_map[m_button_num]);
-					if (m_button_num >= SYS_AXIS1_X && m_button_num <= SYS_AXIS_MX)
+					if ((m_button_num == SYS_BTN_L2 || m_button_num == SYS_BTN_R2) && is_axis_token(l_btn))
 					{
-						fill_map[m_button_num] = l_button_code | 0x20000;
+						const int trigger_axis_idx = SYS_AXIS_L2 + (m_button_num - SYS_BTN_L2);
+						fill_map[trigger_axis_idx] = trigger_axis_map_from_token(l_btn, l_button_code, dev_fd);
+						if (fill_map[trigger_axis_idx])
+							fill_map[m_button_num] = trigger_button_code_from_axis_map(fill_map[trigger_axis_idx]);
+					}
+					else
+					{
+						fill_map[m_button_num] =  m_button_high ? ((l_button_code << 16) | fill_map[m_button_num]) : ((l_button_code & 0xFFFF)  | fill_map[m_button_num]);
+					}
+					if (m_button_num >= SYS_AXIS1_X && m_button_num <= SYS_AXIS_Y)
+					{
+						fill_map[m_button_num] = l_button_code | MAP_FLAG_ANALOG;
 					}
 				}
 			}
@@ -454,13 +547,13 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
     if (!fill_map[SYS_AXIS1_X] && fill_map[SYS_BTN_RIGHT] > KEY_EMU)
     {
 						uint16_t axis_idx = (fill_map[SYS_BTN_RIGHT] - KEY_EMU) >> 1;
-            fill_map[SYS_AXIS1_X] = axis_idx | 0x20000;
+            fill_map[SYS_AXIS1_X] = axis_idx | MAP_FLAG_ANALOG;
     }
 
     if (!fill_map[SYS_AXIS1_Y] && fill_map[SYS_BTN_UP] > KEY_EMU)
     {
 						uint16_t axis_idx = (fill_map[SYS_BTN_UP] - KEY_EMU) >> 1;
-            fill_map[SYS_AXIS1_Y] = axis_idx | 0x20000;
+            fill_map[SYS_AXIS1_Y] = axis_idx | MAP_FLAG_ANALOG;
     }
 
 

--- a/gamecontroller_db.cpp
+++ b/gamecontroller_db.cpp
@@ -144,6 +144,12 @@ static bool is_axis_token(const char *btn_name)
 	return (btn_name[0] == '-' || btn_name[0] == '+') && btn_name[1] == 'a';
 }
 
+static bool axis_token_is_inverted(const char *btn_name)
+{
+	const size_t len = btn_name ? strlen(btn_name) : 0;
+	return len && btn_name[len - 1] == '~';
+}
+
 static uint16_t axis_from_mapped_code(int mapped_code)
 {
 	return (mapped_code >= KEY_EMU) ? ((mapped_code - KEY_EMU) >> 1) : (uint16_t)mapped_code;
@@ -217,16 +223,19 @@ static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_cod
 	const uint16_t axis = axis_from_mapped_code(mapped_code);
 	if (axis > ABS_MAX) return 0;
 
+	const bool inverted = axis_token_is_inverted(btn_name);
 	uint32_t map = axis | MAP_FLAG_ANALOG | MAP_FLAG_TRIGGER;
 	if (btn_name[0] == '-' || btn_name[0] == '+')
 	{
 		map |= MAP_FLAG_CENTERED;
-		if (btn_name[0] == '-') map |= MAP_FLAG_NEGATIVE;
+		if ((btn_name[0] == '-') != inverted) map |= MAP_FLAG_NEGATIVE;
 	}
-	else
+	else if (inverted)
 	{
-		map |= GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION;
+		map |= MAP_FLAG_NEGATIVE;
 	}
+	else map |= GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION;
+
 	return map;
 }
 
@@ -265,7 +274,7 @@ static bool print_axis_mapping(const char *sdlname, uint32_t axis_map, uint16_t 
 			if (axis_map & MAP_FLAG_CENTERED)
 				printf("%s:%ca%d,", sdlname, (axis_map & MAP_FLAG_NEGATIVE) ? '-' : '+', j);
 			else
-				printf("%s:a%d,", sdlname, j);
+				printf("%s:a%d%s,", sdlname, j, (axis_map & MAP_FLAG_NEGATIVE) ? "~" : "");
 			return true;
 		}
 	}
@@ -317,6 +326,7 @@ static int find_linux_code_for_button(const char *btn_name, uint16_t *btn_map, u
 				int abs_axis = abs_map[aidx];
 				if (a_edge)
 				{
+					if (*suffix) a_edge = 3 - a_edge;
 					return KEY_EMU + (abs_axis << 1) - 1 + a_edge;
 				}
 				return abs_axis;
@@ -500,7 +510,7 @@ void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid,
 					{
 							if (abs_map[j] == i_code)
 							{
-								printf("%s:a%d,", sdlname, j);
+								printf("%s:a%d%s,", sdlname, j, (cur_map[i] & MAP_FLAG_INVERT) ? "~" : "");
 								break;
 							}
 					}
@@ -590,7 +600,8 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 					}
 					if (m_button_num >= SYS_AXIS1_X && m_button_num <= SYS_AXIS_Y)
 					{
-						fill_map[m_button_num] = l_button_code | MAP_FLAG_ANALOG;
+						fill_map[m_button_num] = l_button_code | MAP_FLAG_ANALOG |
+							(axis_token_is_inverted(l_btn) ? MAP_FLAG_INVERT : 0);
 					}
 				}
 			}

--- a/gamecontroller_db.cpp
+++ b/gamecontroller_db.cpp
@@ -51,8 +51,12 @@ static const char *sdlname_to_mister_idx[] = {
 	"rightstick",
 };
 
+#define GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION 0x80000000U
+
 typedef struct {
 	uint16_t id[4]; //bustype, vid, pid, version
+	char core_name[32];
+	char orig_core_name[32];
 	uint32_t map[NUMBUTTONS];
 } controllerdb_entry;
 
@@ -149,7 +153,7 @@ static int trigger_axis_released_near_max(int dev_fd, uint16_t axis)
 	return absinfo.value >= (absinfo.maximum - edge_threshold);
 }
 
-static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_code, int dev_fd)
+static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_code)
 {
 	if (!is_axis_token(btn_name)) return 0;
 
@@ -162,9 +166,9 @@ static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_cod
 		map |= MAP_FLAG_CENTERED;
 		if (btn_name[0] == '-') map |= MAP_FLAG_NEGATIVE;
 	}
-	else if (trigger_axis_released_near_max(dev_fd, axis))
+	else
 	{
-		map |= MAP_FLAG_NEGATIVE;
+		map |= GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION;
 	}
 	return map;
 }
@@ -173,6 +177,23 @@ static int trigger_button_code_from_axis_map(uint32_t axis_map)
 {
 	if (!axis_map) return -1;
 	return KEY_EMU + ((axis_map & MAP_AXIS_MASK) << 1) + ((axis_map & MAP_FLAG_NEGATIVE) ? 0 : 1);
+}
+
+static void resolve_trigger_axis_directions(int dev_fd, uint32_t *map)
+{
+	for (int trigger = 0; trigger < 2; trigger++)
+	{
+		const int axis_idx = SYS_AXIS_L2 + trigger;
+		uint32_t axis_map = map[axis_idx];
+		if (!(axis_map & GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION)) continue;
+
+		axis_map &= ~(GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION | MAP_FLAG_NEGATIVE);
+		if (trigger_axis_released_near_max(dev_fd, axis_map & MAP_AXIS_MASK))
+			axis_map |= MAP_FLAG_NEGATIVE;
+
+		map[axis_idx] = axis_map;
+		map[SYS_BTN_L2 + trigger] = trigger_button_code_from_axis_map(axis_map);
+	}
 }
 
 static bool print_axis_mapping(const char *sdlname, uint32_t axis_map, uint16_t *abs_map)
@@ -488,7 +509,7 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 					if ((m_button_num == SYS_BTN_L2 || m_button_num == SYS_BTN_R2) && is_axis_token(l_btn))
 					{
 						const int trigger_axis_idx = SYS_AXIS_L2 + (m_button_num - SYS_BTN_L2);
-						fill_map[trigger_axis_idx] = trigger_axis_map_from_token(l_btn, l_button_code, dev_fd);
+						fill_map[trigger_axis_idx] = trigger_axis_map_from_token(l_btn, l_button_code);
 						if (fill_map[trigger_axis_idx])
 							fill_map[m_button_num] = trigger_button_code_from_axis_map(fill_map[trigger_axis_idx]);
 					}
@@ -610,7 +631,10 @@ static int gcdb_controller_idx(uint16_t bustype, uint16_t vid, uint16_t pid, uin
 {
 	for (int i=0; i < MAX_GCDB_ENTRIES; i++)
 	{
-		if (db_maps[i].id[0] == bustype && db_maps[i].id[1] == vid && db_maps[i].id[2] == pid && db_maps[i].id[3] == version)
+		if (db_maps[i].id[0] == bustype && db_maps[i].id[1] == vid &&
+			db_maps[i].id[2] == pid && db_maps[i].id[3] == version &&
+			!strcmp(db_maps[i].core_name, user_io_get_core_name()) &&
+			!strcmp(db_maps[i].orig_core_name, user_io_get_core_name(1)))
 		{
 			return i;
 		}
@@ -630,6 +654,8 @@ static void gcdb_cache_controller_map(uint16_t bustype, uint16_t vid, uint16_t p
 	db_maps[last_db_idx].id[1] = vid;
 	db_maps[last_db_idx].id[2] = pid;
 	db_maps[last_db_idx].id[3] = version;
+	snprintf(db_maps[last_db_idx].core_name, sizeof(db_maps[last_db_idx].core_name), "%s", user_io_get_core_name());
+	snprintf(db_maps[last_db_idx].orig_core_name, sizeof(db_maps[last_db_idx].orig_core_name), "%s", user_io_get_core_name(1));
 	memcpy(db_maps[last_db_idx].map, button_map, sizeof(uint32_t)*NUMBUTTONS);
 	last_db_idx = (last_db_idx +1) % MAX_GCDB_ENTRIES;
 }
@@ -642,6 +668,7 @@ bool gcdb_map_for_controller(uint16_t bustype, uint16_t vid, uint16_t pid, uint1
 		if (cache_idx != -1)
 		{
 			memcpy(fill_map, db_maps[cache_idx].map, sizeof(uint32_t)*NUMBUTTONS);
+			resolve_trigger_axis_directions(dev_fd, fill_map);
 
 			return true;
 		}
@@ -660,7 +687,9 @@ bool gcdb_map_for_controller(uint16_t bustype, uint16_t vid, uint16_t pid, uint1
 
 		if (found_entry)
 		{
+			// Cache unresolved maps so each physical device supplies its own trigger polarity.
 			gcdb_cache_controller_map(bustype, vid, pid, version, fill_map);
+			resolve_trigger_axis_directions(dev_fd, fill_map);
 			return true;
 		}
 		return false;

--- a/gamecontroller_db.cpp
+++ b/gamecontroller_db.cpp
@@ -52,6 +52,16 @@ static const char *sdlname_to_mister_idx[] = {
 };
 
 #define GCDB_MAP_FLAG_DETECT_TRIGGER_DIRECTION 0x80000000U
+#define MAX_GCDB_AXIS_BASELINES 32
+
+typedef struct {
+	int fd;
+	uint8_t valid[ABS_MAX + 1];
+	int32_t value[ABS_MAX + 1];
+} controller_axis_baseline;
+
+static controller_axis_baseline axis_baselines[MAX_GCDB_AXIS_BASELINES] = {};
+static int axis_baseline_count = 0;
 
 typedef struct {
 	uint16_t id[4]; //bustype, vid, pid, version
@@ -139,6 +149,51 @@ static uint16_t axis_from_mapped_code(int mapped_code)
 	return (mapped_code >= KEY_EMU) ? ((mapped_code - KEY_EMU) >> 1) : (uint16_t)mapped_code;
 }
 
+void gcdb_reset_axis_baselines()
+{
+	memset(axis_baselines, 0, sizeof(axis_baselines));
+	axis_baseline_count = 0;
+}
+
+void gcdb_capture_axis_baseline(int dev_fd)
+{
+	if (dev_fd < 0 || axis_baseline_count >= MAX_GCDB_AXIS_BASELINES) return;
+
+	controller_axis_baseline *baseline = &axis_baselines[axis_baseline_count++];
+	memset(baseline, 0, sizeof(*baseline));
+	baseline->fd = dev_fd;
+
+	unsigned char absbits[(ABS_MAX + 8) / 8] = {};
+	if (ioctl(dev_fd, EVIOCGBIT(EV_ABS, sizeof(absbits)), absbits) < 0) return;
+
+	for (int axis = 0; axis <= ABS_MAX; axis++)
+	{
+		if (!(absbits[axis / 8] & (1 << (axis % 8)))) continue;
+
+		input_absinfo absinfo = {};
+		if (ioctl(dev_fd, EVIOCGABS(axis), &absinfo) < 0) continue;
+
+		baseline->valid[axis] = 1;
+		baseline->value[axis] = absinfo.value;
+	}
+}
+
+static int gcdb_axis_baseline_value(int dev_fd, uint16_t axis, int32_t *value)
+{
+	if (axis > ABS_MAX || !value) return 0;
+
+	for (int i = 0; i < axis_baseline_count; i++)
+	{
+		if (axis_baselines[i].fd == dev_fd && axis_baselines[i].valid[axis])
+		{
+			*value = axis_baselines[i].value[axis];
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 static int trigger_axis_released_near_max(int dev_fd, uint16_t axis)
 {
 	if (dev_fd < 0 || axis > ABS_MAX) return 0;
@@ -150,7 +205,9 @@ static int trigger_axis_released_near_max(int dev_fd, uint16_t axis)
 	if (range <= 1) return 0;
 
 	const int edge_threshold = (range / 8) > 4 ? (range / 8) : 4;
-	return absinfo.value >= (absinfo.maximum - edge_threshold);
+	int32_t released_value = absinfo.value;
+	gcdb_axis_baseline_value(dev_fd, axis, &released_value);
+	return released_value >= (absinfo.maximum - edge_threshold);
 }
 
 static uint32_t trigger_axis_map_from_token(const char *btn_name, int mapped_code)

--- a/gamecontroller_db.cpp
+++ b/gamecontroller_db.cpp
@@ -258,7 +258,7 @@ static bool print_axis_mapping(const char *sdlname, uint32_t axis_map, uint16_t 
 	if (!axis_map) return false;
 
 	const uint16_t axis_idx = axis_map & MAP_AXIS_MASK;
-	for (unsigned int j = 0; j < ABS_MAX; j++)
+	for (unsigned int j = 0; j < GCDB_AXIS_MAP_SIZE; j++)
 	{
 		if (abs_map[j] == axis_idx)
 		{
@@ -274,7 +274,18 @@ static bool print_axis_mapping(const char *sdlname, uint32_t axis_map, uint16_t 
 }
 
 
-static int find_linux_code_for_button(char *btn_name, uint16_t *btn_map, uint16_t *abs_map)
+static int parse_mapping_index(const char *text, int max_index, const char **suffix)
+{
+	if (!text) return -1;
+
+	char *end = NULL;
+	long index = strtol(text, &end, 10);
+	if (end == text || index < 0 || index > max_index) return -1;
+	if (suffix) *suffix = end;
+	return index;
+}
+
+static int find_linux_code_for_button(const char *btn_name, uint16_t *btn_map, uint16_t *abs_map)
 {
 	if (!btn_name || !strlen(btn_name)) return -1;
 
@@ -291,50 +302,50 @@ static int find_linux_code_for_button(char *btn_name, uint16_t *btn_map, uint16_
 			case 'b':
 			{
 				//Normal button
-				int bidx = strtol(btn_name+1, NULL, 10);
+				const char *suffix = NULL;
+				int bidx = parse_mapping_index(btn_name + 1, GCDB_BUTTON_MAP_SIZE - 1, &suffix);
+				if (bidx < 0 || *suffix || btn_map[bidx] == UINT16_MAX) return -1;
 				return btn_map[bidx];
-				break;
 			}
 
 			case 'a':
 			{
-				int aidx = strtol(btn_name + (a_edge != 0 ? 2 : 1) , NULL, 10);
+				const char *suffix = NULL;
+				int aidx = parse_mapping_index(btn_name + (a_edge != 0 ? 2 : 1), GCDB_AXIS_MAP_SIZE - 1, &suffix);
+				if (aidx < 0 || (*suffix && strcmp(suffix, "~")) || abs_map[aidx] == UINT16_MAX) return -1;
+
 				int abs_axis = abs_map[aidx];
 				if (a_edge)
 				{
 					return KEY_EMU + (abs_axis << 1) - 1 + a_edge;
-				} else {
-						return abs_axis;
 				}
-				break;
+				return abs_axis;
 			}
 			case 'h':
 			//Mister creates fake digital buttons for hats that depend on the code and axis direction.
 			{
-				char *dot_ptr = NULL;
-				int hidx = strtol(btn_name+1, NULL, 10);
+				const char *dot_ptr = NULL;
+				int hidx = parse_mapping_index(btn_name + 1, (ABS_HAT3Y - ABS_HAT0X) / 2, &dot_ptr);
+				if (hidx < 0 || *dot_ptr != '.') return -1;
+
 				int base_hat = ABS_HAT0X + hidx*2;
 				//base_hat is X, base_hat+1 is Y
-				dot_ptr = strchr(btn_name, '.');
-				if (dot_ptr)
+				const char *suffix = NULL;
+				int hat_dir = parse_mapping_index(dot_ptr + 1, 8, &suffix);
+				if (hat_dir >= 0 && !*suffix)
 				{
-					int hat_dir = strtol(dot_ptr+1, NULL, 10);
 					switch(hat_dir)
 					{
 						case 1: //UP
 							return KEY_EMU + ((base_hat+1) << 1); //up is min value of Y axis
-							break;
 						case 2: // RIGHT
 							return KEY_EMU + (base_hat << 1) + 1; // (axis << 1) -1 + 2 right is max value
-							break;
 						case 4: //DOWN
 							return KEY_EMU + ((base_hat+1) << 1) + 1; //down is max value of Y axis
 						case 8: //LEFT
 							return KEY_EMU + (base_hat << 1); //(axis << 1) - 1 + 1 left is min value
-							break;
 						default:
 							return -1;
-							break;
 					}
 				}
 				break;
@@ -349,10 +360,12 @@ static int find_linux_code_for_button(char *btn_name, uint16_t *btn_map, uint16_
 #define test_bit(bit, array)  (array [bit / 8] & (1 << (bit % 8)))
 
 
-void get_ctrl_index_maps(int dev_fd, char *guid, uint16_t *btn_map, uint16_t *abs_map)
+void get_ctrl_index_maps(int dev_fd, const char *guid, uint16_t *btn_map, uint16_t *abs_map)
 {
-	unsigned char keybits[(KEY_MAX+7) / 8];
-	unsigned char absbits[(ABS_MAX+7) / 8];
+	if (!btn_map || !abs_map) return;
+
+	unsigned char keybits[(KEY_MAX + 8) / 8] = {};
+	unsigned char absbits[(ABS_MAX + 8) / 8] = {};
 	uint16_t btn_cnt = 0;
 	uint16_t abs_cnt = 0;
 
@@ -360,7 +373,7 @@ void get_ctrl_index_maps(int dev_fd, char *guid, uint16_t *btn_map, uint16_t *ab
   	printf("Gamecontrollerdb: mapping buttons for %s ", guid);
 	if (ioctl(dev_fd, EVIOCGBIT(EV_KEY, sizeof(keybits)), keybits) >= 0)
 	{
-		for (int i = BTN_JOYSTICK; i < KEY_MAX; i++)
+		for (int i = BTN_JOYSTICK; i <= KEY_MAX; i++)
 		{
 				if (test_bit(i, keybits))
 				{
@@ -417,8 +430,8 @@ void get_ctrl_index_maps(int dev_fd, char *guid, uint16_t *btn_map, uint16_t *ab
 void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid, uint16_t version,int dev_fd, const char *name, uint32_t *cur_map)
 {
 	static char map_guid[GUID_LEN] = {0};
-	static uint16_t btn_map[KEY_MAX - BTN_JOYSTICK] = {0xFFFF};
-	static uint16_t abs_map[ABS_MAX] = {0xFFFF};
+	static uint16_t btn_map[GCDB_BUTTON_MAP_SIZE] = {0xFFFF};
+	static uint16_t abs_map[GCDB_AXIS_MAP_SIZE] = {0xFFFF};
 	if (!cur_map) return;
 
 	char guid_str[GUID_LEN] = {0};
@@ -428,7 +441,7 @@ void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid,
 
 		memset(btn_map, 0xFFFF, sizeof(btn_map));
 		memset(abs_map, 0xFFFF, sizeof(abs_map));
-		strncpy(map_guid, guid_str, GUID_LEN);
+		snprintf(map_guid, sizeof(map_guid), "%s", guid_str);
 		get_ctrl_index_maps(dev_fd, guid_str, btn_map, abs_map);
 	}
 	//Directions/hats+Buttons
@@ -523,10 +536,10 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 {
 
 	static char map_guid[GUID_LEN] = {0};
-	static uint16_t btn_map[KEY_MAX - BTN_JOYSTICK] = {0};
-	static uint16_t abs_map[ABS_MAX] = {0};
+	static uint16_t btn_map[GCDB_BUTTON_MAP_SIZE] = {};
+	static uint16_t abs_map[GCDB_AXIS_MAP_SIZE] = {};
 
-	if (!map_str || !fill_map) return false;
+	if (!map_str || !guid || !fill_map) return false;
 
 
 	//gamecontrollerdb references buttons/axes numerically, and the number depends on the actual buttons supported
@@ -534,9 +547,10 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 
 	if (strcmp(map_guid, guid)) //New guid, map out button indexes for this new controller
 	{
-		bzero(btn_map, sizeof(btn_map));
-		bzero(abs_map, sizeof(abs_map));
+		memset(btn_map, 0xFF, sizeof(btn_map));
+		memset(abs_map, 0xFF, sizeof(abs_map));
 		get_ctrl_index_maps(dev_fd, guid, btn_map, abs_map);
+		snprintf(map_guid, sizeof(map_guid), "%s", guid);
 	}
 
 	char l_btn[20] = {};
@@ -584,13 +598,13 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 			bzero(m_btn, sizeof(m_btn));
 		} else if (in_m_btn) {
 			//Just truncate button names if they are too big
-			if (i <= sizeof(m_btn))
+			if (i + 1 < sizeof(m_btn))
 			{
 				m_btn[i] = *cur_str;
 				i++;
 			}
 		}	 else {
-			if (i <= sizeof(l_btn))
+			if (i + 1 < sizeof(l_btn))
 			{
 				l_btn[i] = *cur_str;
 				i++;
@@ -649,6 +663,8 @@ static bool parse_mapping_string(char *map_str, char *guid, int dev_fd, uint32_t
 
 bool read_controller_map_from_file(char *fname, char *guid, int dev_fd, uint32_t *fill_map)
 {
+	if (!fname || !guid || strlen(guid) != GUID_LEN - 1 || !fill_map) return false;
+
 	fileTextReader reader;
 	char matched[1024] = {};
 	char *map_start = NULL;
@@ -660,16 +676,16 @@ bool read_controller_map_from_file(char *fname, char *guid, int dev_fd, uint32_t
 		while ((line = FileReadLine(&reader)))
 		{
 			if (line[0] == '#') continue;
+
 			const char *gcom = strchr(line, ',');
-			if (!strncasecmp(line, guid, gcom-line))
+			if (!gcom || gcom - line != GUID_LEN - 1 || strncasecmp(line, guid, GUID_LEN - 1)) continue;
+
+			if (cdb_entry_matches((char *)gcom))
 			{
-				if (cdb_entry_matches((char *)gcom))
+				map_start = strchr((char *)gcom + 1, ',');
+				if (map_start)
 				{
-					map_start = strchr((char *)gcom+1, ',');
-					if (map_start)
-					{
-						strncpy(matched, map_start+1, sizeof(matched));
-					}
+					snprintf(matched, sizeof(matched), "%s", map_start + 1);
 				}
 			}
 		}

--- a/gamecontroller_db.h
+++ b/gamecontroller_db.h
@@ -8,12 +8,14 @@
 
 //Including terminating nul
 #define GUID_LEN 33 
+#define GCDB_BUTTON_MAP_SIZE (KEY_MAX + 1)
+#define GCDB_AXIS_MAP_SIZE   (ABS_MAX + 1)
 
 void gcdb_reset_axis_baselines();
 void gcdb_capture_axis_baseline(int dev_fd);
 bool gcdb_map_for_controller(uint16_t bustype, uint16_t vid, uint16_t pid, uint16_t version, int dev_fd, uint32_t *fill_map);
 void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid, uint16_t version,int dev_fd, const char *name, uint32_t *cur_map);
-void get_ctrl_index_maps(int dev_fd, char *guid, uint16_t *btn_map, uint16_t *abs_map);
+void get_ctrl_index_maps(int dev_fd, const char *guid, uint16_t *btn_map, uint16_t *abs_map);
 #endif
 
 

--- a/gamecontroller_db.h
+++ b/gamecontroller_db.h
@@ -9,6 +9,8 @@
 //Including terminating nul
 #define GUID_LEN 33 
 
+void gcdb_reset_axis_baselines();
+void gcdb_capture_axis_baseline(int dev_fd);
 bool gcdb_map_for_controller(uint16_t bustype, uint16_t vid, uint16_t pid, uint16_t version, int dev_fd, uint32_t *fill_map);
 void gcdb_show_string_for_ctrl_map(uint16_t bustype, uint16_t vid, uint16_t pid, uint16_t version,int dev_fd, const char *name, uint32_t *cur_map);
 void get_ctrl_index_maps(int dev_fd, char *guid, uint16_t *btn_map, uint16_t *abs_map);

--- a/input.cpp
+++ b/input.cpp
@@ -1817,6 +1817,17 @@ static uint16_t mapping_last_axis = 0;
 static int mapping_key_mapped = 0;
 static triggerCaptureState mapping_trigger_capture = {};
 
+static void claim_mapping_device(int dev)
+{
+	if (mapping_dev >= 0) return;
+
+	mapping_dev = dev;
+	if (!is_menu()) return;
+
+	if (menu_mouse_map) clear_mouse_map_slots(input[dev].map);
+	else clear_joypad_map_slots(input[dev].map);
+}
+
 static inline uint16_t map_axis_code(uint32_t map)
 {
 	return (uint16_t)(map & MAP_AXIS_MASK);
@@ -4137,7 +4148,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				int clear = (ev->code == KEY_F12 || ev->code == KEY_MENU || ev->code == KEY_HOMEPAGE) && !is_menu();
 				if (ev->value == 1 && mapping_dev < 0 && !clear)
 				{
-					mapping_dev = dev;
+					claim_mapping_device(dev);
 					mapping_type = (ev->code >= 256 || input[dev].force_joy) ? 1 : 0;
 					mapping_key_mapped = 0;
 				}
@@ -4153,11 +4164,6 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 								(mapping_button < SYS_MAP_AXIS_X || mapping_button > SYS_MAP_AXIS_Y) &&
 								!(!mapping_button && mapping_last_axis && ((ev->code == mapping_last_axis) || (ev->code == mapping_last_axis + 1))))
 							{
-								if (!mapping_button)
-								{
-									if (menu_mouse_map) clear_mouse_map_slots(input[dev].map);
-									else clear_joypad_map_slots(input[dev].map);
-								}
 								input[dev].osd_combo = 0;
 
 								int found = 0;
@@ -4324,7 +4330,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					mapping_last_axis = 0;
 					if (ev->type == EV_ABS && max)
 					{
-						if (mapping_dev < 0) mapping_dev = dev;
+						claim_mapping_device(dev);
 						mapping_type = 1;
 
 						if (absinfo->maximum > 2)
@@ -4344,7 +4350,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 						if (!map_skip)
 						{
 							mapping_button += 2;
-							if (mapping_dev < 0) mapping_dev = dev;
+							claim_mapping_device(dev);
 							if (ev->code < 256)
 							{
 								// keyboard, skip stick 1/2
@@ -4366,7 +4372,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				//Sticks
 				else if (ev->type == EV_ABS && idx)
 				{
-					if (mapping_dev < 0) mapping_dev = dev;
+					claim_mapping_device(dev);
 
 					if (idx && max && absinfo->maximum > 2)
 					{

--- a/input.cpp
+++ b/input.cpp
@@ -2072,6 +2072,38 @@ static void restore_menu_tmp_axis_stage(int pos)
 	sync_menu_tmp_axes();
 }
 
+static int tmp_axis_contains_axis(uint16_t axis)
+{
+	for (int i = 0; i < (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0])); i++)
+	{
+		if ((tmp_axis[i] & MAP_FLAG_ANALOG) && map_axis_code(tmp_axis[i]) == axis) return 1;
+	}
+	return 0;
+}
+
+static int reserve_tmp_axis_slots_for_pos(int pos)
+{
+	int min_count = 0;
+	switch (pos)
+	{
+	case -3: min_count = 1; break; // left stick Y
+	case -2: min_count = 2; break; // right stick X
+	case -1: min_count = 3; break; // right stick Y
+	}
+
+	while (tmp_axis_n < min_count && tmp_axis_n < (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0])))
+		tmp_axis[tmp_axis_n++] = 0;
+
+	return tmp_axis_n < (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0]));
+}
+
+static int append_tmp_axis_for_pos(int pos, uint16_t axis)
+{
+	if (!reserve_tmp_axis_slots_for_pos(pos)) return 0;
+	tmp_axis[tmp_axis_n++] = axis | MAP_FLAG_ANALOG;
+	return 1;
+}
+
 static int grabbed = 1;
 
 static uint32_t osd_timer = 0;
@@ -2139,7 +2171,6 @@ static void advance_map_button()
 		return;
 
 	mapping_button++;
-	if (mapping_button < 0 && (mapping_button & 1)) mapping_button++;
 
 	while (mapping_type <= 1 && mapping_button < mapping_count)
 	{
@@ -3738,22 +3769,22 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			}
 			else
 			{
-				if (input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS1_X])
+				if ((input[dev].mmap[SYS_AXIS_X] & MAP_FLAG_ANALOG) && input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS1_X])
 				{
 					input[dev].stick_l[0] = SYS_AXIS1_X;
 					if (input[dev].mmap[SYS_AXIS2_X] & MAP_FLAG_ANALOG) input[dev].stick_r[0] = SYS_AXIS2_X;
 				}
-				if (input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS1_Y])
+				if ((input[dev].mmap[SYS_AXIS_Y] & MAP_FLAG_ANALOG) && input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS1_Y])
 				{
 					input[dev].stick_l[1] = SYS_AXIS1_Y;
 					if (input[dev].mmap[SYS_AXIS2_Y] & MAP_FLAG_ANALOG) input[dev].stick_r[1] = SYS_AXIS2_Y;
 				}
-				if (input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS2_X])
+				if ((input[dev].mmap[SYS_AXIS_X] & MAP_FLAG_ANALOG) && input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS2_X])
 				{
 					input[dev].stick_l[0] = SYS_AXIS2_X;
 					if (input[dev].mmap[SYS_AXIS1_X] & MAP_FLAG_ANALOG) input[dev].stick_r[0] = SYS_AXIS1_X;
 				}
-				if (input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS2_Y])
+				if ((input[dev].mmap[SYS_AXIS_Y] & MAP_FLAG_ANALOG) && input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS2_Y])
 				{
 					input[dev].stick_l[1] = SYS_AXIS2_Y;
 					if (input[dev].mmap[SYS_AXIS1_Y] & MAP_FLAG_ANALOG) input[dev].stick_r[1] = SYS_AXIS1_Y;
@@ -4323,12 +4354,9 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					{
 						if (mapping_button < 0)
 						{
-							int found = 0;
-							for (int i = 0; i < tmp_axis_n; i++) if (ev->code == (tmp_axis[i] & 0xFFFF)) found = 1;
-							if (!found)
+							if (!tmp_axis_contains_axis(ev->code) && append_tmp_axis_for_pos(mapping_button, ev->code))
 							{
 								mapping_type = 1;
-								tmp_axis[tmp_axis_n++] = ev->code | MAP_FLAG_ANALOG;
 								//if (min) tmp_axis[idx - AXIS1_X] |= 0x10000;
 								mapping_button++;
 								if (tmp_axis_n >= 4) mapping_button = 0;

--- a/input.cpp
+++ b/input.cpp
@@ -6017,6 +6017,7 @@ int input_test(int getchar)
 			pool[i].events = 0;
 		}
 
+		gcdb_reset_axis_baselines();
 		reset_analog_triggers();
 
 		// clear button reference counts and key states
@@ -6385,6 +6386,7 @@ int input_test(int getchar)
 						// use specific keyboard(s) as a joystick
 						for (int i = 0; i < (int)cfg.keyboard_as_joystick[0]; i++) input[n].force_joy = (input[n].vid == (cfg.keyboard_as_joystick[i + 1] >> 16) && input[n].pid == (cfg.keyboard_as_joystick[i + 1] & 0xFFFF));
 
+						if (!input[n].mouse) gcdb_capture_axis_baseline(pool[n].fd);
 						ioctl(pool[n].fd, EVIOCGRAB, (grabbed | user_io_osd_is_visible()) ? 1 : 0);
 
 						n++;

--- a/input.cpp
+++ b/input.cpp
@@ -1833,6 +1833,14 @@ static inline uint16_t map_axis_code(uint32_t map)
 	return (uint16_t)(map & MAP_AXIS_MASK);
 }
 
+static int map_axis_offset(uint32_t map, int offset)
+{
+	if (!(map & MAP_FLAG_INVERT)) return offset;
+
+	offset = -offset;
+	return (offset > 127) ? 127 : offset;
+}
+
 static int input_test_bit(int bit, const unsigned char *array)
 {
 	return array[bit / 8] & (1 << (bit % 8));
@@ -4918,21 +4926,21 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					else
 					{
 						int offset = (value < -1 || value > 1) ? value : 0;
-						if (input[dev].stick_l[0] && ev->code == (uint16_t)input[dev].mmap[input[dev].stick_l[0]])
+						if (input[dev].stick_l[0] && ev->code == map_axis_code(input[dev].mmap[input[dev].stick_l[0]]))
 						{
-							joy_analog(dev, 0, offset, 0);
+							joy_analog(dev, 0, map_axis_offset(input[dev].mmap[input[dev].stick_l[0]], offset), 0);
 						}
-						else if (input[dev].stick_l[1] && ev->code == (uint16_t)input[dev].mmap[input[dev].stick_l[1]])
+						else if (input[dev].stick_l[1] && ev->code == map_axis_code(input[dev].mmap[input[dev].stick_l[1]]))
 						{
-							joy_analog(dev, 1, offset, 0);
+							joy_analog(dev, 1, map_axis_offset(input[dev].mmap[input[dev].stick_l[1]], offset), 0);
 						}
-						else if (input[dev].stick_r[0] && ev->code == (uint16_t)input[dev].mmap[input[dev].stick_r[0]])
+						else if (input[dev].stick_r[0] && ev->code == map_axis_code(input[dev].mmap[input[dev].stick_r[0]]))
 						{
-							joy_analog(dev, 0, offset, 1);
+							joy_analog(dev, 0, map_axis_offset(input[dev].mmap[input[dev].stick_r[0]], offset), 1);
 						}
-						else if (input[dev].stick_r[1] && ev->code == (uint16_t)input[dev].mmap[input[dev].stick_r[1]])
+						else if (input[dev].stick_r[1] && ev->code == map_axis_code(input[dev].mmap[input[dev].stick_r[1]]))
 						{
-							joy_analog(dev, 1, offset, 1);
+							joy_analog(dev, 1, map_axis_offset(input[dev].mmap[input[dev].stick_r[1]], offset), 1);
 						}
 					}
 				}

--- a/input.cpp
+++ b/input.cpp
@@ -3931,7 +3931,12 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 		if (!assign_btn && ev->type == EV_KEY && ev->value >= 1 && ev->code >= 256)
 		{
-			for (int i = SYS_BTN_RIGHT; i <= SYS_BTN_R3; i++)
+			for (int i = SYS_BTN_RIGHT; i <= SYS_BTN_START; i++)
+			{
+				if (ev->code == input[dev].mmap[i]) assign_btn = 1;
+			}
+
+			for (int i = SYS_BTN_L2; !assign_btn && i <= SYS_BTN_R3; i++)
 			{
 				if (ev->code == input[dev].mmap[i]) assign_btn = 1;
 			}

--- a/input.cpp
+++ b/input.cpp
@@ -1885,9 +1885,68 @@ static void prepare_mapping_trigger_capture()
 	mapping_trigger_capture.valid = 1;
 }
 
+static int map_entry_uses_axis(uint32_t map, uint16_t axis)
+{
+	if (map & MAP_FLAG_ANALOG)
+		return map_axis_code(map) == axis;
+
+	const uint32_t last_axis_key = KEY_EMU + (ABS_MAX << 1) + 1;
+	return map >= KEY_EMU && map <= last_axis_key && ((map - KEY_EMU) >> 1) == axis;
+}
+
+static int trigger_axis_is_reserved(int dev, uint16_t axis)
+{
+	if (axis >= ABS_HAT0X && axis <= ABS_HAT3Y) return 1;
+	if ((axis == ABS_RUDDER || axis == ABS_WHEEL) && input[dev].quirk != QUIRK_WHEEL) return 1;
+
+	for (int i = 0; i < (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0])); i++)
+	{
+		if (map_entry_uses_axis(tmp_axis[i], axis)) return 1;
+	}
+
+	for (int i = SYS_BTN_RIGHT; i <= SYS_BTN_UP; i++)
+	{
+		if (map_entry_uses_axis(input[dev].map[i], axis)) return 1;
+	}
+
+	for (int i = SYS_AXIS1_X; i <= SYS_AXIS_Y; i++)
+	{
+		if (map_entry_uses_axis(input[dev].map[i], axis)) return 1;
+	}
+
+	for (int i = SYS_AXIS_MX; i <= SYS_AXIS_MY; i++)
+	{
+		if (map_entry_uses_axis(input[dev].map[i], axis)) return 1;
+	}
+
+	return 0;
+}
+
+static int trigger_axis_has_valid_baseline(int dev, uint16_t axis)
+{
+	if (!mapping_trigger_capture.valid ||
+		mapping_trigger_capture.dev != dev ||
+		mapping_trigger_capture.pos != mapping_button ||
+		axis > ABS_MAX ||
+		!mapping_trigger_capture.has_axis[axis])
+		return 0;
+
+	const input_absinfo *base = &mapping_trigger_capture.absinfo[axis];
+	const int range = base->maximum - base->minimum;
+	if (range <= 1) return 0;
+
+	const int threshold = (range / 8) > 4 ? (range / 8) : 4;
+	const int center = base->minimum + (range / 2);
+	return base->value <= base->minimum + threshold ||
+		base->value >= base->maximum - threshold ||
+		abs(base->value - center) <= threshold;
+}
+
 static uint32_t build_trigger_axis_map_for_axis(int dev, uint16_t axis, const input_absinfo *absinfo, int negative, int threshold_divisor)
 {
-	if (!absinfo || axis > ABS_MAX)
+	if (!absinfo || axis > ABS_MAX ||
+		trigger_axis_is_reserved(dev, axis) ||
+		!trigger_axis_has_valid_baseline(dev, axis))
 		return 0;
 
 	uint32_t map = axis | MAP_FLAG_ANALOG | MAP_FLAG_TRIGGER;
@@ -2018,16 +2077,15 @@ static void apply_menu_analog_trigger_map(int dev, uint32_t trigger_map)
 	input[dev].mmap[idx] = trigger_map;
 }
 
-static void map_menu_analog_trigger_axis(int dev, uint16_t axis, const input_absinfo *absinfo)
+static void update_menu_analog_trigger_axis(int dev)
 {
 	if (!is_menu_trigger_map_pos(mapping_button) ||
 		mapping_dev != dev ||
 		!mapping_key_mapped ||
-		mapping_key_mapped >= KEY_EMU ||
-		input[dev].map[SYS_AXIS_L2 + (mapping_button - SYS_MAP_BTN_L2)])
+		mapping_key_mapped >= KEY_EMU)
 		return;
 
-	apply_menu_analog_trigger_map(dev, build_trigger_axis_map_for_axis(dev, axis, absinfo, 0, 32));
+	apply_menu_analog_trigger_map(dev, detect_moved_trigger_axis_map(dev));
 }
 
 static void map_menu_analog_trigger(int dev, uint16_t keycode, const input_absinfo *absinfo)
@@ -4111,7 +4169,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 		if (map_skip) clear_mapping_current_input();
 		if (ev->type == EV_ABS && absinfo)
-			map_menu_analog_trigger_axis(dev, ev->code, absinfo);
+			update_menu_analog_trigger_axis(dev);
 
 		if (ev->type == EV_KEY && mapping_button>=0 && !osd_event)
 		{

--- a/input.cpp
+++ b/input.cpp
@@ -2159,6 +2159,7 @@ static void do_map_clear()
 	if (!mapping || mapping_type > 1 || mapping_dev < 0)
 		return;
 
+	const int mouse_session = is_menu() && menu_mouse_map;
 	clear_mapping_current_input();
 	clear_mapping_combo_state();
 	clear_map_feedback();
@@ -2169,10 +2170,10 @@ static void do_map_clear()
 	osd_timer = 0;
 	mapping_finish = 0;
 
-	if (menu_mouse_map) clear_mouse_map_slots(input[mapping_dev].map);
+	if (mouse_session) clear_mouse_map_slots(input[mapping_dev].map);
 	else clear_joypad_map_slots(input[mapping_dev].map);
 
-	mapping_button = menu_mouse_map ? SYS_BTN_A : 0;
+	mapping_button = mouse_session ? SYS_BTN_A : 0;
 	mapping_clear = 1;
 }
 

--- a/input.cpp
+++ b/input.cpp
@@ -3299,6 +3299,25 @@ static void joy_analog(int dev, int axis, int offset, int stick = 0)
 static uint8_t analog_trigger_pos[NUMPLAYERS][2] = {};
 static uint8_t analog_trigger_last[NUMPLAYERS][2] = {};
 
+void input_analog_triggers_resync(int suppress)
+{
+	for (int num = 0; num < NUMPLAYERS; num++)
+	{
+		const uint8_t l2 = suppress ? 0 : analog_trigger_pos[num][0];
+		const uint8_t r2 = suppress ? 0 : analog_trigger_pos[num][1];
+
+		analog_trigger_last[num][0] = l2;
+		analog_trigger_last[num][1] = r2;
+		user_io_analog_triggers(num, l2, r2);
+	}
+}
+
+static void reset_analog_triggers()
+{
+	memset(analog_trigger_pos, 0, sizeof(analog_trigger_pos));
+	input_analog_triggers_resync(0);
+}
+
 static uint8_t normalize_analog_trigger(uint32_t map, int value, const input_absinfo *absinfo)
 {
 	if (!absinfo || absinfo->maximum == absinfo->minimum)
@@ -3349,7 +3368,7 @@ static int joy_analog_triggers(int dev, int axis, int value, const input_absinfo
 		handled = 1;
 	}
 
-	if (handled)
+	if (handled && !user_io_osd_is_visible())
 	{
 		if (analog_trigger_pos[num][0] != analog_trigger_last[num][0] ||
 			analog_trigger_pos[num][1] != analog_trigger_last[num][1])
@@ -3508,8 +3527,7 @@ void reset_players()
 	for (int i = 0; i < NUMPLAYERS; i++) {
 		clear_autofire(i);
 	}
-	memset(analog_trigger_pos, 0, sizeof(analog_trigger_pos));
-	memset(analog_trigger_last, 0, sizeof(analog_trigger_last));
+	reset_analog_triggers();
 	memset(player_pad, 0, sizeof(player_pad));
 	memset(player_pdsp, 0, sizeof(player_pdsp));
 }
@@ -4719,7 +4737,16 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 		//analog joystick
 		case EV_ABS:
-			if (!user_io_osd_is_visible())
+			if (user_io_osd_is_visible())
+			{
+				int value = ev->value;
+				if (ev->value < absinfo->minimum) value = absinfo->minimum;
+				else if (ev->value > absinfo->maximum) value = absinfo->maximum;
+
+				joy_analog_triggers(dev, ev->code, value, absinfo);
+				break;
+			}
+
 			{
 				int value = ev->value;
 				if (ev->value < absinfo->minimum) value = absinfo->minimum;
@@ -5982,6 +6009,8 @@ int input_test(int getchar)
 			pool[i].fd = -1;
 			pool[i].events = 0;
 		}
+
+		reset_analog_triggers();
 
 		// clear button reference counts and key states
 		memset(key_states, 0, sizeof(key_states));

--- a/input.cpp
+++ b/input.cpp
@@ -1690,27 +1690,88 @@ void sysled_enable(int en)
 }
 
 #define JOYMAP_DIR  "inputs/"
+#define SYS_MAP_GAMEPAD_COUNT   19
+#define TRIGGER_CAPTURE_AXIS_COUNT (ABS_MAX + 1)
+static int menu_mouse_map = 0;
+
+typedef struct
+{
+	uint8_t valid;
+	int dev;
+	int pos;
+	uint8_t has_axis[TRIGGER_CAPTURE_AXIS_COUNT];
+	input_absinfo absinfo[TRIGGER_CAPTURE_AXIS_COUNT];
+} triggerCaptureState;
+
+static void clear_mouse_map_slots(uint32_t *map)
+{
+	memset(&map[SYS_MS_RIGHT], 0, sizeof(map[0]) * (SYS_MS_BTN_EMU - SYS_MS_RIGHT + 1));
+	memset(&map[SYS_AXIS_MX], 0, sizeof(map[0]) * ((SYS_AXIS_MY - SYS_AXIS_MX) + 1));
+}
+
+static void clear_joypad_map_slots(uint32_t *map)
+{
+	uint32_t mouse_buttons[SYS_MS_BTN_EMU - SYS_MS_RIGHT + 1];
+	uint32_t mouse_axes[(SYS_AXIS_MY - SYS_AXIS_MX) + 1];
+
+	memcpy(mouse_buttons, &map[SYS_MS_RIGHT], sizeof(mouse_buttons));
+	memcpy(mouse_axes, &map[SYS_AXIS_MX], sizeof(mouse_axes));
+	memset(map, 0, sizeof(map[0]) * NUMBUTTONS);
+	memcpy(&map[SYS_MS_RIGHT], mouse_buttons, sizeof(mouse_buttons));
+	memcpy(&map[SYS_AXIS_MX], mouse_axes, sizeof(mouse_axes));
+}
+
+static void clear_mapping_slot_for_pos(uint32_t *map, int pos);
+int step_back_map_setting();
+
+static int get_system_map_button_idx(int pos)
+{
+	if (menu_mouse_map)
+	{
+		if (pos >= SYS_BTN_A && pos < (SYS_BTN_A + 8)) return SYS_MS_RIGHT + (pos - SYS_BTN_A);
+		return -1;
+	}
+
+	if (pos >= SYS_BTN_RIGHT && pos <= SYS_BTN_R) return pos;
+	if (pos >= SYS_MAP_BTN_L2 && pos < SYS_MAP_BTN_SELECT) return SYS_BTN_L2 + (pos - SYS_MAP_BTN_L2);
+	if (pos >= SYS_MAP_BTN_SELECT && pos < SYS_MAP_POS_OSD) return SYS_BTN_SELECT + (pos - SYS_MAP_BTN_SELECT);
+	if (pos >= SYS_MAP_POS_OSD && pos < SYS_MAP_AXIS_X) return SYS_BTN_OSD_KTGL + (pos - SYS_MAP_POS_OSD);
+	return -1;
+}
+
+template<size_t N>
+static void get_joymap_path(char (&path)[N], const char *name)
+{
+	sprintfz(path, JOYMAP_DIR "%s", name);
+}
+
 static int load_map(const char *name, void *pBuffer, int size)
 {
-	char path[256] = { JOYMAP_DIR };
-	strcat(path, name);
+	char path[256];
+	get_joymap_path(path, name);
 	int ret = FileLoadConfig(path, pBuffer, size);
-	if (!ret) return FileLoadConfig(name, pBuffer, size);
+	if (ret)
+	{
+		printf("Loaded map: %s\n", path);
+		return ret;
+	}
+	ret = FileLoadConfig(name, pBuffer, size);
+	if (ret) printf("Loaded map: %s\n", name);
 	return ret;
 }
 
 static void delete_map(const char *name)
 {
-	char path[256] = { JOYMAP_DIR };
-	strcat(path, name);
+	char path[256];
+	get_joymap_path(path, name);
 	FileDeleteConfig(name);
 	FileDeleteConfig(path);
 }
 
 static int save_map(const char *name, void *pBuffer, int size)
 {
-	char path[256] = { JOYMAP_DIR };
-	strcat(path, name);
+	char path[256];
+	get_joymap_path(path, name);
 	FileDeleteConfig(name);
 	return FileSaveConfig(path, pBuffer, size);
 }
@@ -1724,23 +1785,506 @@ static int mapping_clear;
 static int mapping_finish;
 static int mapping_set;
 
+enum
+{
+	MAP_HOLD_NONE = 0,
+	MAP_HOLD_SKIP,
+	MAP_HOLD_BACK,
+	MAP_HOLD_CLEAR = 4
+};
 
+#define MAP_HOLD_ACTION_MS 1000
+#define MAP_HOLD_FEEDBACK_DELAY_MS 333
 static int mapping_current_key = 0;
 static int mapping_current_dev = -1;
+static int mapping_hold_key = 0;
+static int mapping_ignore_release_key = 0;
+static int mapping_ignore_release_key2 = 0;
+static uint32_t mapping_hold_timer = 0;
+static uint32_t mapping_hold_feedback_timer = 0;
+static int mapping_hold_action = MAP_HOLD_NONE;
+static int mapping_combo_second_key = 0;
+static uint8_t mapping_combo_release_mask = 0;
+static char mapping_feedback[32] = {};
+static uint32_t mapping_feedback_timer = 0;
+static int mapping_feedback_advance = 0;
 static advancedButtonMap *mapping_store = NULL;
 
 static uint32_t tmp_axis[4];
 static int tmp_axis_n = 0;
+static uint8_t tmp_axis_stage_count[6] = {};
+static uint16_t mapping_last_axis = 0;
+static int mapping_key_mapped = 0;
+static triggerCaptureState mapping_trigger_capture = {};
+
+static inline uint16_t map_axis_code(uint32_t map)
+{
+	return (uint16_t)(map & MAP_AXIS_MASK);
+}
+
+static int input_test_bit(int bit, const unsigned char *array)
+{
+	return array[bit / 8] & (1 << (bit % 8));
+}
+
+static int is_menu_trigger_map_pos(int pos)
+{
+	return !menu_mouse_map && (pos == SYS_MAP_BTN_L2 || pos == (SYS_MAP_BTN_L2 + 1));
+}
+
+static void clear_mapping_trigger_capture()
+{
+	memset(&mapping_trigger_capture, 0, sizeof(mapping_trigger_capture));
+}
+
+static void prepare_mapping_trigger_capture()
+{
+	if (!is_menu() || !mapping || !is_menu_trigger_map_pos(mapping_button) || mapping_dev < 0)
+	{
+		clear_mapping_trigger_capture();
+		return;
+	}
+
+	if (mapping_trigger_capture.valid &&
+		mapping_trigger_capture.dev == mapping_dev &&
+		mapping_trigger_capture.pos == mapping_button)
+		return;
+
+	clear_mapping_trigger_capture();
+	mapping_trigger_capture.dev = mapping_dev;
+	mapping_trigger_capture.pos = mapping_button;
+
+	unsigned char absbits[(ABS_MAX + 7) / 8] = {};
+	if (pool[mapping_dev].fd < 0 || ioctl(pool[mapping_dev].fd, EVIOCGBIT(EV_ABS, sizeof(absbits)), absbits) < 0)
+		return;
+
+	for (int axis = 0; axis <= ABS_MAX; axis++)
+	{
+		if (!input_test_bit(axis, absbits))
+			continue;
+
+		input_absinfo info = {};
+		if (ioctl(pool[mapping_dev].fd, EVIOCGABS(axis), &info) < 0)
+			continue;
+
+		mapping_trigger_capture.has_axis[axis] = 1;
+		mapping_trigger_capture.absinfo[axis] = info;
+	}
+
+	mapping_trigger_capture.valid = 1;
+}
+
+static uint32_t build_trigger_axis_map_for_axis(int dev, uint16_t axis, const input_absinfo *absinfo, int negative, int threshold_divisor)
+{
+	if (!absinfo || axis > ABS_MAX)
+		return 0;
+
+	uint32_t map = axis | MAP_FLAG_ANALOG | MAP_FLAG_TRIGGER;
+
+	if (mapping_trigger_capture.valid &&
+		mapping_trigger_capture.dev == dev &&
+		mapping_trigger_capture.pos == mapping_button &&
+		mapping_trigger_capture.has_axis[axis])
+	{
+		const input_absinfo *base_info = &mapping_trigger_capture.absinfo[axis];
+		const int range = base_info->maximum - base_info->minimum;
+		const int delta = abs(absinfo->value - base_info->value);
+
+		if (range > 1 && threshold_divisor > 0)
+		{
+			const int threshold = (range / threshold_divisor) > 4 ? (range / threshold_divisor) : 4;
+			if (delta < threshold)
+				return 0;
+		}
+
+		const int center = base_info->minimum + (range / 2);
+		const int centered_threshold = range / 4;
+		if (range > 1 && abs(base_info->value - center) <= centered_threshold)
+			map |= MAP_FLAG_CENTERED;
+
+		if (delta)
+			negative = absinfo->value < base_info->value;
+	}
+
+	if (negative)
+		map |= MAP_FLAG_NEGATIVE;
+
+	return map;
+}
+
+static uint32_t build_trigger_axis_map(int dev, uint16_t keycode, const input_absinfo *absinfo)
+{
+	if (keycode < KEY_EMU)
+		return 0;
+
+	return build_trigger_axis_map_for_axis(dev, (keycode - KEY_EMU) >> 1, absinfo, !(keycode & 1), 5);
+}
+
+static uint32_t detect_moved_trigger_axis_map(int dev)
+{
+	if (!mapping_trigger_capture.valid ||
+		mapping_trigger_capture.dev != dev ||
+		mapping_trigger_capture.pos != mapping_button ||
+		pool[dev].fd < 0)
+		return 0;
+
+	uint32_t best_map = 0;
+	int best_score = 0;
+
+	for (uint16_t axis = 0; axis <= ABS_MAX; axis++)
+	{
+		if (!mapping_trigger_capture.has_axis[axis])
+			continue;
+
+		input_absinfo absinfo = {};
+		if (ioctl(pool[dev].fd, EVIOCGABS(axis), &absinfo) < 0)
+			continue;
+
+		const input_absinfo *base_info = &mapping_trigger_capture.absinfo[axis];
+		const int range = base_info->maximum - base_info->minimum;
+		if (range <= 1)
+			continue;
+
+		const int delta = abs(absinfo.value - base_info->value);
+		const int threshold = (range / 32) > 4 ? (range / 32) : 4;
+		if (delta < threshold)
+			continue;
+
+		const int score = (delta * 1024) / range;
+		if (score <= best_score)
+			continue;
+
+		const uint32_t map = build_trigger_axis_map_for_axis(dev, axis, &absinfo, absinfo.value < base_info->value, 32);
+		if (!map)
+			continue;
+
+		best_map = map;
+		best_score = score;
+	}
+
+	return best_map;
+}
+
+static uint32_t detect_standard_trigger_axis_map(int dev, uint16_t keycode)
+{
+	int axis = -1;
+	if (keycode == BTN_TL2) axis = ABS_Z;
+	else if (keycode == BTN_TR2) axis = ABS_RZ;
+	else return 0;
+
+	if (!mapping_trigger_capture.valid ||
+		mapping_trigger_capture.dev != dev ||
+		mapping_trigger_capture.pos != mapping_button ||
+		!mapping_trigger_capture.has_axis[axis] ||
+		pool[dev].fd < 0)
+		return 0;
+
+	input_absinfo absinfo = {};
+	if (ioctl(pool[dev].fd, EVIOCGABS(axis), &absinfo) < 0)
+		return 0;
+
+	const input_absinfo *base_info = &mapping_trigger_capture.absinfo[axis];
+	const int range = base_info->maximum - base_info->minimum;
+	if (range <= 1)
+		return 0;
+
+	const int edge_threshold = (range / 8) > 4 ? (range / 8) : 4;
+	const int released_near_min = base_info->value <= (base_info->minimum + edge_threshold);
+	const int released_near_max = base_info->value >= (base_info->maximum - edge_threshold);
+	if (!released_near_min && !released_near_max)
+		return 0;
+
+	return build_trigger_axis_map_for_axis(dev, axis, &absinfo, released_near_max, 0);
+}
+
+static void apply_menu_analog_trigger_map(int dev, uint32_t trigger_map)
+{
+	if (!trigger_map)
+		return;
+
+	const int idx = SYS_AXIS_L2 + (mapping_button - SYS_MAP_BTN_L2);
+	input[dev].map[idx] = trigger_map;
+	input[dev].mmap[idx] = trigger_map;
+}
+
+static void map_menu_analog_trigger_axis(int dev, uint16_t axis, const input_absinfo *absinfo)
+{
+	if (!is_menu_trigger_map_pos(mapping_button) ||
+		mapping_dev != dev ||
+		!mapping_key_mapped ||
+		mapping_key_mapped >= KEY_EMU ||
+		input[dev].map[SYS_AXIS_L2 + (mapping_button - SYS_MAP_BTN_L2)])
+		return;
+
+	apply_menu_analog_trigger_map(dev, build_trigger_axis_map_for_axis(dev, axis, absinfo, 0, 32));
+}
+
+static void map_menu_analog_trigger(int dev, uint16_t keycode, const input_absinfo *absinfo)
+{
+	if (!is_menu_trigger_map_pos(mapping_button))
+		return;
+
+	uint32_t trigger_map = build_trigger_axis_map(dev, keycode, absinfo);
+	if (!trigger_map && keycode < KEY_EMU)
+		trigger_map = detect_moved_trigger_axis_map(dev);
+	if (!trigger_map && keycode < KEY_EMU)
+		trigger_map = detect_standard_trigger_axis_map(dev, keycode);
+
+	apply_menu_analog_trigger_map(dev, trigger_map);
+}
+
+static int get_tmp_axis_stage_index(int pos)
+{
+	if (pos < -6 || pos > -1) return -1;
+	return pos + 6;
+}
+
+static void sync_menu_tmp_axes()
+{
+	if (!is_menu() || menu_mouse_map || mapping_dev < 0) return;
+
+	memcpy(&input[mapping_dev].mmap[SYS_AXIS1_X], tmp_axis, sizeof(tmp_axis));
+	memcpy(&input[mapping_dev].map[SYS_AXIS1_X], tmp_axis, sizeof(tmp_axis));
+	input[mapping_dev].mmap[SYS_AXIS_X] = (tmp_axis_n >= 2) ? tmp_axis[0] : 0;
+	input[mapping_dev].mmap[SYS_AXIS_Y] = (tmp_axis_n >= 2) ? tmp_axis[1] : 0;
+	input[mapping_dev].map[SYS_AXIS_X] = input[mapping_dev].mmap[SYS_AXIS_X];
+	input[mapping_dev].map[SYS_AXIS_Y] = input[mapping_dev].mmap[SYS_AXIS_Y];
+}
+
+static void record_menu_tmp_axis_stage()
+{
+	const int idx = get_tmp_axis_stage_index(mapping_button);
+	if (idx >= 0) tmp_axis_stage_count[idx] = tmp_axis_n;
+}
+
+static void restore_menu_tmp_axis_stage(int pos)
+{
+	const int idx = get_tmp_axis_stage_index(pos);
+	if (idx < 0) return;
+
+	tmp_axis_n = tmp_axis_stage_count[idx];
+	if (tmp_axis_n > (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0]))) tmp_axis_n = sizeof(tmp_axis) / sizeof(tmp_axis[0]);
+	for (int i = tmp_axis_n; i < (int)(sizeof(tmp_axis) / sizeof(tmp_axis[0])); i++) tmp_axis[i] = 0;
+
+	// Re-enter the menu detector as a joypad path; keyboard selection will switch it back on input.
+	mapping_type = 1;
+	mapping_last_axis = 0;
+	sync_menu_tmp_axes();
+}
 
 static int grabbed = 1;
 
 static uint32_t osd_timer = 0;
 static uint32_t map_advance_timer = 0;
 
-void start_map_setting(int cnt, int set, advancedButtonMap *abm_store)
+static void clear_mapping_hold_state()
+{
+	mapping_hold_key = 0;
+	mapping_hold_timer = 0;
+	mapping_hold_feedback_timer = 0;
+	mapping_hold_action = MAP_HOLD_NONE;
+}
+
+static void clear_mapping_current_input()
 {
 	mapping_current_key = 0;
 	mapping_current_dev = -1;
+	clear_mapping_hold_state();
+}
+
+static void clear_mapping_combo_state()
+{
+	mapping_combo_second_key = 0;
+	mapping_combo_release_mask = 0;
+}
+
+static void set_mapping_ignore_release_keys(int key1, int key2 = 0)
+{
+	mapping_ignore_release_key = key1;
+	mapping_ignore_release_key2 = key2;
+}
+
+static void clear_map_feedback()
+{
+	mapping_feedback[0] = 0;
+	mapping_feedback_timer = 0;
+	mapping_feedback_advance = 0;
+}
+
+static void do_map_clear()
+{
+	if (!mapping || mapping_type > 1 || mapping_dev < 0)
+		return;
+
+	clear_mapping_current_input();
+	clear_mapping_combo_state();
+	clear_map_feedback();
+	mapping_key_mapped = 0;
+	mapping_last_axis = 0;
+	clear_mapping_trigger_capture();
+	map_advance_timer = 0;
+	osd_timer = 0;
+	mapping_finish = 0;
+
+	if (menu_mouse_map) clear_mouse_map_slots(input[mapping_dev].map);
+	else clear_joypad_map_slots(input[mapping_dev].map);
+
+	mapping_button = menu_mouse_map ? SYS_BTN_A : 0;
+	mapping_clear = 1;
+}
+
+static void advance_map_button()
+{
+	if (!(mapping_type <= 1) || mapping_button >= mapping_count)
+		return;
+
+	mapping_button++;
+	if (mapping_button < 0 && (mapping_button & 1)) mapping_button++;
+
+	while (mapping_type <= 1 && mapping_button < mapping_count)
+	{
+		int skip = 0;
+		if (!is_menu() && mapping_button >= 4 && !strcmp(joy_bnames[mapping_button - 4], "-"))
+			skip = 1;
+		if (!skip) break;
+		mapping_button++;
+	}
+
+	prepare_mapping_trigger_capture();
+}
+
+static int map_core_button_code(int dev, int code)
+{
+	if (!mapping || is_menu() || mapping_type > 1 || mapping_dev != dev || mapping_button < 0 || mapping_button >= mapping_count)
+		return 0;
+
+	const uint32_t mapped_code = (uint32_t)code;
+
+	if (!mapping_button)
+	{
+		for (uint i = 0; i < sizeof(input[0].map) / sizeof(input[0].map[0]); i++)
+		{
+			input[dev].map[i] &= mapping_set ? 0x0000FFFF : 0xFFFF0000;
+		}
+	}
+
+	int found = 0;
+	for (int i = 0; i < mapping_button; i++)
+	{
+		if (mapping_set && (input[dev].map[i] >> 16) == mapped_code) found = 1;
+		if (!mapping_set && (input[dev].map[i] & 0xFFFF) == mapped_code) found = 1;
+	}
+
+	if (!found)
+	{
+		if (mapping_set) input[dev].map[mapping_button] = (input[dev].map[mapping_button] & 0xFFFF) | (mapped_code << 16);
+		else input[dev].map[mapping_button] = (input[dev].map[mapping_button] & 0xFFFF0000) | mapped_code;
+		mapping_key_mapped = code;
+		return 1;
+	}
+
+	return 0;
+}
+
+static const char *get_map_hold_feedback_text(int action)
+{
+	switch (action)
+	{
+	case MAP_HOLD_SKIP:
+		return "Skip/Unmap";
+	case MAP_HOLD_BACK:
+		return "Previous";
+	case MAP_HOLD_CLEAR:
+		return "Clearing";
+	default:
+		return NULL;
+	}
+}
+
+void set_menu_mouse_map(int enable)
+{
+	menu_mouse_map = enable ? 1 : 0;
+}
+
+int get_menu_mouse_map()
+{
+	return menu_mouse_map;
+}
+
+static void clear_mapping_slot_for_pos(uint32_t *map, int pos)
+{
+	if (is_menu())
+	{
+		if (pos < SYS_MAP_POS_OSD)
+		{
+			const int idx = get_system_map_button_idx(pos);
+			if (idx >= 0) map[idx] = 0;
+			if (pos == SYS_MAP_BTN_L2) map[SYS_AXIS_L2] = 0;
+			if (pos == (SYS_MAP_BTN_L2 + 1)) map[SYS_AXIS_R2] = 0;
+			if (menu_mouse_map)
+			{
+				if (pos == SYS_BTN_A || pos == SYS_BTN_B) map[SYS_AXIS_MX] = 0;
+				if (pos == SYS_BTN_X || pos == SYS_BTN_Y) map[SYS_AXIS_MY] = 0;
+			}
+		}
+		else if (pos == SYS_MAP_POS_OSD)
+		{
+			map[SYS_BTN_OSD_KTGL + 1] = 0;
+			map[SYS_BTN_OSD_KTGL + 2] = 0;
+		}
+		else if (pos == SYS_MAP_POS_OSD + 1)
+		{
+			map[SYS_BTN_MENU_FUNC] &= 0xFFFF0000;
+		}
+		else if (pos == SYS_MAP_POS_OSD + 2)
+		{
+			map[SYS_BTN_MENU_FUNC] &= 0x0000FFFF;
+		}
+		else if (pos == SYS_MAP_AXIS_X)
+		{
+			map[SYS_AXIS_X] = 0;
+		}
+		else if (pos == SYS_MAP_AXIS_Y)
+		{
+			map[SYS_AXIS_Y] = 0;
+		}
+	}
+	else if (pos >= 0 && pos < mapping_count)
+	{
+		map[pos] &= mapping_set ? 0x0000FFFF : 0xFFFF0000;
+	}
+}
+
+int step_back_map_setting()
+{
+	if (!mapping || mapping_type > 1 || mapping_dev < 0) return 0;
+
+	int min_pos = is_menu() ? (menu_mouse_map ? SYS_BTN_A : -6) : 0;
+	int pos = mapping_button;
+
+	if (pos >= mapping_count) pos = mapping_count - 1;
+	else pos--;
+
+	if (is_menu() && !menu_mouse_map && mapping_type == 0 && pos < 0) pos = -6;
+
+	while (pos >= min_pos && !is_menu() && pos >= SYS_BTN_A && !strcmp(joy_bnames[pos - SYS_BTN_A], "-")) pos--;
+	if (pos < min_pos) return 0;
+
+	clear_mapping_slot_for_pos(input[mapping_dev].map, pos);
+	mapping_button = pos;
+	if (is_menu() && !menu_mouse_map && pos < 0) restore_menu_tmp_axis_stage(pos);
+	clear_mapping_current_input();
+	mapping_clear = 0;
+	mapping_finish = 0;
+	prepare_mapping_trigger_capture();
+	return 1;
+}
+
+void start_map_setting(int cnt, int set, advancedButtonMap *abm_store)
+{
+	clear_mapping_current_input();
+	clear_mapping_combo_state();
+	clear_map_feedback();
 
 	mapping_button = 0;
 	mapping = 1;
@@ -1764,9 +2308,12 @@ void start_map_setting(int cnt, int set, advancedButtonMap *abm_store)
 	mapping_clear = 0;
 	mapping_finish = 0;
 	tmp_axis_n = 0;
+	memset(tmp_axis_stage_count, 0, sizeof(tmp_axis_stage_count));
+	clear_mapping_trigger_capture();
 
-	if (mapping_type <= 1 && is_menu()) mapping_button = -6;
+	if (mapping_type <= 1 && is_menu()) mapping_button = menu_mouse_map ? SYS_BTN_A : -6;
 	memset(tmp_axis, 0, sizeof(tmp_axis));
+	prepare_mapping_trigger_capture();
 
 	//un-stick the enter key
 	user_io_kbd(KEY_ENTER, 0);
@@ -1780,6 +2327,25 @@ advancedButtonMap *get_map_code_store()
 int get_map_count()
 {
 	return mapping_count;
+}
+
+int poll_map_hold_action()
+{
+	if (!mapping || mapping_type > 1 || !mapping_hold_key || !mapping_hold_timer || !mapping_hold_action)
+		return 0;
+
+	if (!CheckTimer(mapping_hold_timer))
+		return 0;
+
+	int action = mapping_hold_action;
+	set_mapping_ignore_release_keys(mapping_hold_key);
+	clear_mapping_current_input();
+	return action;
+}
+
+int get_map_active()
+{
+	return mapping;
 }
 
 int get_map_set()
@@ -1799,7 +2365,9 @@ int get_map_type()
 
 int get_map_clear()
 {
-	return mapping_clear;
+	int clear = mapping_clear;
+	mapping_clear = 0;
+	return clear;
 }
 
 int get_map_finish()
@@ -1824,6 +2392,47 @@ int get_map_advance()
 	return (mapping && !is_menu() && map_advance_timer && CheckTimer(map_advance_timer));
 }
 
+const char *get_map_feedback()
+{
+	if (!mapping_feedback[0] || !mapping_feedback_timer || CheckTimer(mapping_feedback_timer))
+		return NULL;
+
+	return mapping_feedback;
+}
+
+void poll_map_feedback()
+{
+	if (!mapping_feedback_timer || !CheckTimer(mapping_feedback_timer))
+		return;
+
+	mapping_feedback_timer = 0;
+	mapping_feedback[0] = 0;
+
+	if (mapping_feedback_advance)
+		advance_map_button();
+
+	mapping_feedback_advance = 0;
+}
+
+const char *get_map_hold_feedback()
+{
+	if (!mapping || mapping_type > 1 || !mapping_hold_key || !mapping_hold_timer || !mapping_hold_action)
+		return NULL;
+
+	if (CheckTimer(mapping_hold_timer))
+		return NULL;
+
+	if (!mapping_hold_feedback_timer || !CheckTimer(mapping_hold_feedback_timer))
+		return NULL;
+
+	return get_map_hold_feedback_text(mapping_hold_action);
+}
+
+void trigger_map_clear()
+{
+	do_map_clear();
+}
+
 static char *get_unique_mapping(int dev, int force_unique = 0)
 {
 	uint32_t vidpid = (input[dev].vid << 16) | input[dev].pid;
@@ -1843,13 +2452,19 @@ static char *get_unique_mapping(int dev, int force_unique = 0)
 	return str;
 }
 
+template<size_t N>
+static void build_map_name(char (&name)[N], int dev, int def, int version)
+{
+	char *id = get_unique_mapping(dev);
+
+	if (def || is_menu()) sprintfz(name, "input_%s%s_v%d.map", id, input[dev].mod ? "_m" : "", version);
+	else sprintfz(name, "%s_input_%s%s_v%d.map", user_io_get_core_name(), id, input[dev].mod ? "_m" : "", version);
+}
+
 static char *get_map_name(int dev, int def)
 {
 	static char name[1024];
-	char *id = get_unique_mapping(dev);
-
-	if (def || is_menu()) sprintfz(name, "input_%s%s_v3.map", id, input[dev].mod ? "_m" : "");
-	else sprintfz(name, "%s_input_%s%s_v3.map", user_io_get_core_name(), id, input[dev].mod ? "_m" : "");
+	build_map_name(name, dev, def, 4);
 	return name;
 }
 
@@ -1896,14 +2511,25 @@ void finish_map_setting(int dismiss)
 	}
 	else
 	{
+		char legacy_name[1024];
+
 		for (int i = 0; i < NUMDEV; i++)
 		{
 			input[i].has_map = 0;
 			input[i].has_mmap = 0;
 		}
+		build_map_name(legacy_name, mapping_dev, 0, 3);
 
-		if (!dismiss) save_map(get_map_name(mapping_dev, 0), &input[mapping_dev].map, sizeof(input[mapping_dev].map));
-		if (dismiss == 2) delete_map(get_map_name(mapping_dev, 0));
+		if (!dismiss)
+		{
+			delete_map(legacy_name);
+			save_map(get_map_name(mapping_dev, 0), &input[mapping_dev].map, sizeof(input[mapping_dev].map));
+		}
+		if (dismiss == 2)
+		{
+			delete_map(get_map_name(mapping_dev, 0));
+			delete_map(legacy_name);
+		}
 	}
 }
 
@@ -2639,6 +3265,73 @@ static void joy_analog(int dev, int axis, int offset, int stick = 0)
 	}
 }
 
+static uint8_t analog_trigger_pos[NUMPLAYERS][2] = {};
+static uint8_t analog_trigger_last[NUMPLAYERS][2] = {};
+
+static uint8_t normalize_analog_trigger(uint32_t map, int value, const input_absinfo *absinfo)
+{
+	if (!absinfo || absinfo->maximum == absinfo->minimum)
+		return 0;
+
+	if (value < absinfo->minimum) value = absinfo->minimum;
+	if (value > absinfo->maximum) value = absinfo->maximum;
+
+	int released = absinfo->minimum;
+	int pressed = absinfo->maximum;
+
+	if (map & MAP_FLAG_CENTERED)
+	{
+		released = (absinfo->minimum + absinfo->maximum) / 2;
+		pressed = (map & MAP_FLAG_NEGATIVE) ? absinfo->minimum : absinfo->maximum;
+	}
+	else if (map & MAP_FLAG_NEGATIVE)
+	{
+		released = absinfo->maximum;
+		pressed = absinfo->minimum;
+	}
+
+	const int denom = pressed - released;
+	if (!denom)
+		return 0;
+
+	int out = ((value - released) * 255) / denom;
+	if (out < 0) out = 0;
+	if (out > 255) out = 255;
+	return (uint8_t)out;
+}
+
+static int joy_analog_triggers(int dev, int axis, int value, const input_absinfo *absinfo)
+{
+	if (!input[dev].num || input[dev].num > NUMPLAYERS)
+		return 0;
+
+	const int num = input[dev].num - 1;
+	int handled = 0;
+
+	for (int trigger = 0; trigger < 2; trigger++)
+	{
+		const uint32_t map = input[dev].mmap[SYS_AXIS_L2 + trigger];
+		if (!(map & MAP_FLAG_TRIGGER) || map_axis_code(map) != axis)
+			continue;
+
+		analog_trigger_pos[num][trigger] = normalize_analog_trigger(map, value, absinfo);
+		handled = 1;
+	}
+
+	if (handled)
+	{
+		if (analog_trigger_pos[num][0] != analog_trigger_last[num][0] ||
+			analog_trigger_pos[num][1] != analog_trigger_last[num][1])
+		{
+			analog_trigger_last[num][0] = analog_trigger_pos[num][0];
+			analog_trigger_last[num][1] = analog_trigger_pos[num][1];
+			user_io_analog_triggers(num, analog_trigger_pos[num][0], analog_trigger_pos[num][1]);
+		}
+	}
+
+	return handled;
+}
+
 static char* get_led_path(int dev, int add_id = 1)
 {
 	static char path[1024];
@@ -2784,6 +3477,8 @@ void reset_players()
 	for (int i = 0; i < NUMPLAYERS; i++) {
 		clear_autofire(i);
 	}
+	memset(analog_trigger_pos, 0, sizeof(analog_trigger_pos));
+	memset(analog_trigger_last, 0, sizeof(analog_trigger_last));
 	memset(player_pad, 0, sizeof(player_pad));
 	memset(player_pdsp, 0, sizeof(player_pdsp));
 }
@@ -2928,7 +3623,8 @@ static uint16_t def_mmap[] = {
 	0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
 	0x0000, 0x0000, 0x013C, 0x0000, 0x013C, 0x0000, 0x0131, 0x0130,
 	0x0000, 0x0002, 0x0001, 0x0002, 0x0003, 0x0002, 0x0004, 0x0002,
-	0x0000, 0x0002, 0x0001, 0x0002, 0x0000, 0x0000, 0x0000, 0x0000
+	0x0000, 0x0002, 0x0001, 0x0002, 0x0000, 0x0000, 0x0000, 0x0000,
+	0x0000, 0x0000, 0x0000, 0x0000
 };
 
 static void assign_player(int dev, int num, int force = 0)
@@ -2943,8 +3639,6 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 {
 	if (ev->type != EV_KEY && ev->type != EV_ABS && ev->type != EV_REL) return;
 	if (ev->type == EV_KEY && (!ev->code || ev->code == KEY_UNKNOWN)) return;
-
-	static uint16_t last_axis = 0;
 
 	int sub_dev = dev;
 
@@ -2985,11 +3679,10 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 		if (input[dev].kbdmap[ev->code]) ev->code = input[dev].kbdmap[ev->code];
 	}
 
-	static int key_mapped = 0;
-
 	int map_skip = (ev->type == EV_KEY && mapping && ((ev->code == KEY_SPACE && mapping_type == 1) || ev->code == KEY_ALTERASE) && (mapping_dev >= 0 || mapping_button<0));
 	int cancel   = (ev->type == EV_KEY && ev->code == KEY_ESC && !(mapping && mapping_type == 3 && mapping_button));
 	int enter    = (ev->type == EV_KEY && ev->code == KEY_ENTER && !(mapping && mapping_type == 3 && mapping_button));
+	int map_back = (ev->type == EV_KEY && ev->code == KEY_BACKSPACE && mapping && mapping_type <= 1);
 	int origcode = ev->code;
 
 	if (!input[dev].has_mmap)
@@ -3004,18 +3697,33 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 		}
 		else if (input[dev].quirk != QUIRK_PDSP && input[dev].quirk != QUIRK_MSSP)
 		{
-			if (!load_map(get_map_name(dev, 1), &input[dev].mmap, sizeof(input[dev].mmap)))
+			char legacy_name[1024];
+			int loaded_saved_map = 0;
+			memset(input[dev].mmap, 0, sizeof(input[dev].mmap));
+			build_map_name(legacy_name, dev, 1, 3);
+			if (load_map(get_map_name(dev, 1), &input[dev].mmap, sizeof(input[dev].mmap)))
 			{
-				if (!gcdb_map_for_controller(input[sub_dev].bustype, input[sub_dev].vid, input[sub_dev].pid, input[sub_dev].gcdb_version, pool[sub_dev].fd, input[dev].mmap))
+				loaded_saved_map = 1;
+			}
+			else
+			{
+				if (load_map(legacy_name, &input[dev].mmap, sizeof(input[dev].mmap)))
+				{
+					loaded_saved_map = 1;
+				}
+				else if (!gcdb_map_for_controller(input[sub_dev].bustype, input[sub_dev].vid, input[sub_dev].pid, input[sub_dev].gcdb_version, pool[sub_dev].fd, input[dev].mmap))
 				{
 					memset(input[dev].mmap, 0, sizeof(input[dev].mmap));
 					memcpy(input[dev].mmap, def_mmap, sizeof(def_mmap));
 					//input[dev].has_mmap++;
 				}
-			} else {
+			}
+
+			if (!input[dev].mmap[SYS_BTN_OSD_KTGL + 2]) input[dev].mmap[SYS_BTN_OSD_KTGL + 2] = input[dev].mmap[SYS_BTN_OSD_KTGL + 1];
+			if (loaded_saved_map)
+			{
 				gcdb_show_string_for_ctrl_map(input[sub_dev].bustype, input[sub_dev].vid, input[sub_dev].pid, input[sub_dev].gcdb_version, pool[sub_dev].fd, input[sub_dev].name, input[dev].mmap);
 			}
-			if (!input[dev].mmap[SYS_BTN_OSD_KTGL + 2]) input[dev].mmap[SYS_BTN_OSD_KTGL + 2] = input[dev].mmap[SYS_BTN_OSD_KTGL + 1];
 
 			if (input[dev].quirk == QUIRK_WHEEL)
 			{
@@ -3033,22 +3741,22 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				if (input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS1_X])
 				{
 					input[dev].stick_l[0] = SYS_AXIS1_X;
-					if ((input[dev].mmap[SYS_AXIS2_X] >> 16) == 2) input[dev].stick_r[0] = SYS_AXIS2_X;
+					if (input[dev].mmap[SYS_AXIS2_X] & MAP_FLAG_ANALOG) input[dev].stick_r[0] = SYS_AXIS2_X;
 				}
 				if (input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS1_Y])
 				{
 					input[dev].stick_l[1] = SYS_AXIS1_Y;
-					if ((input[dev].mmap[SYS_AXIS2_Y] >> 16) == 2) input[dev].stick_r[1] = SYS_AXIS2_Y;
+					if (input[dev].mmap[SYS_AXIS2_Y] & MAP_FLAG_ANALOG) input[dev].stick_r[1] = SYS_AXIS2_Y;
 				}
 				if (input[dev].mmap[SYS_AXIS_X] == input[dev].mmap[SYS_AXIS2_X])
 				{
 					input[dev].stick_l[0] = SYS_AXIS2_X;
-					if ((input[dev].mmap[SYS_AXIS1_X] >> 16) == 2) input[dev].stick_r[0] = SYS_AXIS1_X;
+					if (input[dev].mmap[SYS_AXIS1_X] & MAP_FLAG_ANALOG) input[dev].stick_r[0] = SYS_AXIS1_X;
 				}
 				if (input[dev].mmap[SYS_AXIS_Y] == input[dev].mmap[SYS_AXIS2_Y])
 				{
 					input[dev].stick_l[1] = SYS_AXIS2_Y;
-					if ((input[dev].mmap[SYS_AXIS1_Y] >> 16) == 2) input[dev].stick_r[1] = SYS_AXIS1_Y;
+					if (input[dev].mmap[SYS_AXIS1_Y] & MAP_FLAG_ANALOG) input[dev].stick_r[1] = SYS_AXIS1_Y;
 				}
 			}
 		}
@@ -3062,22 +3770,30 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			memset(input[dev].map, 0, sizeof(input[dev].map));
 			input[dev].map[map_paddle_btn()] = 0x120;
 		}
-		else if (!load_map(get_map_name(dev, 0), &input[dev].map, sizeof(input[dev].map)))
+		else
 		{
+			char legacy_name[1024];
 			memset(input[dev].map, 0, sizeof(input[dev].map));
-			if (!is_menu())
+			build_map_name(legacy_name, dev, 0, 3);
+			if (!load_map(get_map_name(dev, 0), &input[dev].map, sizeof(input[dev].map)))
 			{
-				if (input[dev].has_mmap == 1)
+				if (!load_map(legacy_name, &input[dev].map, sizeof(input[dev].map)))
 				{
-					// not defined try to guess the mapping
-					map_joystick(input[dev].map, input[dev].mmap);
-				}
-				else
-				{
+					if (!is_menu())
+					{
+						if (input[dev].has_mmap == 1)
+						{
+							// not defined try to guess the mapping
+							map_joystick(input[dev].map, input[dev].mmap);
+						}
+						else
+						{
+							input[dev].has_map++;
+						}
+					}
 					input[dev].has_map++;
 				}
 			}
-			input[dev].has_map++;
 		}
 		input[dev].has_map++;
 	}
@@ -3096,7 +3812,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 		if (!assign_btn && ev->type == EV_KEY && ev->value >= 1 && ev->code >= 256)
 		{
-			for (int i = SYS_BTN_RIGHT; i <= SYS_BTN_START; i++)
+			for (int i = SYS_BTN_RIGHT; i <= SYS_BTN_R3; i++)
 			{
 				if (ev->code == input[dev].mmap[i]) assign_btn = 1;
 			}
@@ -3273,11 +3989,18 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 	if (mapping && (mapping_dev >= 0 || ev->value)
 		&& !((mapping_type < 2 || !mapping_button) && (cancel || enter))
+		&& !map_back
 		&& input[dev].quirk != QUIRK_PDSP
 		&& input[dev].quirk != QUIRK_MSSP)
 	{
+		if (mapping_feedback_timer && !CheckTimer(mapping_feedback_timer))
+			return;
+
 		int idx = 0;
 		osdbtn = 0;
+		int released_hold_action = MAP_HOLD_NONE;
+		int released_hold_feedback_expired = 0;
+		int released_hold_timer_expired = 0;
 
 		if (is_menu())
 		{
@@ -3289,14 +4012,26 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 		if ((ev->type == EV_ABS || ev->type == EV_REL) && (ev->code == 7 || ev->code == 8) && input[dev].quirk != QUIRK_WHEEL) return;
 
 		// protection against joysticks generating 2 codes per button
-		if (ev->type == EV_KEY && !(is_menu() && mapping < 2 && mapping_button == SYS_BTN_OSD_KTGL) && !map_skip)
+		if (ev->type == EV_KEY && !(is_menu() && mapping < 2 && mapping_button == SYS_MAP_POS_OSD) && !map_skip)
 		{
 			if (!mapping_current_key)
 			{
 				if (ev->value == 1)
 				{
+					int hold_action = MAP_HOLD_NONE;
+					if (mapping_type <= 1 && input[dev].mmap[SYS_BTN_RIGHT] && ev->code == input[dev].mmap[SYS_BTN_RIGHT])
+						hold_action = MAP_HOLD_SKIP;
+					else if (mapping_type <= 1 && input[dev].mmap[SYS_BTN_LEFT] && ev->code == input[dev].mmap[SYS_BTN_LEFT])
+						hold_action = MAP_HOLD_BACK;
+					else if (!is_menu() && mapping_type <= 1 && input[dev].mmap[SYS_BTN_SELECT] && ev->code == input[dev].mmap[SYS_BTN_SELECT])
+						hold_action = MAP_HOLD_CLEAR;
+
 					mapping_current_key = ev->code;
 					mapping_current_dev = dev;
+					mapping_hold_key = hold_action ? ev->code : 0;
+					mapping_hold_timer = GetTimer(MAP_HOLD_ACTION_MS);
+					mapping_hold_feedback_timer = hold_action ? GetTimer(MAP_HOLD_FEEDBACK_DELAY_MS) : 0;
+					mapping_hold_action = hold_action;
 				}
 				else return;
 			}
@@ -3304,13 +4039,18 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			{
 				if (ev->value == 0 && mapping_current_key == ev->code && mapping_current_dev == dev)
 				{
-					mapping_current_key = 0;
+					released_hold_action = (mapping_hold_key && ev->code == mapping_hold_key) ? mapping_hold_action : MAP_HOLD_NONE;
+					released_hold_feedback_expired = mapping_hold_feedback_timer && CheckTimer(mapping_hold_feedback_timer);
+					released_hold_timer_expired = mapping_hold_timer && CheckTimer(mapping_hold_timer);
+					clear_mapping_current_input();
 				}
 				else return;
 			}
 		}
 
-		if (map_skip) mapping_current_key = 0;
+		if (map_skip) clear_mapping_current_input();
+		if (ev->type == EV_ABS && absinfo)
+			map_menu_analog_trigger_axis(dev, ev->code, absinfo);
 
 		if (ev->type == EV_KEY && mapping_button>=0 && !osd_event)
 		{
@@ -3350,51 +4090,69 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				{
 					mapping_dev = dev;
 					mapping_type = (ev->code >= 256 || input[dev].force_joy) ? 1 : 0;
-					key_mapped = 0;
-					memset(input[mapping_dev].map, 0, sizeof(input[mapping_dev].map));
+					mapping_key_mapped = 0;
 				}
 
 				mapping_clear = 0;
-				if (mapping_dev >= 0 && !map_skip && (mapping_dev == dev || clear) && mapping_button < (is_menu() ? (mapping_type ? SYS_BTN_CNT_ESC + 1 : SYS_BTN_OSD_KTGL + 1) : mapping_count))
+				if (mapping_dev >= 0 && !map_skip && (mapping_dev == dev || clear) && mapping_button < (is_menu() ? (menu_mouse_map ? mapping_count : (mapping_type ? SYS_MAP_GAMEPAD_COUNT : SYS_MAP_POS_OSD + 1)) : mapping_count))
 				{
-					if (ev->value == 1 && !key_mapped)
+					if (ev->value == 1 && !mapping_key_mapped)
 					{
 						if (is_menu())
 						{
-							if (mapping_dev == dev && !(!mapping_button && last_axis && ((ev->code == last_axis) || (ev->code == last_axis + 1))))
+							if (mapping_dev == dev &&
+								(mapping_button < SYS_MAP_AXIS_X || mapping_button > SYS_MAP_AXIS_Y) &&
+								!(!mapping_button && mapping_last_axis && ((ev->code == mapping_last_axis) || (ev->code == mapping_last_axis + 1))))
 							{
-								if (!mapping_button) memset(input[dev].map, 0, sizeof(input[dev].map));
+								if (!mapping_button)
+								{
+									if (menu_mouse_map) clear_mouse_map_slots(input[dev].map);
+									else clear_joypad_map_slots(input[dev].map);
+								}
 								input[dev].osd_combo = 0;
 
 								int found = 0;
-								if (mapping_button < SYS_BTN_CNT_OK)
+								if (mapping_button < SYS_MAP_POS_OSD + 1)
 								{
-									for (int i = (mapping_button >= BUTTON_DPAD_COUNT) ? BUTTON_DPAD_COUNT : 0; i < mapping_button; i++) if (input[dev].map[i] == ev->code) found = 1;
+									for (int i = (mapping_button >= BUTTON_DPAD_COUNT) ? BUTTON_DPAD_COUNT : 0; i < mapping_button; i++)
+									{
+										const int prev_idx = get_system_map_button_idx(i);
+										if (prev_idx >= 0 && input[dev].map[prev_idx] == ev->code) found = 1;
+									}
 								}
 
-								if (!found || (mapping_button == SYS_BTN_OSD_KTGL && mapping_type))
+								if (!found || (mapping_button == SYS_MAP_POS_OSD && mapping_type))
 								{
-									if (mapping_button == SYS_BTN_CNT_OK) input[dev].map[SYS_BTN_MENU_FUNC] = ev->code & 0xFFFF;
-									else if (mapping_button == SYS_BTN_CNT_ESC) input[dev].map[SYS_BTN_MENU_FUNC] = (ev->code << 16) | input[dev].map[SYS_BTN_MENU_FUNC];
-									else if (mapping_button == SYS_BTN_OSD_KTGL)
+									if (mapping_button == SYS_MAP_POS_OSD + 1) input[dev].map[SYS_BTN_MENU_FUNC] = ev->code & 0xFFFF;
+									else if (mapping_button == SYS_MAP_POS_OSD + 2) input[dev].map[SYS_BTN_MENU_FUNC] = (ev->code << 16) | input[dev].map[SYS_BTN_MENU_FUNC];
+									else if (mapping_button == SYS_MAP_POS_OSD)
 									{
 										input[dev].map[SYS_BTN_OSD_KTGL + mapping_type] = ev->code;
 										input[dev].map[SYS_BTN_OSD_KTGL + 2] = input[dev].map[SYS_BTN_OSD_KTGL + 1];
 										mapping_current_key = 0; // allow 2 buttons to be pressed
 									}
-									else input[dev].map[mapping_button] = ev->code;
-
-									key_mapped = ev->code;
-
-									//check if analog stick has been used for mouse
-									if (mapping_button == BUTTON_DPAD_COUNT + 1 || mapping_button == BUTTON_DPAD_COUNT + 3)
+									else
 									{
-										if (input[dev].map[mapping_button] >= KEY_EMU &&
-											input[dev].map[mapping_button - 1] >= KEY_EMU &&
-											(input[dev].map[mapping_button - 1] - input[dev].map[mapping_button] == 1) && // same axis
+										const int system_map_idx = get_system_map_button_idx(mapping_button);
+										if (system_map_idx >= 0) input[dev].map[system_map_idx] = ev->code;
+										map_menu_analog_trigger(dev, ev->code, absinfo);
+									}
+
+									mapping_key_mapped = ev->code;
+
+									// Check if an analog axis has been assigned to mouse movement.
+									const int mouse_axis_base = menu_mouse_map ? (SYS_BTN_A + 1) : (BUTTON_DPAD_COUNT + 1);
+									if (mapping_button == mouse_axis_base || mapping_button == (mouse_axis_base + 2))
+									{
+										const int cur_idx = get_system_map_button_idx(mapping_button);
+										const int prev_idx = get_system_map_button_idx(mapping_button - 1);
+										if (cur_idx >= 0 && prev_idx >= 0 &&
+											input[dev].map[cur_idx] >= KEY_EMU &&
+											input[dev].map[prev_idx] >= KEY_EMU &&
+											(input[dev].map[prev_idx] - input[dev].map[cur_idx] == 1) && // same axis
 											absinfo)
 										{
-											input[dev].map[SYS_AXIS_MX + (mapping_button - (BUTTON_DPAD_COUNT + 1)) / 2] = ((input[dev].map[mapping_button] - KEY_EMU) / 2) | 0x20000;
+											input[dev].map[SYS_AXIS_MX + (mapping_button - mouse_axis_base) / 2] = ((input[dev].map[cur_idx] - KEY_EMU) / 2) | MAP_FLAG_ANALOG;
 										}
 									}
 								}
@@ -3402,53 +4160,85 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 						}
 						else
 						{
+							const int hold_action_for_key = (mapping_hold_key && ev->code == mapping_hold_key) ? mapping_hold_action : MAP_HOLD_NONE;
 							if (clear)
 							{
-								memset(input[mapping_dev].map, 0, sizeof(input[mapping_dev].map));
-								mapping_button = 0;
-								mapping_clear = 1;
+								do_map_clear();
 							}
-							else
+							else if (hold_action_for_key != MAP_HOLD_CLEAR)
 							{
-								if (!mapping_button)
-								{
-									for (uint i = 0; i < sizeof(input[0].map) / sizeof(input[0].map[0]); i++)
-									{
-										input[dev].map[i] &= mapping_set ? 0x0000FFFF : 0xFFFF0000;
-									}
-								}
-
-								int found = 0;
-								for (int i = 0; i < mapping_button; i++)
-								{
-									if (mapping_set && (input[dev].map[i] >> 16) == ev->code) found = 1;
-									if (!mapping_set && (input[dev].map[i] & 0xFFFF) == ev->code) found = 1;
-								}
-
-								if (!found)
-								{
-									if (mapping_set) input[dev].map[mapping_button] = (input[dev].map[mapping_button] & 0xFFFF) | (ev->code << 16);
-									else input[dev].map[mapping_button] = (input[dev].map[mapping_button] & 0xFFFF0000) | ev->code;
-									key_mapped = ev->code;
-								}
+								map_core_button_code(dev, ev->code);
 							}
 						}
 					}
 					//combo for osd button
-					if (ev->value == 1 && key_mapped && key_mapped != ev->code && is_menu() && mapping_button == SYS_BTN_OSD_KTGL && mapping_type)
+					if (ev->value == 1 && mapping_key_mapped && mapping_key_mapped != ev->code && is_menu() && mapping_button == SYS_MAP_POS_OSD && mapping_type)
 					{
+						if (mapping_hold_key && ev->code != mapping_hold_key)
+						{
+							clear_mapping_hold_state();
+						}
+						mapping_combo_second_key = ev->code;
+						mapping_combo_release_mask = 0;
 						input[dev].map[SYS_BTN_OSD_KTGL + 2] = ev->code;
 						printf("Set combo: %x + %x\n", input[dev].map[SYS_BTN_OSD_KTGL + 1], input[dev].map[SYS_BTN_OSD_KTGL + 2]);
 					}
-					else if(mapping_dev == dev && ev->value == 0 && key_mapped == ev->code)
+					else if (mapping_dev == dev && ev->value == 0 && mapping_button == SYS_MAP_POS_OSD && mapping_type && mapping_key_mapped && mapping_combo_second_key)
 					{
+						if (ev->code == mapping_key_mapped) mapping_combo_release_mask |= 1;
+						if (ev->code == mapping_combo_second_key) mapping_combo_release_mask |= 2;
+						if (mapping_combo_release_mask == 3)
+						{
+							mapping_button++;
+							mapping_key_mapped = 0;
+							clear_mapping_combo_state();
+						}
+					}
+					else if (mapping_dev == dev && ev->value == 0 &&
+						released_hold_action == MAP_HOLD_CLEAR && !mapping_key_mapped)
+					{
+						if (released_hold_timer_expired)
+						{
+							do_map_clear();
+						}
+						else if (released_hold_feedback_expired)
+						{
+							clear_mapping_current_input();
+							clear_mapping_combo_state();
+						}
+						else
+						{
+							clear_mapping_current_input();
+							clear_mapping_combo_state();
+							if (map_core_button_code(dev, ev->code))
+							{
+								mapping_button++;
+								mapping_key_mapped = 0;
+							}
+						}
+					}
+					else if (mapping_dev == dev && ev->value == 0 &&
+						((mapping_ignore_release_key && mapping_ignore_release_key == ev->code) ||
+						 (mapping_ignore_release_key2 && mapping_ignore_release_key2 == ev->code)))
+					{
+						mapping_key_mapped = 0;
+						if (mapping_ignore_release_key == ev->code) mapping_ignore_release_key = 0;
+						if (mapping_ignore_release_key2 == ev->code) mapping_ignore_release_key2 = 0;
+					}
+					else if(mapping_dev == dev && ev->value == 0 && mapping_key_mapped == ev->code)
+					{
+						if (mapping_hold_key && ev->code == mapping_hold_key)
+						{
+							clear_mapping_hold_state();
+						}
 						mapping_button++;
-						key_mapped = 0;
+						mapping_key_mapped = 0;
+						clear_mapping_combo_state();
 					}
 
-					if(!ev->value && mapping_dev == dev && ((ev->code == last_axis) || (ev->code == last_axis+1)))
+					if(!ev->value && mapping_dev == dev && ((ev->code == mapping_last_axis) || (ev->code == mapping_last_axis+1)))
 					{
-						last_axis = 0;
+						mapping_last_axis = 0;
 					}
 				}
 			}
@@ -3458,8 +4248,8 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			//Define min-0-max analogs
 			switch (mapping_button)
 			{
-				case 23: idx = SYS_AXIS_X;  break;
-				case 24: idx = SYS_AXIS_Y;  break;
+				case SYS_MAP_AXIS_X:  idx = SYS_AXIS_X;  break;
+				case SYS_MAP_AXIS_Y:  idx = SYS_AXIS_Y;  break;
 				case -4: idx = SYS_AXIS1_X; break;
 				case -3: idx = SYS_AXIS1_Y; break;
 				case -2: idx = SYS_AXIS2_X; break;
@@ -3482,7 +4272,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				//check DPAD horz
 				if (mapping_button == -6)
 				{
-					last_axis = 0;
+					mapping_last_axis = 0;
 					if (ev->type == EV_ABS && max)
 					{
 						if (mapping_dev < 0) mapping_dev = dev;
@@ -3490,7 +4280,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 
 						if (absinfo->maximum > 2)
 						{
-							tmp_axis[tmp_axis_n++] = ev->code | 0x20000;
+							tmp_axis[tmp_axis_n++] = ev->code | MAP_FLAG_ANALOG;
 							mapping_button++;
 						}
 						else
@@ -3520,7 +4310,7 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				{
 					if (ev->type == EV_ABS && max && absinfo->maximum > 1 && ev->code != (tmp_axis[0] & 0xFFFF))
 					{
-						tmp_axis[tmp_axis_n++] = ev->code | 0x20000;
+						tmp_axis[tmp_axis_n++] = ev->code | MAP_FLAG_ANALOG;
 						mapping_button++;
 					}
 				}
@@ -3538,18 +4328,18 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 							if (!found)
 							{
 								mapping_type = 1;
-								tmp_axis[tmp_axis_n++] = ev->code | 0x20000;
+								tmp_axis[tmp_axis_n++] = ev->code | MAP_FLAG_ANALOG;
 								//if (min) tmp_axis[idx - AXIS1_X] |= 0x10000;
 								mapping_button++;
 								if (tmp_axis_n >= 4) mapping_button = 0;
-								last_axis = KEY_EMU + (ev->code << 1);
+								mapping_last_axis = KEY_EMU + (ev->code << 1);
 							}
 						}
 						else
 						{
 							if (idx == SYS_AXIS_X || ev->code != (input[dev].map[idx - 1] & 0xFFFF))
 							{
-								input[dev].map[idx] = ev->code | 0x20000;
+								input[dev].map[idx] = ev->code | MAP_FLAG_ANALOG;
 								//if (min) input[dev].map[idx] |= 0x10000;
 								mapping_button++;
 							}
@@ -3568,14 +4358,15 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					if (mapping_dev >= 0)
 					{
 						if (idx) input[mapping_dev].map[idx] = 0;
-						else if (mapping_button > 0)
-						{
-							if (!is_menu()) input[mapping_dev].map[mapping_button] &= mapping_set ? 0x0000FFFF : 0xFFFF0000;
-						}
+						else if (mapping_button >= 0) clear_mapping_slot_for_pos(input[mapping_dev].map, mapping_button);
 					}
-					last_axis = 0;
-					mapping_button++;
-					if (mapping_button < 0 && (mapping_button & 1)) mapping_button++;
+					set_mapping_ignore_release_keys(mapping_key_mapped, mapping_combo_second_key);
+					mapping_key_mapped = 0;
+					clear_mapping_combo_state();
+					mapping_last_axis = 0;
+					advance_map_button();
+					map_skip = 0;
+					break;
 				}
 			}
 
@@ -3584,15 +4375,17 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			if (!map_skip) break;
 		}
 
-		if (is_menu() && mapping_type <= 1 && mapping_dev >= 0)
+		prepare_mapping_trigger_capture();
+
+		if (is_menu() && mapping_type <= 1 && mapping_dev >= 0 && !menu_mouse_map)
 		{
-			memcpy(&input[mapping_dev].mmap[SYS_AXIS1_X], tmp_axis, sizeof(tmp_axis));
-			memcpy(&input[mapping_dev].map[SYS_AXIS1_X], tmp_axis, sizeof(tmp_axis));
+			if (mapping_button < 0) record_menu_tmp_axis_stage();
+			sync_menu_tmp_axes();
 		}
 	}
 	else
 	{
-		key_mapped = 0;
+		mapping_key_mapped = 0;
 		switch (ev->type)
 		{
 		case EV_KEY:
@@ -3748,10 +4541,10 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 						input[dev].has_map = 1;
 					}
 
-					for (uint i = 0; i < BTN_NUM; i++)
+					for (uint i = 0; i < BTN_NUM && i < 32; i++)
 					{
 						if (ev->code == (input[dev].map[i] & 0xFFFF) || ev->code == (input[dev].map[i] >> 16)) {
-							if (ev->value <= 1) joy_digital(input[dev].num, 1 << i, origcode, ev->value, i, (ev->code == input[dev].mmap[SYS_BTN_OSD_KTGL + 1] || ev->code == input[dev].mmap[SYS_BTN_OSD_KTGL + 2]));
+							if (ev->value <= 1) joy_digital(input[dev].num, 1u << i, origcode, ev->value, i, (ev->code == input[dev].mmap[SYS_BTN_OSD_KTGL + 1] || ev->code == input[dev].mmap[SYS_BTN_OSD_KTGL + 2]));
 						}
 					}
 
@@ -3807,11 +4600,11 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 				{
 					if (!kbd_toggle)
 					{
-						for (uint i = 0; i < BTN_NUM; i++)
+						for (uint i = 0; i < BTN_NUM && i < 32; i++)
 						{
 							if (ev->code == (uint16_t)input[dev].map[i])
 							{
-								if (ev->value <= 1) joy_digital((user_io_get_kbdemu() == EMU_JOY0) ? 1 : 2, 1 << i, origcode, ev->value, i);
+								if (ev->value <= 1) joy_digital((user_io_get_kbdemu() == EMU_JOY0) ? 1 : 2, 1u << i, origcode, ev->value, i);
 								return;
 							}
 						}
@@ -3914,6 +4707,9 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 					}
 					break;
 				}
+
+				if (joy_analog_triggers(dev, ev->code, value, absinfo))
+					break;
 
 				int hrange = (absinfo->maximum - absinfo->minimum) / 2;
 
@@ -6098,7 +6894,8 @@ int input_test(int getchar)
 										int treshold = range / 4;
 
 										int only_max = 1;
-										for (int n = 0; n < 4; n++) if (input[dev].mmap[SYS_AXIS1_X + n] && ((input[dev].mmap[SYS_AXIS1_X + n] & 0xFFFF) == ev.code)) only_max = 0;
+										for (int n = 0; n < 4; n++) if (input[dev].mmap[SYS_AXIS1_X + n] && (map_axis_code(input[dev].mmap[SYS_AXIS1_X + n]) == ev.code)) only_max = 0;
+										for (int n = 0; n < 2; n++) if ((input[dev].mmap[SYS_AXIS_L2 + n] & MAP_FLAG_NEGATIVE) && (map_axis_code(input[dev].mmap[SYS_AXIS_L2 + n]) == ev.code)) only_max = 0;
 
 										if (ev.value < center - treshold && !only_max) axis_edge = 1;
 										if (ev.value > center + treshold) axis_edge = 2;
@@ -6568,8 +7365,9 @@ uint32_t advanced_get_btn_mask_for_code(uint16_t evcode, int devnum)
 
 	for (uint i = 0; i < BTN_NUM; i++)
 	{
-		if (evcode == (input[devnum].map[i] & 0xFFFF)) mask |= 1 << i;
-		else if (evcode == (input[devnum].map[i] >> 16)) mask |= 1 << i;
+		if (i >= 32) break;
+		if (evcode == (input[devnum].map[i] & 0xFFFF)) mask |= 1u << i;
+		else if (evcode == (input[devnum].map[i] >> 16)) mask |= 1u << i;
 	}
 
 	return mask;

--- a/input.cpp
+++ b/input.cpp
@@ -7667,8 +7667,8 @@ advancedButtonMap *get_advanced_map_defs(int devnum)
 void get_button_name_for_code(uint16_t btn_code, int devnum, char *bname, size_t bname_sz)
 {
 	static int last_devnum = -1;
-	static uint16_t btn_map[KEY_MAX - BTN_JOYSTICK] = {0};
-	static uint16_t abs_map[ABS_MAX] = {0};
+	static uint16_t btn_map[GCDB_BUTTON_MAP_SIZE] = {};
+	static uint16_t abs_map[GCDB_AXIS_MAP_SIZE] = {};
 	if (devnum != last_devnum)
 	{
 		memset(btn_map, 0xFFFF, sizeof(btn_map));

--- a/input.h
+++ b/input.h
@@ -31,8 +31,8 @@
 
 #define NUMPLAYERS          6
 
-#define NUMBUTTONS         32
-#define BUTTON_DPAD_COUNT  12 // dpad + 8 buttons
+#define NUMBUTTONS         38
+#define BUTTON_DPAD_COUNT  16 // dpad + 12 buttons
 
 #define SYS_BTN_RIGHT       0
 #define SYS_BTN_LEFT        1
@@ -64,6 +64,25 @@
 #define SYS_AXIS_Y         29
 #define SYS_AXIS_MX        30
 #define SYS_AXIS_MY        31
+#define SYS_BTN_L2         32
+#define SYS_BTN_R2         33
+#define SYS_BTN_L3         34
+#define SYS_BTN_R3         35
+#define SYS_AXIS_L2        36
+#define SYS_AXIS_R2        37
+
+#define SYS_MAP_BTN_L2     10
+#define SYS_MAP_BTN_SELECT 14
+#define SYS_MAP_POS_OSD    16
+#define SYS_MAP_AXIS_X     19
+#define SYS_MAP_AXIS_Y     20
+
+#define MAP_AXIS_MASK       0x0000FFFF
+#define MAP_FLAG_INVERT     0x00010000
+#define MAP_FLAG_ANALOG     0x00020000
+#define MAP_FLAG_TRIGGER    0x00040000
+#define MAP_FLAG_CENTERED   0x00080000
+#define MAP_FLAG_NEGATIVE   0x00100000
 
 #define SYS_BTN_CNT_OK     21
 #define SYS_BTN_CNT_ESC    22
@@ -103,6 +122,9 @@ int input_poll(int getchar);
 int is_key_pressed(int key);
 
 void start_map_setting(int cnt, int set = 0, advancedButtonMap *code_store = NULL);
+void set_menu_mouse_map(int enable);
+int get_menu_mouse_map();
+int step_back_map_setting();
 int get_map_set();
 int get_map_button();
 int get_map_type();
@@ -115,9 +137,15 @@ uint16_t get_map_pid();
 int get_map_dev();
 advancedButtonMap *get_map_code_store();
 int get_map_advance();
+const char *get_map_feedback();
+const char *get_map_hold_feedback();
+void poll_map_feedback();
 int get_map_count();
 int has_default_map();
 void send_map_cmd(int key);
+void trigger_map_clear();
+int poll_map_hold_action();
+int get_map_active();
 void reset_players();
 
 uint32_t get_key_mod();

--- a/input.h
+++ b/input.h
@@ -147,6 +147,7 @@ void trigger_map_clear();
 int poll_map_hold_action();
 int get_map_active();
 void reset_players();
+void input_analog_triggers_resync(int suppress);
 
 uint32_t get_key_mod();
 uint32_t get_ps2_code(uint16_t key);

--- a/joymapping.cpp
+++ b/joymapping.cpp
@@ -14,6 +14,7 @@ This file contains lookup information on known controllers
 #include "cfg.h"
 
 #define DPAD_COUNT 4
+#define CORE_BUTTON_COUNT (32 - DPAD_COUNT)
 
 /*****************************************************************************/
 static void trim(char * s)
@@ -51,7 +52,7 @@ static void read_buttons()
 	p = get_buttons(0);
 	if (p)
 	{
-		for (int n = 0; n < NUMBUTTONS - DPAD_COUNT; n++)
+		for (int n = 0; n < CORE_BUTTON_COUNT; n++)
 		{
 			substrcpy(joy_names[n], p, n);
 			if (!joy_names[n][0]) break;
@@ -114,6 +115,22 @@ static int is_fire(char* name)
 	return 0;
 }
 
+static int is_extended_button(char *name)
+{
+	return !strcasecmp(name, "L2")
+		|| !strcasecmp(name, "R2")
+		|| !strcasecmp(name, "L3")
+		|| !strcasecmp(name, "R3");
+}
+
+static void copy_core_button_name(char *dst, int index)
+{
+	strcpy(dst, joy_names[index]);
+	char *p = strchr(dst, '(');
+	if (p) *p = 0;
+	trim(dst);
+}
+
 void map_joystick(uint32_t *map, uint32_t *mmap)
 {
 	/*
@@ -152,6 +169,11 @@ void map_joystick(uint32_t *map, uint32_t *mmap)
 		int idx = i+DPAD_COUNT;
 		char btn_name[32];
 		strcpy(btn_name, defaults ? joy_pnames[n] : joy_nnames[n]);
+		if (!btn_name[0])
+		{
+			copy_core_button_name(btn_name, i);
+			if (!is_extended_button(btn_name)) btn_name[0] = 0;
+		}
 
 		char *p = strchr(btn_name, '|');
 		if (p) *p = 0;
@@ -197,6 +219,26 @@ void map_joystick(uint32_t *map, uint32_t *mmap)
 			map[idx] = mmap[SYS_BTN_L];
 		}
 
+		else if(!strcasecmp(btn_name, "L2"))
+		{
+			map[idx] = mmap[SYS_BTN_L2];
+		}
+
+		else if(!strcasecmp(btn_name, "R2"))
+		{
+			map[idx] = mmap[SYS_BTN_R2];
+		}
+
+		else if(!strcasecmp(btn_name, "L3"))
+		{
+			map[idx] = mmap[SYS_BTN_L3];
+		}
+
+		else if(!strcasecmp(btn_name, "R3"))
+		{
+			map[idx] = mmap[SYS_BTN_R3];
+		}
+
 		else if(!strcasecmp(btn_name, "Select")
 		|| !strcasecmp(btn_name, "Mode")
 		|| !strcasecmp(btn_name, "Game Select")
@@ -240,6 +282,10 @@ static const char* get_std_name(uint16_t code, uint32_t *mmap)
 		if (code == mmap[SYS_BTN_Y]) return "[Y]";
 		if (code == mmap[SYS_BTN_L]) return "[L]";
 		if (code == mmap[SYS_BTN_R]) return "[R]";
+		if (code == mmap[SYS_BTN_L2]) return "[L2]";
+		if (code == mmap[SYS_BTN_R2]) return "[R2]";
+		if (code == mmap[SYS_BTN_L3]) return "[L3]";
+		if (code == mmap[SYS_BTN_R3]) return "[R3]";
 		if (code == mmap[SYS_BTN_SELECT]) return "[\x96]";
 		if (code == mmap[SYS_BTN_START]) return "[\x16]";
 		return "[ ]";

--- a/joymapping.cpp
+++ b/joymapping.cpp
@@ -149,16 +149,24 @@ void map_joystick(uint32_t *map, uint32_t *mmap)
 
 	if (mmap[SYS_AXIS_X] && !is_psx())
 	{
-		uint32_t key = KEY_EMU + (((uint16_t)mmap[SYS_AXIS_X]) << 1);
-		map[SYS_BTN_LEFT] = (key << 16) | map[SYS_BTN_LEFT];
-		map[SYS_BTN_RIGHT] = ((key+1) << 16) | map[SYS_BTN_RIGHT];
+		const uint32_t min_key = KEY_EMU + ((mmap[SYS_AXIS_X] & MAP_AXIS_MASK) << 1);
+		const uint32_t max_key = min_key + 1;
+		const uint32_t left_key = (mmap[SYS_AXIS_X] & MAP_FLAG_INVERT) ? max_key : min_key;
+		const uint32_t right_key = (mmap[SYS_AXIS_X] & MAP_FLAG_INVERT) ? min_key : max_key;
+
+		map[SYS_BTN_LEFT] = (left_key << 16) | map[SYS_BTN_LEFT];
+		map[SYS_BTN_RIGHT] = (right_key << 16) | map[SYS_BTN_RIGHT];
 	}
 
 	if (mmap[SYS_AXIS_Y] && !is_psx())
 	{
-		uint32_t key = KEY_EMU + (((uint16_t)mmap[SYS_AXIS_Y]) << 1);
-		map[SYS_BTN_UP] = (key << 16) | map[SYS_BTN_UP];
-		map[SYS_BTN_DOWN] = ((key + 1) << 16) | map[SYS_BTN_DOWN];
+		const uint32_t min_key = KEY_EMU + ((mmap[SYS_AXIS_Y] & MAP_AXIS_MASK) << 1);
+		const uint32_t max_key = min_key + 1;
+		const uint32_t up_key = (mmap[SYS_AXIS_Y] & MAP_FLAG_INVERT) ? max_key : min_key;
+		const uint32_t down_key = (mmap[SYS_AXIS_Y] & MAP_FLAG_INVERT) ? min_key : max_key;
+
+		map[SYS_BTN_UP] = (up_key << 16) | map[SYS_BTN_UP];
+		map[SYS_BTN_DOWN] = (down_key << 16) | map[SYS_BTN_DOWN];
 	}
 
 	// loop through core requested buttons and construct result map

--- a/menu.cpp
+++ b/menu.cpp
@@ -232,6 +232,19 @@ static uint32_t load_addr = 0;
 static int32_t  bt_timer = 0;
 static bool     bt_present = false;
 static bool     bt_pairing = false;
+static uint8_t joymap_confirm_armed = 0;
+
+enum
+{
+	MENU_SYSTEM_SUB_STORAGE = 0,
+	MENU_SYSTEM_SUB_KBDMAP,
+	MENU_SYSTEM_SUB_JOYPAD_MAP,
+	MENU_SYSTEM_SUB_MOUSE_MAP,
+	MENU_SYSTEM_SUB_SCRIPTS,
+	MENU_SYSTEM_SUB_HELP,
+	MENU_SYSTEM_SUB_REBOOT,
+	MENU_SYSTEM_SUB_EXIT
+};
 
 static bool osd_unlocked = 1;
 static char osd_code_entry[32];
@@ -249,8 +262,8 @@ const char *config_autofire_msg[] = { "        AUTOFIRE OFF", "        AUTOFIRE 
 const char *config_joystick_mode[] = { "Digital", "Analog", "CD32", "Analog" };
 const char *config_button_turbo_msg[] = { "OFF", "FAST", "MEDIUM", "SLOW" };
 const char *config_button_turbo_choice_msg[] = { "A only", "B only", "A & B" };
-const char *joy_button_map[] = { "RIGHT", "LEFT", "DOWN", "UP", "BUTTON A", "BUTTON B", "BUTTON X", "BUTTON Y", "BUTTON L", "BUTTON R", "SELECT", "START", "KBD TOGGLE", "MENU", "    Stick 1: Tilt RIGHT", "    Stick 1: Tilt DOWN", "   Mouse emu X: Tilt RIGHT", "   Mouse emu Y: Tilt DOWN" };
-const char *joy_ana_map[] = { "    DPAD test: Press RIGHT", "    DPAD test: Press DOWN", "   Stick 1 Test: Tilt RIGHT", "   Stick 1 Test: Tilt DOWN", "   Stick 2 Test: Tilt RIGHT", "   Stick 2 Test: Tilt DOWN" };
+const char *joy_button_map[] = { "RIGHT", "LEFT", "DOWN", "UP", "A", "B", "X", "Y", "L", "R", "SELECT", "START", "KBD TOGGLE", "Menu", "   Stick 1: Analog RIGHT", "    Stick 1: Analog DOWN", "   Mouse emu X: Tilt RIGHT", "   Mouse emu Y: Tilt DOWN" };
+const char *joy_ana_map[] = { "DPAD test: Press RIGHT", "DPAD test: Press DOWN", "Stick 1: Analog RIGHT", "Stick 1: Analog DOWN", "Stick 2: Analog RIGHT", "Stick 2: Analog DOWN" };
 const char *config_stereo_msg[] = { "0%", "25%", "50%", "100%" };
 const char *config_uart_msg[] = { "      None", "       PPP", "   Console", "      MIDI", "     Modem", "UDP", "SNI"};
 const char *config_midilink_mode[] = {"Local", "Local", "  USB", "  UDP", "-----", "-----", "  USB" };
@@ -260,6 +273,8 @@ const char *config_scale[] = { "Normal", "V-Integer", "HV-Integer-", "HV-Integer
 
 #define DPAD_NAMES 4
 #define DPAD_BUTTON_NAMES 12  //DPAD_NAMES + 6 buttons + start/select
+#define SYS_MAP_KEYBOARD_BUTTON_COUNT (SYS_MAP_POS_OSD - DPAD_NAMES + 1)
+#define SYS_MAP_GAMEPAD_BUTTON_COUNT  (SYS_MAP_POS_OSD - DPAD_NAMES + 3)
 
 #define script_line_length 1024
 #define script_lines 50
@@ -589,7 +604,7 @@ static uint32_t menu_key_get(void)
 		else if (CheckTimer(repeat))
 		{
 			repeat = GetTimer(REPEATRATE);
-			if (GetASCIIKey(c1) || menustate == MENU_FILE_SELECT2 || ((menustate == MENU_COMMON2) && (menusub == 17)) || ((menustate == MENU_SYSTEM2) && (menusub == 5)))
+			if (GetASCIIKey(c1) || menustate == MENU_FILE_SELECT2 || ((menustate == MENU_COMMON2) && (menusub == 17)) || ((menustate == MENU_SYSTEM2) && (menusub == MENU_SYSTEM_SUB_REBOOT)))
 			{
 				c = c1;
 				hold_cnt++;
@@ -632,7 +647,11 @@ static uint32_t menu_key_get(void)
 				longpress_consumed = 1;
 				if (is_menu())
 				{
-					if (menustate == MENU_SYSTEM2 || menustate == MENU_FILE_SELECT2) menustate = MENU_JOYSYSMAP;
+					if (menustate == MENU_SYSTEM2 || menustate == MENU_FILE_SELECT2)
+					{
+						set_menu_mouse_map(0);
+						menustate = MENU_JOYSYSMAP;
+					}
 				}
 				else if (get_map_vid() || get_map_pid())
 				{
@@ -1088,6 +1107,11 @@ static void *close_pipe_async(void *arg)
 	return NULL;
 }
 
+static int is_map_nav_hold_feedback(const char *feedback)
+{
+	return feedback && (!strcmp(feedback, "Skip/Unmap") || !strcmp(feedback, "Previous"));
+}
+
 void HandleUI(void)
 {
 	PROFILE_FUNCTION();
@@ -1133,7 +1157,7 @@ void HandleUI(void)
 	static char ioctl_index;
 	char *p;
 	static char s[256];
-	unsigned char m = 0, up, down, select, menu, back, right, left, plus, minus, recent;
+	unsigned char m = 0, up, down, select, menu, back, right, left, plus, minus, recent, finish;
 	char enable;
 	static int reboot_req = 0;
 	static uint32_t helptext_timer;
@@ -1226,11 +1250,15 @@ void HandleUI(void)
 		// get user control codes
 		c = menu_key_get();
 	}
+	int map_hold_action = poll_map_hold_action();
+	poll_map_feedback();
+	if (map_hold_action) c = 0;
 
 	// decode and set events
 	menu = false;
 	back = false;
 	select = false;
+	finish = false;
 	up = false;
 	down = false;
 	left = false;
@@ -1238,6 +1266,19 @@ void HandleUI(void)
 	plus = false;
 	minus = false;
 	recent = false;
+
+	switch (map_hold_action)
+	{
+	case 1:
+		send_map_cmd(KEY_ALTERASE);
+		break;
+	case 2:
+		back = true;
+		break;
+	case 4:
+		trigger_map_clear();
+		break;
+	}
 
 	if (c && cfg.bootcore[0] != '\0') cfg.bootcore[0] = '\0';
 
@@ -1308,6 +1349,7 @@ void HandleUI(void)
 	//prevent OSD control while script is executing on framebuffer
 	if ((!video_fb_state() || video_chvt(0) != 2) && !select_ini)
 	{
+		if (c == KEY_ENTER || c == KEY_KPENTER) finish = true;
 		switch (c)
 		{
 		case KEY_F12:
@@ -1380,7 +1422,7 @@ void HandleUI(void)
 			else menu = true;
 			break;
 		case KEY_BACKSPACE | UPSTROKE:
-			if (saved_menustate || !osd_unlocked) back = true;
+			if (saved_menustate || !osd_unlocked || get_map_active()) back = true;
 			break;
 		case KEY_ENTER:
 		case KEY_SPACE:
@@ -4134,18 +4176,35 @@ void HandleUI(void)
 		break;
 
 	case MENU_JOYRESET:
-		OsdWrite(3);
-		OsdWrite(4, "       Reset to default");
-		OsdWrite(5);
+		for (int i = 0; i < OsdGetSize(); i++) OsdWrite(i);
+		m = 6;
+		menumask = 3;
+		OsdWrite(m++, "    Reset saved mapping?");
+		OsdWrite(m++, "           No", menusub == 0);
+		OsdWrite(m++, "           Yes", menusub == 1);
+		OsdWrite(m++, "     Enter to confirm");
+		parentstate = menustate;
 		menustate = MENU_JOYRESET1;
 		break;
 
 	case MENU_JOYRESET1:
-		if (!user_io_user_button())
+		if (menu || back)
 		{
-			finish_map_setting(2);
-			menustate = MENU_COMMON1;
-			menusub = 1;
+			menustate = MENU_JOYDIGMAP1;
+			break;
+		}
+		if (select)
+		{
+			if (menusub)
+			{
+				finish_map_setting(2);
+				menustate = MENU_COMMON1;
+				menusub = 1;
+			}
+			else
+			{
+				menustate = MENU_JOYDIGMAP1;
+			}
 		}
 		break;
 
@@ -4172,7 +4231,17 @@ void HandleUI(void)
 
 	case MENU_JOYDIGMAP1:
 		{
-			int line_info = 0;
+			int show_combo_hint = 0;
+			int combo_hint_below_prompt = 0;
+			int save_now = finish;
+			char id_line[64] = { 0 };
+			const char *subtitle = 0;
+			const char *map_feedback = get_map_feedback();
+			const char *map_hold_feedback = get_map_hold_feedback();
+			const int show_hold_feedback_in_prompt = is_map_nav_hold_feedback(map_hold_feedback);
+			char info_line[32] = { 0 };
+			const int show_gamepad = is_menu() && joy_bcount && !get_menu_mouse_map() &&
+				get_map_button() >= SYS_BTN_RIGHT && get_map_button() <= SYS_MAP_POS_OSD + 2;
 			if (get_map_clear())
 			{
 				OsdWrite(3);
@@ -4190,12 +4259,26 @@ void HandleUI(void)
 				break;
 			}
 
+			if (back && step_back_map_setting())
+			{
+				back = 0;
+				save_now = 0;
+			}
+
 			if (is_menu() && !get_map_button()) OsdWrite(7);
 
 			const char* p = 0;
 			if (get_map_button() < 0)
 			{
-				strcpy(s, joy_ana_map[get_map_button() + 6]);
+				const char *pa = joy_ana_map[get_map_button() + 6];
+				s[0] = 0;
+				int len = (30 - (int)strlen(pa)) / 2;
+				while (len > 0)
+				{
+					strcat(s, " ");
+					len--;
+				}
+				strcat(s, pa);
 				OsdWrite(7, "   Space/User \x16 Skip");
 			}
 			else if (get_map_button() < DPAD_NAMES)
@@ -4207,14 +4290,13 @@ void HandleUI(void)
 				p = joy_bnames[get_map_button() - DPAD_NAMES];
 				if (is_menu())
 				{
-					if (!get_map_type()) joy_bcount = 17;
-					if (get_map_button() == SYS_BTN_OSD_KTGL)
+					if (!get_menu_mouse_map())
 					{
-						p = joy_button_map[DPAD_BUTTON_NAMES + get_map_type()];
-						if (get_map_type())
+						if (!get_map_type()) joy_bcount = SYS_MAP_KEYBOARD_BUTTON_COUNT;
+						if (get_map_button() == SYS_MAP_POS_OSD)
 						{
-							OsdWrite(12, "   (can use 2-button combo)");
-							line_info = 1;
+							p = joy_button_map[DPAD_BUTTON_NAMES + get_map_type()];
+							if (get_map_type()) show_combo_hint = 1;
 						}
 					}
 				}
@@ -4224,11 +4306,44 @@ void HandleUI(void)
 				p = (get_map_button() < DPAD_BUTTON_NAMES) ? joy_button_map[get_map_button()] : joy_button_map[DPAD_BUTTON_NAMES + get_map_type()];
 			}
 
+			if (is_menu() && get_map_type() && !get_menu_mouse_map())
+			{
+				switch (get_map_button())
+				{
+					case SYS_BTN_A:
+						p = "A";
+						break;
+					case SYS_BTN_B:
+						p = "B";
+						break;
+					case SYS_BTN_X:
+						p = "X";
+						break;
+					case SYS_BTN_Y:
+						p = "Y";
+						break;
+				}
+			}
+
+			if (show_hold_feedback_in_prompt)
+			{
+				show_combo_hint = 0;
+			}
+			else if (map_hold_feedback) subtitle = map_hold_feedback;
+			else if (map_feedback) subtitle = map_feedback;
+
 			if (get_map_button() >= 0)
 			{
-				if (is_menu() && get_map_button() > SYS_BTN_CNT_ESC)
+				if (show_hold_feedback_in_prompt)
 				{
-					strcpy(s, joy_button_map[(get_map_button() - SYS_BTN_CNT_ESC - 1) + DPAD_BUTTON_NAMES + 2]);
+					int len = (30 - (int)strlen(map_hold_feedback)) / 2;
+					s[0] = 0;
+					while (len-- > 0) strcat(s, " ");
+					strcat(s, map_hold_feedback);
+				}
+				else if (is_menu() && get_map_button() >= SYS_MAP_AXIS_X && get_map_button() <= SYS_MAP_AXIS_Y)
+				{
+					strcpy(s, joy_button_map[(get_map_button() - SYS_MAP_AXIS_X) + DPAD_BUTTON_NAMES + 2]);
 				}
 				else
 				{
@@ -4245,10 +4360,51 @@ void HandleUI(void)
 				}
 			}
 
-			OsdWrite(3, s, 0, 0);
-			OsdWrite(4);
+			if (get_map_vid() || get_map_pid())
+			{
+				char id_text[48];
+				sprintf(id_text, "%s ID: %04x:%04x", get_map_type() ? "Joypad" : "Keyboard", get_map_vid(), get_map_pid());
+				int len = (30 - (int)strlen(id_text)) / 2;
+				while (len-- > 0) strcat(id_line, " ");
+				strcat(id_line, id_text);
+			}
 
-			if(is_menu() && joy_bcount && get_map_button() >= SYS_BTN_RIGHT && get_map_button() <= SYS_BTN_START)
+			if (subtitle)
+			{
+				int len = (30 - (int)strlen(subtitle)) / 2;
+				while (len-- > 0) strcat(info_line, " ");
+				strcat(info_line, subtitle);
+			}
+			else if (show_combo_hint)
+			{
+				strcpy(info_line, "   (can use 2-button combo)");
+				combo_hint_below_prompt = 1;
+			}
+
+			if (show_gamepad)
+			{
+				OsdWrite(1, s, 0, 0);
+				OsdWrite(2, info_line, 0, 0);
+				OsdWrite(3, id_line, 0, 0);
+				OsdWrite(4);
+				OsdWrite(5, "User/Space/Hold RIGHT \x16 Undefine");
+				OsdWrite(6, " Backspace/Hold LEFT \x16 Prev");
+				OsdWrite(7, "          Esc \x16 Cancel");
+				OsdWrite(8, "        Enter \x16 Finish");
+				OsdWrite(9);
+			}
+			else
+			{
+				OsdWrite(1);
+				OsdWrite(2, (info_line[0] && !combo_hint_below_prompt) ? info_line : "", 0, 0);
+				OsdWrite(3, s, 0, 0);
+				OsdWrite(4);
+				OsdWrite(5, id_line, 0, 0);
+				OsdWrite(6);
+				if (combo_hint_below_prompt) OsdWrite(12, info_line);
+			}
+
+			if (show_gamepad)
 			{
 				// draw an on-screen gamepad to help with central button mapping
 				if (!flash_timer || CheckTimer(flash_timer))
@@ -4258,18 +4414,18 @@ void HandleUI(void)
 					{
 						switch (get_map_button())
 						{
-							case SYS_BTN_L:      OsdWrite(10, "  \x86   \x88               \x86 R \x88  "); break;
-							case SYS_BTN_R:      OsdWrite(10, "  \x86 L \x88               \x86   \x88  "); break;
-							case SYS_BTN_UP:     OsdWrite(12, " \x83                     X   \x83");        break;
-							case SYS_BTN_X:      OsdWrite(12, " \x83   U                     \x83");        break;
-							case SYS_BTN_A:      OsdWrite(13, " \x83 L \x1b R  Sel Start  Y     \x83");     break;
-							case SYS_BTN_Y:      OsdWrite(13, " \x83 L \x1b R  Sel Start      A \x83");     break;
-							case SYS_BTN_LEFT:   OsdWrite(13, " \x83   \x1b R  Sel Start  Y   A \x83");     break;
-							case SYS_BTN_RIGHT:  OsdWrite(13, " \x83 L \x1b    Sel Start  Y   A \x83");     break;
-							case SYS_BTN_SELECT: OsdWrite(13, " \x83 L \x1b R      Start  Y   A \x83");     break;
-							case SYS_BTN_START:  OsdWrite(13, " \x83 L \x1b R  Sel        Y   A \x83");     break;
-							case SYS_BTN_DOWN:   OsdWrite(14, " \x83       \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88   B   \x83"); break;
-							case SYS_BTN_B:      OsdWrite(14, " \x83   D   \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88       \x83"); break;
+							case SYS_BTN_L:              OsdWrite(10, "  \x86   \x88               \x86 R \x88  "); break;
+							case SYS_BTN_R:              OsdWrite(10, "  \x86 L \x88               \x86   \x88  "); break;
+							case SYS_BTN_UP:             OsdWrite(12, " \x83                     X   \x83");        break;
+							case SYS_BTN_X:              OsdWrite(12, " \x83   U                     \x83");        break;
+							case SYS_BTN_A:              OsdWrite(13, " \x83 L \x1b R  Sel Start  Y     \x83");     break;
+							case SYS_BTN_Y:              OsdWrite(13, " \x83 L \x1b R  Sel Start      A \x83");     break;
+							case SYS_BTN_LEFT:           OsdWrite(13, " \x83   \x1b R  Sel Start  Y   A \x83");     break;
+							case SYS_BTN_RIGHT:          OsdWrite(13, " \x83 L \x1b    Sel Start  Y   A \x83");     break;
+							case SYS_MAP_BTN_SELECT:     OsdWrite(13, " \x83 L \x1b R      Start  Y   A \x83");     break;
+							case SYS_MAP_BTN_SELECT + 1: OsdWrite(13, " \x83 L \x1b R  Sel        Y   A \x83");     break;
+							case SYS_BTN_DOWN:           OsdWrite(14, " \x83       \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88   B   \x83"); break;
+							case SYS_BTN_B:              OsdWrite(14, " \x83   D   \x86\x81\x81\x81\x81\x81\x81\x81\x81\x81\x88       \x83"); break;
 						}
 					}
 					else
@@ -4286,7 +4442,7 @@ void HandleUI(void)
 			}
 			else
 			{
-				if(flash_timer)
+				if (flash_timer)
 				{
 					//clear all gamepad gfx
 					OsdWrite(10);
@@ -4295,10 +4451,18 @@ void HandleUI(void)
 					OsdWrite(13);
 					OsdWrite(14);
 					OsdWrite(15);
+					if (is_menu())
+					{
+						OsdWrite(8, "          Esc \x16 Cancel");
+						OsdWrite(9, "        Enter \x16 Finish");
+					}
+					else
+					{
+						OsdWrite(8, "    Menu-hold \x16 Cancel");
+						OsdWrite(9, "        Enter \x16 Finish");
+					}
 					flash_timer = 0;
 				}
-
-				if (!line_info) OsdWrite(12);
 			}
 
 			if (get_map_vid() || get_map_pid())
@@ -4314,32 +4478,34 @@ void HandleUI(void)
 				}
 				else
 				{
-					sprintf(s, "   %s ID: %04x:%04x", get_map_type() ? "Joystick" : "Keyboard", get_map_vid(), get_map_pid());
 					if (get_map_button() > 0 || !joymap_first)
 					{
-						OsdWrite(7, (!get_map_type()) ? "         User \x16 Undefine" :
-							is_menu() ? "   User/Space \x16 Undefine" : "    User/Menu \x16 Undefine");
+						if (!show_gamepad)
+						{
+							OsdWrite(7, (!get_map_type()) ? "         User \x16 Undefine" :
+								is_menu() ? "   User/Space \x16 Undefine" : "    User/Menu \x16 Undefine");
+						}
 
 						if (!get_map_type()) OsdWrite(9);
 					}
-					OsdWrite(5, s);
 					if (!is_menu()) OsdWrite(10, "          F12 \x16 Clear all");
 				}
 			}
 
-			if (!is_menu() && (get_map_button() >= (joy_bcount ? joy_bcount + 4 : 8) || (select & get_map_vid() & get_map_pid())) && joymap_first && get_map_type())
+			if (!is_menu() && (get_map_button() >= (joy_bcount ? joy_bcount + 4 : 8) || (save_now && get_map_vid() && get_map_pid())) && joymap_first && get_map_type())
 			{
 				finish_map_setting(0);
+				joymap_confirm_armed = 1;
 				menustate = MENU_JOYDIGMAP3;
 				menusub = 0;
 			}
-			else if (select || menu || get_map_button() >= (joy_bcount ? joy_bcount + 4 : 8))
+			else if ((save_now && get_map_dev() >= 0) || menu || get_map_button() >= (joy_bcount ? joy_bcount + 4 : 8))
 			{
 				finish_map_setting(menu);
 				if (is_menu())
 				{
 					menustate = MENU_SYSTEM1;
-					menusub = 2;
+					menusub = get_menu_mouse_map() ? 3 : 2;
 				}
 				else
 				{
@@ -4366,6 +4532,7 @@ void HandleUI(void)
 		OsdWrite(m++, "    alternative buttons?");
 		OsdWrite(m++, "           No", menusub == 0);
 		OsdWrite(m++, "           Yes", menusub == 1);
+		OsdWrite(m++, "     A/Enter to confirm");
 		parentstate = menustate;
 		menustate = MENU_JOYDIGMAP4;
 		break;
@@ -4373,20 +4540,27 @@ void HandleUI(void)
 	case MENU_JOYDIGMAP4:
 		if (menu)
 		{
+			joymap_confirm_armed = 0;
 			menustate = MENU_COMMON1;
 			menusub = 2;
 			break;
 		}
-		else if (select)
+		else if (joymap_confirm_armed)
+		{
+			if (!finish && !select) joymap_confirm_armed = 0;
+		}
+		else if (finish || select)
 		{
 			switch (menusub)
 			{
 			case 0:
+				joymap_confirm_armed = 0;
 				menustate = MENU_COMMON1;
 				menusub = 2;
 				break;
 
 			case 1:
+				joymap_confirm_armed = 0;
 				start_map_setting(joy_bcount ? joy_bcount + 4 : 8, 1);
 				menustate = MENU_JOYDIGMAP;
 				menusub = 0;
@@ -6746,7 +6920,7 @@ void HandleUI(void)
 
 		m = 0;
 		OsdSetTitle("System Settings", OSD_ARROW_LEFT);
-		menumask = 0x7F;
+		menumask = (1 << (MENU_SYSTEM_SUB_EXIT + 1)) - 1;
 
 		OsdWrite(m++);
 		sprintf(s, "       MiSTer v%s", version + 5);
@@ -6795,19 +6969,20 @@ void HandleUI(void)
 			}
 		}
 		OsdWrite(m++, "");
-		OsdWrite(m++, " Remap keyboard            \x16", menusub == 1);
-		OsdWrite(m++, " Define joystick buttons   \x16", menusub == 2);
-		OsdWrite(m++, " Scripts                   \x16", menusub == 3);
-		OsdWrite(m++, " Help                      \x16", menusub == 4);
+		OsdWrite(m++, " Remap keyboard            \x16", menusub == MENU_SYSTEM_SUB_KBDMAP);
+		OsdWrite(m++, " Define joypad buttons     \x16", menusub == MENU_SYSTEM_SUB_JOYPAD_MAP);
+		OsdWrite(m++, " Define mouse buttons      \x16", menusub == MENU_SYSTEM_SUB_MOUSE_MAP);
+		OsdWrite(m++, " Scripts                   \x16", menusub == MENU_SYSTEM_SUB_SCRIPTS);
+		OsdWrite(m++, " Help                      \x16", menusub == MENU_SYSTEM_SUB_HELP);
 		OsdWrite(m++, "");
 		cr = m;
-		OsdWrite(m++, " Reboot (hold \x16 cold reboot)", menusub == 5);
+		OsdWrite(m++, " Reboot (hold \x16 cold reboot)", menusub == MENU_SYSTEM_SUB_REBOOT);
 		sysinfo_timer = 0;
 
 		reboot_req = 0;
 
 		while(m < OsdGetSize()-1) OsdWrite(m++, "");
-		OsdWrite(15, STD_EXIT, menusub == 6);
+		OsdWrite(15, STD_EXIT, menusub == MENU_SYSTEM_SUB_EXIT);
 		menustate = MENU_SYSTEM2;
 		break;
 
@@ -6825,17 +7000,23 @@ void HandleUI(void)
 				if (getStorage(1) || isUSBMounted()) setStorage(!getStorage(1));
 				break;
 
-			case 1:
+			case MENU_SYSTEM_SUB_KBDMAP:
 				start_map_setting(0);
 				menustate = MENU_KBDMAP;
 				menusub = 0;
 				break;
 
-			case 2:
+			case MENU_SYSTEM_SUB_JOYPAD_MAP:
+				set_menu_mouse_map(0);
 				menustate = MENU_JOYSYSMAP;
 				break;
 
-			case 3:
+			case MENU_SYSTEM_SUB_MOUSE_MAP:
+				set_menu_mouse_map(1);
+				menustate = MENU_JOYSYSMAP;
+				break;
+
+			case MENU_SYSTEM_SUB_SCRIPTS:
 				{
 					uint8_t confirm[32] = {};
 					int match = 0;
@@ -6862,13 +7043,13 @@ void HandleUI(void)
 				}
 				break;
 
-			case 4:
+			case MENU_SYSTEM_SUB_HELP:
 				strcpy(Selected_tmp, DOCS_DIR);
 				FileCreatePath(Selected_tmp);
 				SelectFile(Selected_tmp, "PDFTXTMD ", SCANO_DIR | SCANO_TXT, MENU_DOC_FILE_SELECTED, MENU_NONE1);
 				break;
 
-			case 5:
+			case MENU_SYSTEM_SUB_REBOOT:
 				{
 					reboot_req = 1;
 
@@ -6881,7 +7062,7 @@ void HandleUI(void)
 				}
 				break;
 
-			case 6:
+			case MENU_SYSTEM_SUB_EXIT:
 				menustate = MENU_NONE1;
 				break;
 			}
@@ -6895,27 +7076,40 @@ void HandleUI(void)
 		break;
 
 	case MENU_JOYSYSMAP:
-		strcpy(joy_bnames[SYS_BTN_A - DPAD_NAMES], "A");
-		strcpy(joy_bnames[SYS_BTN_B - DPAD_NAMES], "B");
-		strcpy(joy_bnames[SYS_BTN_X - DPAD_NAMES], "X");
-		strcpy(joy_bnames[SYS_BTN_Y - DPAD_NAMES], "Y");
-		strcpy(joy_bnames[SYS_BTN_L - DPAD_NAMES], "L");
-		strcpy(joy_bnames[SYS_BTN_R - DPAD_NAMES], "R");
-		strcpy(joy_bnames[SYS_BTN_SELECT - DPAD_NAMES], "Select");
-		strcpy(joy_bnames[SYS_BTN_START - DPAD_NAMES], "Start");
-		strcpy(joy_bnames[SYS_MS_RIGHT - DPAD_NAMES], "Mouse Move RIGHT");
-		strcpy(joy_bnames[SYS_MS_LEFT - DPAD_NAMES], "Mouse Move LEFT");
-		strcpy(joy_bnames[SYS_MS_DOWN - DPAD_NAMES], "Mouse Move DOWN");
-		strcpy(joy_bnames[SYS_MS_UP - DPAD_NAMES], "Mouse Move UP");
-		strcpy(joy_bnames[SYS_MS_BTN_L - DPAD_NAMES], "Mouse Btn Left");
-		strcpy(joy_bnames[SYS_MS_BTN_R - DPAD_NAMES], "Mouse Btn Right");
-		strcpy(joy_bnames[SYS_MS_BTN_M - DPAD_NAMES], "Mouse Btn Middle");
-		strcpy(joy_bnames[SYS_MS_BTN_EMU - DPAD_NAMES], "Mouse Emu/Sniper");
-		strcpy(joy_bnames[SYS_BTN_OSD_KTGL - DPAD_NAMES], "Menu");
-		strcpy(joy_bnames[SYS_BTN_CNT_OK - DPAD_NAMES], "Menu: OK");
-		strcpy(joy_bnames[SYS_BTN_CNT_ESC - DPAD_NAMES], "Menu: Back");
-		joy_bcount = 20 + 1; //buttons + OSD/KTGL button
-		start_map_setting(joy_bcount + 6); // + dpad + Analog X/Y
+		memset(joy_bnames, 0, sizeof(joy_bnames));
+		if (get_menu_mouse_map())
+		{
+			strcpy(joy_bnames[0], "Mouse Move RIGHT");
+			strcpy(joy_bnames[1], "Mouse Move LEFT");
+			strcpy(joy_bnames[2], "Mouse Move DOWN");
+			strcpy(joy_bnames[3], "Mouse Move UP");
+			strcpy(joy_bnames[4], "Mouse Btn Left");
+			strcpy(joy_bnames[5], "Mouse Btn Right");
+			strcpy(joy_bnames[6], "Mouse Btn Middle");
+			strcpy(joy_bnames[7], "Mouse Emu/Sniper");
+			joy_bcount = 8;
+			start_map_setting(joy_bcount + 4);
+		}
+		else
+		{
+			strcpy(joy_bnames[SYS_BTN_A - DPAD_NAMES], "A");
+			strcpy(joy_bnames[SYS_BTN_B - DPAD_NAMES], "B");
+			strcpy(joy_bnames[SYS_BTN_X - DPAD_NAMES], "X");
+			strcpy(joy_bnames[SYS_BTN_Y - DPAD_NAMES], "Y");
+			strcpy(joy_bnames[SYS_BTN_L - DPAD_NAMES], "L");
+			strcpy(joy_bnames[SYS_BTN_R - DPAD_NAMES], "R");
+			strcpy(joy_bnames[SYS_MAP_BTN_L2 - DPAD_NAMES], "L2");
+			strcpy(joy_bnames[SYS_MAP_BTN_L2 - DPAD_NAMES + 1], "R2");
+			strcpy(joy_bnames[SYS_MAP_BTN_L2 - DPAD_NAMES + 2], "L3");
+			strcpy(joy_bnames[SYS_MAP_BTN_L2 - DPAD_NAMES + 3], "R3");
+			strcpy(joy_bnames[SYS_MAP_BTN_SELECT - DPAD_NAMES], "Select");
+			strcpy(joy_bnames[SYS_MAP_BTN_SELECT - DPAD_NAMES + 1], "Start");
+			strcpy(joy_bnames[SYS_MAP_POS_OSD - DPAD_NAMES], "Menu");
+			strcpy(joy_bnames[SYS_MAP_POS_OSD - DPAD_NAMES + 1], "Menu: OK");
+			strcpy(joy_bnames[SYS_MAP_POS_OSD - DPAD_NAMES + 2], "Menu: Back");
+			joy_bcount = SYS_MAP_GAMEPAD_BUTTON_COUNT;
+			start_map_setting(joy_bcount + 4); // + dpad
+		}
 		menustate = MENU_JOYDIGMAP;
 		menusub = 0;
 		break;
@@ -7067,7 +7261,7 @@ void HandleUI(void)
 				video_menu_bg(user_io_status_get("[3:1]"));
 				video_fb_enable(0);
 				menustate = MENU_SYSTEM1;
-				menusub = 3;
+				menusub = MENU_SYSTEM_SUB_SCRIPTS;
 				OsdClear();
 				OsdEnable(DISABLE_KEYBOARD);
 			}
@@ -7198,7 +7392,7 @@ void HandleUI(void)
 				else
 				{
 					menustate = MENU_SYSTEM1;
-					menusub = 3;
+					menusub = MENU_SYSTEM_SUB_SCRIPTS;
 				}
 			}
 		}

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1792,6 +1792,19 @@ void user_io_r_analog_joystick(unsigned char joystick, char valueX, char valueY)
 	}
 }
 
+void user_io_analog_triggers(unsigned char joystick, uint8_t l2, uint8_t r2)
+{
+	uint8_t joy = (joystick > 1 || !joyswap) ? joystick : joystick ^ 1;
+
+	if (core_type == CORE_TYPE_8BIT)
+	{
+		spi_uio_cmd8_cont(UIO_ATRIG, joy);
+		spi8(l2);
+		spi8(r2);
+		DisableIO();
+	}
+}
+
 void user_io_digital_joystick(unsigned char joystick, uint32_t map, int newdir)
 {
 	uint8_t joy = (joystick>1 || !joyswap) ? joystick : joystick ^ 1;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1751,6 +1751,7 @@ static int joyswap = 0;
 void user_io_set_joyswap(int swap)
 {
 	joyswap = swap;
+	input_analog_triggers_resync(osd_is_visible);
 }
 
 int user_io_get_joyswap()
@@ -4192,8 +4193,11 @@ void user_io_check_reset(unsigned short modifiers, char useKeys)
 
 void user_io_osd_key_enable(char on)
 {
+	on = !!on;
 	//printf("OSD is now %s\n", on ? "visible" : "invisible");
+	if (osd_is_visible != on) input_analog_triggers_resync(on);
 	osd_is_visible = on;
+
 	if (cfg.log_file_entry) MakeFile("/tmp/OSD_VISIBLE", on ? "1" : "0");
 	input_switch(-1);
 }

--- a/user_io.h
+++ b/user_io.h
@@ -76,6 +76,7 @@
 #define UIO_GET_FR_CNT  0x42  // get frame counter
 #define UIO_GET_F12_MOD 0x43  // get framework menu key modifier
 #define UIO_HDMI_INT    0x44
+#define UIO_ATRIG       0x45  // analog trigger state: joy, L2, R2
 
 // codes as used by 8bit for file loading from OSD
 #define FIO_FILE_TX     0x53
@@ -213,6 +214,7 @@ int user_io_get_joy_transl();
 void user_io_digital_joystick(unsigned char, uint32_t, int);
 void user_io_l_analog_joystick(unsigned char, char, char);
 void user_io_r_analog_joystick(unsigned char, char, char);
+void user_io_analog_triggers(unsigned char, uint8_t, uint8_t);
 void user_io_set_joyswap(int swap);
 int user_io_get_joyswap();
 char user_io_osd_is_visible();


### PR DESCRIPTION
- Add v4 joypad mapping with L2, R2, L3, and R3
- Preserve v3 map compatibility by appending new slots after existing v3 layout
- Infer analog L2/R2 triggers during normal L2/R2 mapping prompts
- Support separate, inverted, and centered/shared trigger axes
- Keep digital L2/R2 fallback mappings alongside analog trigger mappings
- Add gamecontrollerdb analog trigger support for aN, +aN, and -aN
- Send normalized 0..255 analog trigger values to cores via UIO_ATRIG
- Split joypad and mouse mapping into separate menu entries
- Keep upstream-style virtual joypad graphics in the mapping dialog

Tested with [InputTest_20260521.zip](https://github.com/user-attachments/files/28124984/InputTest_20260521.zip) (PR https://github.com/MiSTer-devel/InputTest_MiSTer/pull/18)