### PR TITLE
hdmi_cec: send Image View On to wake a standby TV on power-on

### DIFF
--- a/hdmi_cec.cpp
+++ b/hdmi_cec.cpp
@@ -775,17 +775,17 @@ static bool cec_receive_message(cec_message_t *msg)
 	return ok;
 }
 
-static bool cec_is_active_source(void)
+// assume_when_unknown: when no active source is known, assume it is us.
+// Pass false to require a confirmed match (e.g. before skipping a TV wake).
+static bool cec_is_active_source(bool assume_when_unknown = true)
 {
 	if (cec_active_physical_addr == CEC_INVALID_PHYS_ADDR)
 	{
-		printf("CEC: cec_active_physical_addr=FFFF - assume no one is active, so we are active.\n");
-		return true;
+		printf("CEC: cec_active_physical_addr=FFFF - no active source%s.\n",
+			assume_when_unknown ? ", assuming we are active" : "");
+		return assume_when_unknown;
 	}
-	else
-	{
-		printf("CEC: cec_active_physical_addr=%04X, cec_physical_addr=%04X\n", cec_active_physical_addr, cec_physical_addr);
-	}
+	printf("CEC: cec_active_physical_addr=%04X, cec_physical_addr=%04X\n", cec_active_physical_addr, cec_physical_addr);
 	return cec_active_physical_addr == cec_physical_addr;
 }
 
@@ -1102,7 +1102,9 @@ static void cec_poll_power_on_switch(void)
 		break;
 
 	case CEC_POWER_ON_WAIT_BEFORE:
-		if (cec_is_active_source())
+		// Unknown source (TV likely asleep) must still get the wake, so don't
+		// assume we are active here.
+		if (cec_is_active_source(false))
 		{
 			cec_power_on_state = CEC_POWER_ON_DONE;
 			cec_power_on_deadline = 0;


### PR DESCRIPTION
hdmi_cec: wake a standby TV on power-on (One Touch Play)

With HDMI_CEC=1 and HDMI_CEC_POWER_ON=1, the TV does not wake when MiSTer powers on.

**Cause**: On startup the power-on sequence broadcasts Request Active Source and waits, then sends Image View On / Active Source only if it finds it is not already the active source. cec_is_active_source() treats an unknown active source (FFFF) as "we are active". A TV in standby never replies to Request Active Source, so cec_active_physical_addr stays FFFF, the code assumes it is already active, and the wake (Image View On, 0x04) is never sent.

Debug trace (CEC inits fine, then skips the wake):


> CEC: logical=4 physical=1.0.0.0              ; CEC initialized OK
> CEC send: 0x85 (Request Active Source)       ; TV asleep → no reply
> CEC: cec_active_physical_addr=FFFF - assume no one is active, so we are active.
> ; → state goes to DONE; Image View On (0x04) / Active Source (0x82) never sent
> 

Fix: Add assume_when_unknown (default true, so the 6 other callers are unchanged) to cec_is_active_source(), and pass false at the power-on site. An unknown source now proceeds to send Image View On + Active Source, which is exactly the standby-wake case.

Tested on: Hamgeek board (QMTech-style DE10-Nano clone, ADV7513) with a Samsung TV (Anynet+). After the fix, the TV wakes and switches to the MiSTer input on power-on.