### PR TITLE
Fix failed EDID Detection loop

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -1793,14 +1793,13 @@ static void cache_raw_edid_mfg_id()
 	raw_edid_mfg_id_valid = true;
 }
 
-static void read_edid_segment(uint8_t segment, uint8_t *buf)
+static bool read_edid_segment(uint8_t segment, uint8_t *buf)
 {
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC4, segment);
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC9, 0x03);
 	usleep(1000);
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC9, 0x13);
 
-	bool edid_ready = false;
 	unsigned long timeout = GetTimer(500);
 	while (!CheckTimer(timeout))
 	{
@@ -1808,19 +1807,17 @@ static void read_edid_segment(uint8_t segment, uint8_t *buf)
 		if (status >= 0 && (status & 4))
 		{
 			i2c_smbus_write_byte_data(hdmi_main_fd, 0x96, 4);
-			edid_ready = true;
-			break;
+			for (uint16_t i = 0; i < 256; i++)
+			{
+				int value = i2c_smbus_read_byte_data(hdmi_edid_fd, (uint8_t)i);
+				buf[i] = (value < 0) ? 0 : (uint8_t)value;
+			}
+			return true;
 		}
 		usleep(10000);
 	}
 
-	if (!edid_ready) return;
-
-	for (uint16_t i = 0; i < 256; i++)
-	{
-		int value = i2c_smbus_read_byte_data(hdmi_edid_fd, (uint8_t)i);
-		buf[i] = (value < 0) ? 0 : (uint8_t)value;
-	}
+	return false;
 }
 
 static int read_edid(bool force = false)
@@ -1847,8 +1844,9 @@ static int read_edid(bool force = false)
 			raw_edid_mfg_id_valid = false;
 			return 0;
 		}
-		read_edid_segment(0, edid);
+		bool got_interrupt = read_edid_segment(0, edid);
 		if (is_edid_valid()) break;
+		if (!got_interrupt) break;  // no DDC response — display has no EDID, don't retry
 		usleep(100000);
 	}
 

--- a/video.cpp
+++ b/video.cpp
@@ -1800,16 +1800,21 @@ static void read_edid_segment(uint8_t segment, uint8_t *buf)
 	usleep(1000);
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC9, 0x13);
 
+	bool edid_ready = false;
 	unsigned long timeout = GetTimer(500);
 	while (!CheckTimer(timeout))
 	{
-		if (i2c_smbus_read_byte_data(hdmi_main_fd, 0x96) & 4)
+		int status = i2c_smbus_read_byte_data(hdmi_main_fd, 0x96);
+		if (status >= 0 && (status & 4))
 		{
 			i2c_smbus_write_byte_data(hdmi_main_fd, 0x96, 4);
+			edid_ready = true;
 			break;
 		}
 		usleep(10000);
 	}
+
+	if (!edid_ready) return;
 
 	for (uint16_t i = 0; i < 256; i++)
 	{
@@ -1836,6 +1841,12 @@ static int read_edid(bool force = false)
 	// waiting for valid EDID
 	for (int k = 0; k < 20; k++)
 	{
+		int current = i2c_smbus_read_byte_data(hdmi_main_fd, 0x42);
+		if (current < 0 || !(current & 0x20))
+		{
+			raw_edid_mfg_id_valid = false;
+			return 0;
+		}
 		read_edid_segment(0, edid);
 		if (is_edid_valid()) break;
 		usleep(100000);


### PR DESCRIPTION
First of all, you probably should not merge this as it's all vibe coded and I don't really understand what I'm doing. I'm only adding it as a PR so that you can see where the bug was.

Basically the gist is that the new EDID detection added with the CEC stuff would loop if it failed to detect a valid EDID, and it could hold the main thread hostage for 12 seconds.

If you want to try to reproduce it, this is my silly setup:
- 2 MiSTers connected to an HDMI display via switch, and a CRT (via different inputs)
- If you are using MiSTer A on the CRT, but have the HDMI switch set to MiSTer B, MiSter A will never get a valid EDID, so any time you start a core or go back to the menu, main would stall for (up to) 12 seconds, and make the MiSTer unusable for that time.

This is pretty low priority, I think, because it probably doesn't show up anywhere else other than in stupid setups like mine (or a setup that somehow gums up the EDID communication). But it was picking at my brain worms, so I wanted to see if it was fixable.