### PR TITLE
video: add hdmi_int option to disable HDMI interrupt (hotplug/CEC).

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -28,6 +28,7 @@ hdmi_cec_power_on=1    ; 1 - on power-on, try once to make MiSTer the active HDM
 hdmi_cec_sleep=0       ; 1 - send CEC STANDBY after video_off minutes of no input activity. Requires video_off>0.
 hdmi_cec_wake=0        ; 1 - on input after that idle period, send wake (ImageViewOn/TextViewOn/ActiveSource).
 hdmi_cec_clock=0       ; 0 - auto-detect 12MHz/50MHz, otherwise floating point value from 3.0 to 100.0 (3-100MHz).
+hdmi_int=0             ; 0 - disable HDMI interrupt (keep 0 if no image on cold boot), 1 - enable. CEC also requires this =1.
                        ;
 direct_video=0         ; 1 - enable core video timing over HDMI, use only with VGA converters.
                        ; 2 - auto-mode for HDMI DACs that report 1024x768 resolution (AG6200, CS5213). 

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -58,6 +58,7 @@ static const ini_var_t ini_vars[] =
 	{ "HDMI_CEC_INPUT_MODE", (void*)(&(cfg.hdmi_cec_input_mode)), UINT8, 0, 1 },
 	{ "HDMI_CEC_POWER_ON", (void*)(&(cfg.hdmi_cec_power_on)), UINT8, 0, 1 },
 	{ "HDMI_CEC_CLOCK", (void*)(&(cfg.hdmi_cec_clock)), FLOAT, 0, 100 },
+	{ "HDMI_INT", (void*)(&(cfg.hdmi_int)), UINT8, 0, 1 },
 	{ "KBD_NOMOUSE", (void*)(&(cfg.kbd_nomouse)), UINT8, 0, 1 },
 	{ "MOUSE_THROTTLE", (void*)(&(cfg.mouse_throttle)), UINT8, 1, 100 },
 	{ "BOOTSCREEN", (void*)(&(cfg.bootscreen)), UINT8, 0, 1 },

--- a/cfg.h
+++ b/cfg.h
@@ -25,6 +25,7 @@ typedef struct {
 	uint8_t hdmi_cec_input_mode;
 	uint8_t hdmi_cec_power_on;
 	float hdmi_cec_clock;
+	uint8_t hdmi_int;
 	uint8_t direct_video;
 	uint8_t video_info;
 	float refresh_min;

--- a/video.cpp
+++ b/video.cpp
@@ -1405,8 +1405,16 @@ int hdmi_has_int()
 	static int has_int = -1;
 	if (has_int < 0)
 	{
-		has_int = spi_uio_cmd(UIO_HDMI_INT);
-		if (!has_int) printf("HDMI interrupt pin is not available in this core. Hotplug and CEC won't be available.\n");
+		if (!cfg.hdmi_int)
+		{
+			has_int = 0; // disabled by default; avoids false probe on clone boards
+			printf("HDMI interrupt handling disabled (HDMI_INT=0). Hotplug and CEC won't be available.\n");
+		}
+		else
+		{
+			has_int = spi_uio_cmd(UIO_HDMI_INT);
+			if (!has_int) printf("HDMI interrupt pin is not available in this core. Hotplug and CEC won't be available.\n");
+		}
 	}
 	return has_int;
 }


### PR DESCRIPTION
Related to #1207 as I was having the same issue.

**What I observed:** On my board (a Hamgeek clone of the DE10-nano), the MiSTer_20260603 binary gives a black screen on a cold power-on. The disk/user (activity) LED does not light up. A warm reset (reset button) or relaunching the binary over SSH brings the picture back and the menu works normally — only cold boot is affected. 

If I boot without HDMI connected and plug it in afterwards, the picture appears but the menu becomes unresponsive. Reverting to MiSTer_20260325 always works. The same menu.rbf is used in all cases.

**What I think is happening (not 100% certain):** The HDMI hotplug/CEC handling added in 20260603 (video_poll()) runs whenever hdmi_has_int() reports true, which depends on the UIO_HDMI_INT probe and GPI bit 20. On my board this path appears to act on HPD/Monitor-Sense reads in a way that, during the cold-boot window before the HDMI link is stable, either powers the output down (video_hdmi_power(0)) or repeatedly re-initializes video — which matches the black screen and the unresponsive menu. On a warm reset the link is already up, so it doesn't trigger. I haven't been able to verify the exact register behavior on other boards, so I can't say how widespread this is.

**Proposed change:** Add an HDMI_INT ini flag. With it off (default), hdmi_has_int() stays disabled and the board behaves like 20260325, including when there's no MiSTer.ini. Setting HDMI_INT=1 opts back into hotplug detection and CEC. This is meant as a conservative, low-risk escape hatch rather than a behavior change for working boards.

I realize defaulting the new CEC/hotplug feature off may not be ideal for boards where it already works. As a next step, I plan to try a follow-up fix on top of this one to see if I can get the hotplug/CEC path working correctly on my board (for example, handling the cold-boot timing in video_poll() or making the probe more robust). This is my first contribution here, so please let me know if you'd prefer a different approach.
