### PR TITLE
Reduction of memory footprint

### DIFF
--- a/cd.h
+++ b/cd.h
@@ -4,6 +4,7 @@
 #include <libchdr/chd.h>
 #include "file_io.h"
 
+#define CUE_BUFFER_SIZE (100 * 1024)
 
 typedef enum
 {

--- a/support/3do/3docdd.cpp
+++ b/support/3do/3docdd.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <time.h>
+#include <memory>
 
 #include "3do.h"
 #include "../chd/mister_chd.h"
@@ -57,17 +58,18 @@ static int sgets(char *out, int sz, char **in)
 }
 
 int p3docdd_t::LoadCUE(const char* filename) {
-	static char fname[1024 + 10];
-	static char line[256];
+	char fname[1024 + 10];
+	char line[256];
 	char *ptr, *lptr;
-	static char cue[100 * 1024];
+	auto cue = std::make_unique<char[]>(CUE_BUFFER_SIZE);
+
 	int new_file = 0;
 	int file_size = 0;
 
 	strcpy(fname, filename);
 
-	memset(cue, 0, sizeof(cue));
-	if (!FileLoad(fname, cue, sizeof(cue) - 1)) return 1;
+	memset(cue.get(), 0, CUE_BUFFER_SIZE);
+	if (!FileLoad(fname, cue.get(), CUE_BUFFER_SIZE-1)) return 1;
 
 #ifdef P3DO_DEBUG
 	printf("\x1b[32m3DO: Open CUE: %s\n\x1b[0m", fname);
@@ -76,7 +78,7 @@ int p3docdd_t::LoadCUE(const char* filename) {
 	this->toc.last = -1;
 	int idx, mm, ss, bb, pregap = 0;
 
-	char *buf = cue;
+	char *buf = cue.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;

--- a/support/cdi/cdi.cpp
+++ b/support/cdi/cdi.cpp
@@ -176,17 +176,17 @@ static int load_chd(const char* filename, toc_t* table)
 
 static int load_cue(const char* filename, toc_t* table)
 {
-	static char fname[1024 + 10];
-	static char line[128];
+	char fname[1024 + 10];
+	char line[128];
 	char *ptr, *lptr;
-	static char cue[100 * 1024];
+	auto cue = std::make_unique<char[]>(CUE_BUFFER_SIZE);
 
 	unload_cue(table);
 	strcpy(fname, filename);
 	printf("\x1b[32mCDI: Open CUE: %s\n\x1b[0m", fname);
 
-	memset(cue, 0, sizeof(cue));
-	if (!FileLoad(fname, cue, sizeof(cue) - 1))
+	memset(cue.get(), 0, sizeof(cue));
+	if (!FileLoad(fname, cue.get(), CUE_BUFFER_SIZE - 1))
 	{
 		printf("\x1b[32mCDI: cannot load file: %s\n\x1b[0m", fname);
 		return 0;
@@ -213,7 +213,7 @@ static int load_cue(const char* filename, toc_t* table)
 	int index0 = 0;
 	int index1 = 0;
 
-	char* buf = cue;
+	char* buf = cue.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;

--- a/support/megacd/megacdd.cpp
+++ b/support/megacd/megacdd.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <time.h>
+#include <memory>
 
 #include "megacd.h"
 #include "../chd/mister_chd.h"
@@ -72,22 +73,22 @@ static int sgets(char *out, int sz, char **in)
 
 
 int cdd_t::LoadCUE(const char* filename) {
-	static char fname[1024 + 10];
-	static char line[128];
+	char fname[1024 + 10];
+	char line[128];
 	char *ptr, *lptr;
 	static char header[1024];
-	static char toc[100 * 1024];
+	auto toc = std::make_unique<char[]>(CUE_BUFFER_SIZE);
 
 	strcpy(fname, filename);
 
-	memset(toc, 0, sizeof(toc));
-	if (!FileLoad(fname, toc, sizeof(toc) - 1)) return 1;
+	memset(toc.get(), 0, CUE_BUFFER_SIZE);
+	if (!FileLoad(fname, toc.get(), CUE_BUFFER_SIZE - 1)) return 1;
 
 	printf("\x1b[32mMCD: Open CUE: %s\n\x1b[0m", fname);
 
 	int mm, ss, bb, pregap = 0;
 
-	char *buf = toc;
+	char *buf = toc.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;

--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <memory>
 
 #include "../../file_io.h"
 #include "../../user_io.h"
@@ -77,22 +78,22 @@ static int sgets(char *out, int sz, char **in)
 }
 
 int pcecdd_t::LoadCUE(const char* filename) {
-	static char fname[1024 + 10];
-	static char line[128];
+	char fname[1024 + 10];
+	char line[128];
 	char *ptr, *lptr;
-	static char toc[100 * 1024];
+	auto toc = std::make_unique<char[]>(CUE_BUFFER_SIZE);
 	int hdr = 0;
 
 	strcpy(fname, filename);
 
-	memset(toc, 0, sizeof(toc));
-	if (!FileLoad(fname, toc, sizeof(toc) - 1)) return 1;
+	memset(toc.get(), 0, CUE_BUFFER_SIZE);
+	if (!FileLoad(fname, toc.get(), CUE_BUFFER_SIZE - 1)) return 1;
 
 	printf("\x1b[32mPCECD: Open CUE: %s\n\x1b[0m", fname);
 
 	int mm, ss, bb, pregap = 0;
 
-	char *buf = toc;
+	char *buf = toc.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;

--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -14,6 +14,7 @@
 #include "../../cd.h"
 #include "../chd/mister_chd.h"
 #include <libchdr/chd.h>
+#include <memory>
 
 static char buf[1024];
 static uint8_t *chd_hunkbuf = NULL;
@@ -163,18 +164,18 @@ static int load_chd(const char *filename, toc_t *table)
 
 static int load_cue(const char* filename, toc_t *table)
 {
-	static char fname[1024 + 10];
-	static char line[128];
+	char fname[1024 + 10];
+	char line[128];
 	char *ptr, *lptr;
-	static char toc[100 * 1024];
+	auto toc = std::make_unique<char[]>(CUE_BUFFER_SIZE);
 
 	unload_cue(table);
 	printf("\x1b[32mPSX: Open CUE: %s\n\x1b[0m", fname);
 
 	strcpy(fname, filename);
 
-	memset(toc, 0, sizeof(toc));
-	if (!FileLoad(fname, toc, sizeof(toc) - 1))
+	memset(toc.get(), 0, sizeof(toc));
+	if (!FileLoad(fname, toc.get(), CUE_BUFFER_SIZE - 1))
 	{
 		printf("\x1b[32mPSX: cannot load file: %s\n\x1b[0m", fname);
 		return 0;
@@ -183,7 +184,7 @@ static int load_cue(const char* filename, toc_t *table)
 	int mm, ss, bb;
 	int pregap = 0;
 
-	char *buf = toc;
+	char *buf = toc.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;

--- a/support/saturn/saturncdd.cpp
+++ b/support/saturn/saturncdd.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <time.h>
+#include <memory>
 
 #include "saturn.h"
 #include "../../shmem.h"
@@ -79,17 +80,18 @@ static int sgets(char *out, int sz, char **in)
 }
 
 int satcdd_t::LoadCUE(const char* filename) {
-	static char fname[1024 + 10];
-	static char line[128];
+	char fname[1024 + 10];
+	char line[128];
 	char *ptr, *lptr;
-	static char cue[100 * 1024];
+	auto cue = std::make_unique<char[]>(CUE_BUFFER_SIZE);
+
 	int new_file = 0;
 	int file_size = 0;
 
 	strcpy(fname, filename);
 
-	memset(cue, 0, sizeof(cue));
-	if (!FileLoad(fname, cue, sizeof(cue) - 1)) return 1;
+	memset(cue.get(), 0, CUE_BUFFER_SIZE);
+	if (!FileLoad(fname, cue.get(), CUE_BUFFER_SIZE - 1)) return 1;
 
 #ifdef SATURN_DEBUG
 	printf("\x1b[32mSaturn: Open CUE: %s\n\x1b[0m", fname);
@@ -98,7 +100,7 @@ int satcdd_t::LoadCUE(const char* filename) {
 	this->toc.last = -1;
 	int idx, mm, ss, bb, pregap = 0;
 
-	char *buf = cue;
+	char *buf = cue.get();
 	while (sgets(line, sizeof(line), &buf))
 	{
 		lptr = line;


### PR DESCRIPTION
- Removes ~100kB of static memory per CD supporting core for CUE file loading

This change might be controversial. It already got negative feedback on the MiSTer Discord from other devs since it uses C++14 methods of memory allocation.

I could think of an alternative, like a global buffer for this task. Many of the CD cores don't really share code, but I believe this is a small change to at least reduce memory usage in case it might be a problem in the future.

