### PR TITLE
Apple iigs disk support

### DIFF
--- a/support.h
+++ b/support.h
@@ -9,6 +9,8 @@
 
 // Apple 2 support
 #include "support/a2/dsk2nib_lib.h"
+// Apple IIgs disk integration
+#include "support/a2/iigs_disk.h"
 
 // Archie support
 #include "support/archie/archie.h"

--- a/support/a2/IIGS_DISK_SUPPORT.md
+++ b/support/a2/IIGS_DISK_SUPPORT.md
@@ -1,0 +1,451 @@
+# Apple IIgs Disk Support — Design & Implementation Spec
+
+Status: **design document** (no code yet). This is the implementation plan for adding
+multi-format disk support to the new Apple IIgs core in MiSTer Main.
+
+---
+
+## 1. Goal
+
+The IIgs core accepts only two native on-the-wire formats:
+
+- **Hard disk** — raw ProDOS blocks, **no header**.
+- **Floppy (5.25″ and 3.5″)** — **WOZ** bitstream (the core's HDL parses TMAP/TRKS itself).
+
+Users, however, distribute IIgs software in many formats (`.2mg`, `.dsk`, `.do`, `.po`,
+`.nib`, `.hdv`, `.dc42`, `.woz`). The job of MiSTer Main is to **detect the format,
+validate it against the slot, route it to the correct slot, and translate it on the fly**
+to one of the two native formats — without breaking copy protection on native WOZ images.
+
+### Decisions locked in
+| Topic | Decision |
+|---|---|
+| Wrong-disk guard | **Respect the chosen slot when valid; block broken combos** with a guiding OSD message. Not a router (see §6). |
+| Slot tolerance | **HDD slots permissive** (any ProDOS-order block image, any size); **floppy slots strict** on geometry. |
+| Auto-routing | **Never.** A disk is only ever mounted in the slot the user picked, or blocked with guidance. No disk is ever silently moved. |
+| WOZ normalization | **No** — native `.woz` is served byte-for-byte (flat block I/O). Rewriting risks breaking copy protection. |
+| Converter architecture | **On-the-fly** per-LBA translation (the live `SD_TYPE_A2` pattern), **not** one-shot temp files. |
+| Converted-floppy write-back | **Implemented.** On each core write the affected WOZ track is decoded and persisted back to the source `.po/.dsk/.do/.2mg` (per-track, re-skewed to ProDOS where needed). `.nib`/DC42 sources stay read-only. |
+| DiskCopy 4.2 (DC42) | **Demoted.** Mac-native format IIgs software essentially never ships as; kept only as a cheap `probeDC42()` content-detected fallback, no dedicated fixtures/effort (§10, §12). |
+| Dead code | Remove unused `dsk2nib()` from `DiskImage.cpp` (see §9). |
+
+---
+
+## 2. Target core: slot layout
+
+From `Apple-IIgs.sv` (`CONF_STR`, `VDNUM=4`):
+
+| Slot | CONF_STR | Class | HDL routing |
+|---|---|---|---|
+| **S0** | `S0,HDVPO ;` | Hard disk | `HDD_*` unit (raw blocks) |
+| **S1** | `S1,HDVPO ;` | Hard disk | `HDD_*` unit (raw blocks) |
+| **S2** | `S2,WOZ,WOZ 3.5;` | 3.5″ floppy | 3.5″ WOZ controller |
+| **S3** | `S3,WOZ,WOZ 5.25;` | 5.25″ floppy | 5.25″ WOZ controller |
+
+The CONF_STR extension list is the **first-pass filter** (S0/S1 only offer `HDV`/`PO`,
+S2/S3 only `WOZ`). To let users pick the new formats we must **widen these lists** in the
+core, e.g. `S0,HDVPO2MGDC;` and `S3,WOZDSKDOPONIB2MG;`. Widening reintroduces ambiguity
+(a `.2mg` can be HDD *or* floppy), which is exactly what the MiSTer-side guard resolves.
+
+> **Future expansion (3–4 floppies):** the HDL side is the constraint (WOZ track buffers
+> must fit in BRAM). The MiSTer side must therefore be **table-driven** (§6) so adding a
+> slot is one table row, not new logic.
+
+---
+
+## 3. Architecture overview
+
+```
+   File browser (menu.cpp)
+        │  user_io_file_mount(name, index)        index = slot the user picked
+        ▼
+   ┌─────────────────────────────────────────────┐
+   │ MOUNT-TIME (user_io.cpp:2084)                │
+   │  1. classify(name)  → DiskClass + header_off │  (§5 parsers)
+   │  2. route: pick correct slot for the class   │  (§6 routing)
+   │  3. validate: strict reject + InfoMessage     │  (§7 guard)
+   │  4. set sd_type[slot], header_offset[slot]   │
+   └─────────────────────────────────────────────┘
+        │
+        ▼
+   ┌─────────────────────────────────────────────┐
+   │ RUN-TIME per-LBA (user_io.cpp:3256 dispatch) │
+   │  HDD  → offset-mapped passthrough            │  (§8.1)
+   │  WOZ native → flat block passthrough         │  (§8.2)
+   │  DSK/NIB/PO floppy → on-the-fly ⇄ WOZ        │  (§8.3, v2 write)
+   └─────────────────────────────────────────────┘
+```
+
+The existing `SD_TYPE_A2` path (`a2_readDSK`/`a2_writeDSK` → `dsk2nib_lib.cpp`) is the
+proven template: per-LBA, bidirectional, writable. New converters follow the same shape.
+
+---
+
+## 4. Device classes
+
+```c
+enum DiskClass {
+    DC_UNKNOWN,
+    DC_HDD,        // raw ProDOS blocks, any size (typically > 800K)
+    DC_FLOPPY_525, // 140K logical (143360) or NIB (232960) or WOZ type 1
+    DC_FLOPPY_35,  // 800K logical (819200) or WOZ type 2
+};
+```
+
+### Canonical sizes
+| Geometry | Bytes |
+|---|---|
+| 5.25″ logical (35×16×256) | 143,360 |
+| 5.25″ NIB (35×6656) | 232,960 |
+| 3.5″ logical (1600×512) | 819,200 |
+| Hard disk | any 512-multiple, usually > 819,200 |
+
+### Classification rule
+Probe by **content first** (magic/structure), fall back to extension+size only for bare images.
+1. **WOZ** (`magic "WOZ1"/"WOZ2"`): read INFO `disk type` byte → 1 ⇒ `DC_FLOPPY_525`, 2 ⇒ `DC_FLOPPY_35`.
+2. **2MG** (`magic "2IMG"`): parse header (§5.1). `image format` 2 (NIB) ⇒ 525. Otherwise use payload size: 143360 ⇒ 525, 819200 ⇒ 35, else ⇒ HDD.
+3. **DC42** (`probeDC42()` content match, §5.2 — *not* by extension): use `dataSize`: 819200 ⇒ 35, 409600 ⇒ 35 (400K), else HDD.
+4. **Bare by size/ext** (raw, no header): `.nib` ⇒ 525; 143360 (`.dsk/.do/.po`) ⇒ 525; 819200 (`.po`) ⇒ 35; `.hdv` or other ⇒ HDD.
+
+**The one genuine ambiguity:** a ProDOS hard-disk volume that is *exactly* 819,200 bytes is
+indistinguishable from a 3.5″ floppy by size. Rule: **819,200 ⇒ `DC_FLOPPY_35`** (real HDD
+volumes are essentially never exactly 800K). Log the assumption; do not hard-fail.
+
+---
+
+## 5. Format parsers (the byte-level reference)
+
+All multi-byte fields are **little-endian** unless noted. DC42 is **big-endian**.
+
+### 5.1 2MG / 2IMG (`.2mg`, `.2img`) — 64-byte header
+
+| Off | Sz | Field | Use |
+|---|---|---|---|
+| 0x00 | 4 | magic `"2IMG"` | identify |
+| 0x04 | 4 | creator | ignore |
+| 0x08 | 2 | header length (=64) | validate |
+| 0x0A | 2 | version (=1) | — |
+| **0x0C** | 4 | **image format** | 0=DOS order, 1=ProDOS order, 2=NIB, 3=CP/M |
+| 0x10 | 4 | flags + DOS volume# | bit31 = write-protected |
+| 0x14 | 4 | block count | × 512 = size when data length is 0 |
+| **0x18** | 4 | **data offset** | bytes to strip (the header_offset) |
+| **0x1C** | 4 | **data length** | payload size (excludes trailing chunks) |
+| 0x20 | 4 | comment offset | — |
+| 0x24 | 4 | comment length | — |
+| 0x28 | 4 | creator-data offset | — |
+| 0x2C | 4 | creator-data length | — |
+| 0x30 | 16 | reserved | — |
+
+**Parser logic — port verbatim from `sim_blkdevice.cpp:157–185` (it is correct):**
+- `header_offset = data_offset` (NOT a hardcoded 64 — handles larger headers).
+- `payload_size  = data_length`; if `data_length == 0`, `payload_size = block_count × 512`.
+- This correctly ignores **trailing** comment/creator chunks after the data.
+- **Validate before trusting:** `header_length == 64 && data_offset >= 64 &&
+  data_offset + payload_size <= file_size`. On failure, log and treat the file as raw
+  (no header adjustment).
+- `image format` + `payload_size` feed classification (§4) and DOS-vs-ProDOS sector order
+  for the 5.25″ WOZ converter (§8.3).
+
+### 5.2 DiskCopy 4.2 — **detected by content, never by extension** — 84-byte **big-endian** header
+
+| Off | Sz | Field | Use |
+|---|---|---|---|
+| 0x00 | 1 | name length (Pascal) | — (must be ≤ 63) |
+| 0x01 | 63 | disk name | — |
+| 0x40 | 4 | **dataSize** (BE) | payload size (800K=819200) |
+| 0x44 | 4 | tagSize (BE) | tag fork length (usually 0 for IIgs) |
+| 0x48 | 4 | dataChecksum (BE) | **goes stale on write** (see §8.1) |
+| 0x4C | 4 | tagChecksum (BE) | — |
+| 0x50 | 1 | diskFormat | 0=400K,1=800K GCR,2/3=MFM |
+| 0x51 | 1 | formatByte | 0x24 = 800K Apple II/ProDOS |
+| 0x52 | 2 | magic `0x01 0x00` (BE) | validate |
+
+- `header_offset = 84`, `payload_size = dataSize`. Data fork is in ProDOS block order;
+  tag fork (12 bytes/block, after the data fork) is dropped.
+
+> **Why content-detection (verified):** the `.dsk` extension is overloaded — on Apple II it
+> means *raw/headerless*, and on Mac it *also* usually means *raw*, not DC42. Real DC42 files
+> use `.image`/`.img`/`.dc42` (or no extension, type/creator `dImg`/`dCpy`). So **do not key
+> DC42 off any extension.** `probeDC42()` runs on every floppy/HDD candidate and matches only
+> when ALL hold: magic `0x01 0x00` at 0x52 **and** `84 + dataSize + tagSize == filesize`
+> **and** `dataSize % 512 == 0` **and** `tagSize % 12 == 0` **and** name-length ≤ 63. The
+> magic-plus-size-equation pair has no realistic false positives against raw 140K/800K images
+> (a raw 819,200-byte file is 84 bytes too short to satisfy the size equation). This way a
+> DC42 mislabeled `.dsk` and a raw image labeled `.dsk` both parse correctly.
+
+### 5.3 WOZ (`.woz`) — served as-is, parsed only to classify
+
+12-byte file header: `"WOZ1"`/`"WOZ2"` (0x00), `0xFF` (0x04), `0A 0D 0A` (0x05),
+CRC32 of bytes 12+ (0x08; 0 = "not computed"). Then chunks (`ID`,`u32 size`,`data`).
+
+For **classification only** we read the INFO chunk:
+- INFO is the first chunk; payload `disk type` at INFO-data **+1**: `1`=5.25″, `2`=3.5″.
+
+We do **not** parse TMAP/TRKS — the core does. We do **not** rewrite the file. (TMAP/TRKS
+layout is documented in `doc/wozreference.html`; relevant only if we ever build the
+DSK→WOZ converter in §8.3.)
+
+### 5.4 Bare (raw, headerless) formats
+
+These have no header, so order comes from the extension. **`.dsk` is raw on *both* Apple II
+and Mac** (it is *not* a DC42 indicator — see §5.2); only a positive `probeDC42()` content
+match makes a file DC42, regardless of its extension.
+
+| Ext | Order | header_offset | Notes |
+|---|---|---|---|
+| `.po` | ProDOS | 0 | 140K floppy or HDD volume by size |
+| `.do` | DOS 3.3 | 0 | 140K 5.25″ floppy |
+| `.dsk` | DOS 3.3 (assumed) | 0 | raw; order not recorded — assume DOS for 5.25″ |
+| `.nib` | nibbles | 0 | 232,960; 5.25″ only |
+| `.hdv` | ProDOS | 0 | hard disk, any size |
+
+---
+
+## 6. Slot validation (respect the user's choice; don't auto-route)
+
+**Guiding principle: the slot the user picked is their intent — honor it whenever the
+image is valid there.** Auto-routing by detected class is *wrong* as a default because some
+combinations are legitimately a user choice, not a mistake:
+
+- An **800K `.2mg` in a hard-disk slot** is a deliberate, valid choice — it runs as a fast
+  raw-block volume instead of as a (slower) emulated 3.5″ floppy. Silently rerouting it to
+  the floppy slot would break that workflow.
+
+So this is a **validator**, not a router. It leans on a slot→class table plus the
+**asymmetric tolerance** of the two classes:
+
+```c
+struct SlotDef { int index; DiskClass cls; };
+static const SlotDef IIGS_SLOTS[] = {
+    {0, DC_HDD},        // permissive: any ProDOS-order block image, any size
+    {1, DC_HDD},        // permissive
+    {2, DC_FLOPPY_35},  // strict: must be 800K-equivalent (or 3.5″ WOZ)
+    {3, DC_FLOPPY_525}, // strict: must be 140K/NIB-equivalent (or 5.25″ WOZ)
+};
+```
+
+**`accepts(slot, image)` — the compatibility test:**
+
+| Slot class | Accepts | Rejects |
+|---|---|---|
+| `DC_HDD` | any **ProDOS-order** block image of any size: `.hdv`, `.po`, `.2mg` fmt 1, `.dc42`, raw — incl. 140K/800K volumes | DOS-order-only images (`.do`, `.dsk`, `.2mg` fmt 0), `.nib`, `.woz` |
+| `DC_FLOPPY_35` | 800K (819,200) payload: `.po`/`.2mg`/`.dc42`; or `.woz` INFO type 2 | anything not 800K; 5.25″ WOZ; HDD-sized images |
+| `DC_FLOPPY_525` | 140K (143,360) `.dsk/.do/.po`/`.2mg` fmt 0/2; `.nib` (232,960); or `.woz` INFO type 1 | 800K; 3.5″ WOZ; HDD-sized images |
+
+**Mount algorithm** (inside / wrapping `user_io_file_mount`):
+
+1. `cls = classify(name)` (§4–5). If `DC_UNKNOWN` → block + error (§7).
+2. **If `accepts(picked_slot, image)` → mount there. Done. No message, no move.**
+   (This is the common path, and it preserves intentional choices like 800K-as-HDD.)
+3. Else the combo is **broken** → **block + guiding error** (§7). Do not mount; leave the
+   slot empty. The message names where the image *should* go, e.g.:
+   "This looks like a hard-disk image — load it into a Hard Disk slot (S0/S1)."
+
+**No disk is ever auto-routed.** The mount either lands in the slot the user picked (when
+valid) or is blocked with guidance. This keeps behavior fully predictable and never places
+a disk where the user wasn't looking — including the intentional 800K-as-HDD choice, which
+is simply a *valid* combo that lands where picked.
+
+---
+
+## 7. Broken-combo guard (OSD message)
+
+Fires only when §6 step 3 determines the image can't work in the chosen slot (and isn't
+being rerouted). **Detection is entirely MiSTer-side** (we already parsed the header and
+know the slot), so use the **direct OSD popup**, not the core's `info_req` path:
+
+- `InfoMessage(const char *msg, int timeout=2000, const char *title="Message")` — titled
+  message box (`menu.cpp:7900`).  ← use this.
+- `Info(const char *msg, ...)` — lighter overlay (`menu.cpp:7930`).
+
+On any validation failure: **do not mount**, leave the slot empty, and show a specific
+message, e.g.:
+- "3.5″ drive needs an 800 KB disk — this image is a 32 MB hard disk."
+- "5.25″ drive needs a 140 KB disk — this is an 800 KB 3.5″ image."
+- "Unrecognized disk image."
+
+> The core-driven `info_req`/`info` + CONF_STR `I` mechanism (`user_io.cpp:3669`,
+> `show_core_info`) is **not used here** — it's for problems only the HDL can detect at
+> runtime. Mount-time validation lives where the data already is.
+
+---
+
+## 8. Run-time translation (per-LBA)
+
+Dispatched from `user_io.cpp:3256` (where `SD_TYPE_A2` is handled today). Add a per-slot
+`header_offset[16]` array (model: the sim's `header_size[]`). Note `fileTYPE.offset` is the
+running cursor, **not** a base offset, so header stripping must be explicit.
+
+### 8.1 Hard disk — offset-mapped passthrough  (read/write, v1)
+- Read/write `512×lba + header_offset[slot]`. No byte transform.
+- `.hdv`/`.po`/raw: `header_offset = 0`.
+- `.2mg`: `header_offset = data_offset`. Writes land in the payload; the static header is
+  untouched → **fully writable, correct.**
+- `.dc42`: `header_offset = 84`. Writes are correct, **but the header `dataChecksum`
+  becomes stale.** v1 policy: **mount DC42 read-only** (set `img_readonly`), or (v2)
+  recompute and rewrite the checksum on eject. Recommend read-only for v1.
+
+### 8.2 Native WOZ floppy — flat block passthrough  (read; write within allocation)
+- Served byte-for-byte; the core navigates TMAP/TRKS and requests blocks. `header_offset=0`.
+- **Writes**: the core writes 512-byte blocks back into the existing TRKS BITS region;
+  we pass them straight through. This works **only within the blocks already allocated to
+  a track**. Per `wozreference.html`: unused tracks are `0xFF` in TMAP with zero-length
+  TRKS, and tracks can vary in length. We **do not** grow/relocate/normalize (would risk
+  copy protection), so:
+  - Writes to already-formatted tracks: persist.
+  - Writes that would need a new/larger track allocation: **cannot persist** in v1.
+  - After any write the file's CRC32 is stale → **zero the CRC** field on first write (a
+    0 CRC is explicitly "not computed" and accepted by readers).
+- Document this as a known v1 limitation; full WOZ write support is a v2 topic.
+
+### 8.3 Converted floppy (DSK/DO/PO/NIB/2MG-wrapped) → WOZ  (v2 write)
+The core reads only WOZ, so non-WOZ floppies must be **synthesized into a WOZ on the fly**,
+exactly like `a2_readDsk2Nib` synthesizes NIB per offset — but emitting a WOZ layout we
+control. Because we choose the layout, we make it an **"easy WOZ"**: uniform per-track
+block allocation, standard 6-and-2 (5.25″) / zoned GCR (3.5″) encoding, no copy-protection
+tricks. That makes the inverse (WOZ→sectors→original file) trivial, so **writes round-trip**
+back to the source `.dsk`/`.po` — the same model as the live `a2_writeNib2Dsk`.
+
+- **5.25″** (`.dsk/.do/.po/.nib`, 140K / 2MG fmt 0/2): reuse the 6-and-2 nibblizer in
+  `dsk2nib_lib.cpp`; bit-pack MSB-first into an easy-WOZ track; DOS vs ProDOS sector order
+  comes from the source (`.do`/2MG fmt0 = DOS, `.po`/2MG fmt1 = ProDOS).
+- **3.5″** (`.po`/`.2mg`/`.dc42`, 800K): zoned layout (12/11/10/9/8 sectors), 524-byte
+  tag-padded sectors, the 3-byte scrambling GCR checksum. Hardest piece — crib from
+  MAME / CiderPress2 / Applesauce reference code rather than deriving.
+
+**Phasing:**
+- **v1:** converted floppies are read-only.
+- **v2 (done):** write-back enabled. On each block write the affected WOZ track is located
+  (`a2_woz_track_for_lba`), decoded (`a2_woz35_decode_track` / `a2_woz525_decode_track`), and
+  the resulting sectors are written to the source file — at the 2MG/DC42 header offset, and
+  re-skewed DOS→ProDOS for `.po` 5.25 sources. Persisted per-write (survives no clean eject);
+  unwritten blocks of an in-progress track still hold valid prior data, so partial-track
+  writes converge correctly. `.nib` and DC42 sources remain read-only (DC42 = stale-checksum).
+
+---
+
+## 9. Code changes (integration map)
+
+| File | Change |
+|---|---|
+| `DiskImage.cpp` / `DiskImage.h` | **Remove dead** `dsk2nib()` (defn `DiskImage.cpp:3315`, decl `DiskImage.h:6`) — no callers. Leave `x2trd*` (TR-DOS, still used). |
+| `support/a2/` | New `iigs_disk.{cpp,h}`: `classify()`, 2MG/DC42/WOZ header parsers, slot routing, the easy-WOZ encoder (5.25″ now, 3.5″ later). Reuse `dsk2nib_lib.cpp` nibblizer. |
+| `user_io.cpp` | (a) new `SD_TYPE_*` values for HDD-offset / WOZ-native / WOZ-converted; (b) classification + routing + strict guard in/around `user_io_file_mount` (~2084); (c) add `header_offset[]` and apply it in the block dispatch (~3256 / generic seek ~3312); (d) per-class branch in the §3256 dispatch. |
+| `Apple-IIgs.sv` (core repo) | Widen `CONF_STR` slot extension lists (S0/S1 add `2MG`,`DC`; S2/S3 add `DSK/DO/PO/NIB/2MG`). HDL only — no logic change. |
+
+The Makefile globs `support/*/*.cpp`, so new files in `support/a2/` need no Makefile edit.
+
+---
+
+## 10. Implementation phases
+
+1. **Cleanup** — delete dead `dsk2nib()`; add `header_offset[]`; verify HDD `.po/.hdv`
+   mount + read/write unchanged.
+2. **HDD formats** — `classify()` + 2MG (port sim parser) → HDD offset passthrough.
+   Strict guard + `InfoMessage`. (High value, low risk, writable.) **DC42 demoted** to a
+   cheap `probeDC42()` content-detected fallback only — see §12; it is a Mac-native format
+   that IIgs software essentially never ships as, so it gets no dedicated effort.
+3. **Validation** — `accepts(slot,image)` check (HDD permissive, floppy strict); honor valid choices silently; block-with-guidance on broken combos.
+4. **Native WOZ** — pass-through mount on S2/S3 with class validation (read; constrained write per §8.2).
+5. **5.25″ conversion** — easy-WOZ encoder reusing the nibblizer; read-only (v1).
+6. **3.5″ conversion** — zoned GCR easy-WOZ encoder; read-only (v1). **Done — boots GS/OS in sim.**
+7. **v2 — done** — write round-trip for converted floppies (per-track decode → source).
+   Remaining v2+: DC42 checksum rewrite on eject (to make DC42 floppies writable too).
+
+> **Codec status:** the pure codec (`support/a2/iigs_fmt.{h,cpp}`) for phases 2/4/5/6 is
+> written and tested (native round-trips + sim boot).
+>
+> **Integration status (done):** `support/a2/iigs_disk.{h,cpp}` wires it into MiSTer for
+> the `Apple-IIgs` core only (guarded by `iigs_is_core()`), via a new `SD_TYPE_IIGS`
+> dispatch branch in `user_io.cpp` (alongside, not replacing, `SD_TYPE_A2`). At mount it
+> classifies + strictly validates the image against the slot (`InfoMessage` guidance on
+> mismatch), strips 2MG/DC42 headers for HDD slots (offset serving, read/write), and
+> converts `.po/.dsk/.do/.nib/.2mg` floppies to an in-memory WOZ (read-only, v1); native
+> `.woz` and raw `.po/.hdv` pass through. Cross-compiles clean into the ARM binary; the
+> Apple II NIB flow is untouched.
+>
+> **Remaining to expose the formats:** the core's `CONF_STR` extension lists must be
+> widened (HDL, `Apple-IIgs.sv`) — today S0/S1 list only `HDVPO` and S2/S3 only `WOZ`, so
+> the file browser won't *offer* `.2mg/.dsk/.po/...` for those slots even though the
+> MiSTer side now handles them. Needs a one-line-per-slot edit + FPGA rebuild.
+
+---
+
+## 11. Open questions / risks
+
+- **Easy-WOZ acceptance:** confirm the core's WOZ engine reads a minimal standard-layout
+  WOZ (uniform track sizes) for converted disks. (Native protected WOZ is untouched.)
+- **3.5″ WOZ — implemented and sim-validated.** Encode/decode ported from Clemens/CiderPress;
+  round-trips on the real `System.Disk.po`, and a WOZ generated by `iigs_convert po2woz` from
+  `System.Disk.po` **boots GS/OS 6.0.4** in the Verilator core (boot splash at frame 600;
+  GS/OS running at frame 2200). The per-track block budget is fine as-is — no gap trimming
+  needed. Covered by `iigs_regression.sh` (§12).
+- **`.dsk` order ambiguity:** assume DOS 3.3 order (matches existing apple-ii behavior);
+  revisit if IIgs `.dsk` images turn out ProDOS-ordered.
+- **819,200-byte ProDOS HDD volume** misclassified as 3.5″ floppy (§4) — accepted edge case.
+- **ShrinkIt `.shk/.sdk`** (compressed) is **out of scope** — needs a NuFX/LZW decoder.
+
+---
+
+## 12. Test fixtures
+
+Real images collected in `artifacts_for_iigs/` (and the IIgs core repo). Every converter
+input in this spec has at least one genuine fixture. Sizes are exact bytes.
+
+### Hard disk (raw ProDOS blocks → offset passthrough, §8.1)
+| File | Bytes | Exercises |
+|---|---|---|
+| `Live.Install.po` | 33,552,384 | large raw HDD `.po`, no header |
+| `System.Disk.po` | 819,200 | 800K ProDOS `.po` (also valid as 3.5″ floppy — the intentional-overlap case, §6) |
+| `iigs_simulation/.../blank.2mg` | 2,097,216 | **HDD 2MG** (fmt 1 ProDOS, 2 MB / 4096 blocks); `data_off=64`, `data_len=2,097,152` |
+
+### 3.5″ floppy (800K → native WOZ §8.2 or convert §8.3)
+| File | Bytes | Exercises |
+|---|---|---|
+| `Zany Golf.woz` | 1,296,664 | native **WOZ2, disk type 2 (3.5″)**, write-protected; slot-match check |
+| `Arkanoid/Arkanoid.2mg` | 819,272 | 800K floppy 2MG with **8 trailing bytes** after payload → proves we strip via `data_len`, not `filesize−64` |
+| `Airball/Airball.2mg` | 819,271 | 800K floppy 2MG, 7 trailing bytes (same edge case) |
+| `System.Disk.po`, `Tour of the Apple IIGS *.po` | 819,200 | 800K ProDOS `.po` floppies |
+
+### 5.25″ floppy (140K / NIB → native WOZ §8.2 or convert §8.3)
+| File | Bytes | Exercises |
+|---|---|---|
+| `Zork I r15-UG3AU5.woz` | 234,846 | native **WOZ2, disk type 1 (5.25″)**; slot-match check |
+| `Apple DOS 3.3 January 1983.dsk` (+ 22 more `.dsk`) | 143,360 | raw 140K DOS/ProDOS images → 6-and-2 nibblize → easy-WOZ |
+| `Apple DOS 3.3 January 1983.do` | 143,360 | the `.do` extension branch (DOS-order; byte-identical copy of the `.dsk`) |
+| `Apple DOS 3.3 January 1983.nib`, `Apple DOS 3.3 August 1980.nib` | 232,960 | pre-nibblized `.nib` → WOZ wrap path |
+
+### WOZ skeleton (the "easy WOZ" blueprint, §8.3)
+| File | Purpose |
+|---|---|
+| `iigs_simulation/tools/make_blank_woz.py` | Reference generator for the fully-pre-allocated WOZ the core's `woz_floppy_controller` needs to write back. Port to C for the converter. Defines 3.5″ speed-group block counts (19/18/16/14/13) and 5.25″ (51200 bits, 13 blocks/track). |
+| `iigs_simulation/tools/blank_35.woz` | A pre-built blank 3.5″ easy-WOZ to compare encoder output against. |
+
+### DC42 — parser-only, **not IIgs** (DC42 is demoted, §10)
+| File | Bytes | Note |
+|---|---|---|
+| `Blank800K.img` | 819,284 | DiskCopy 4.2, `dataSize=819200`, `tagSize=0`, **formatByte 0x22 = Mac** (not 0x24 ProDOS). Mac HFS payload — exercises `probeDC42()` header parse only; will **not boot** a IIgs. |
+| `Blank400K.img` | 419,284 | DiskCopy 4.2 with a real **9,600-byte tag fork** (800 blocks × 12); tests tag-skip + the `tagSize%12` / size-equation checks. Also Mac (formatByte 0x00). |
+
+> Both DC42 files are Macintosh blanks kept **only** as unit-test inputs for `probeDC42()` —
+> they are not representative IIgs disks. A genuine IIgs-bootable DC42 (formatByte 0x24) can
+> be synthesized on demand by wrapping `System.Disk.po` with a correct big-endian header +
+> DiskCopy checksum, but isn't needed unless DC42 is ever promoted past a fallback.
+
+### Codec, tools & tests (in this repo)
+| Path | Purpose |
+|---|---|
+| `support/a2/iigs_fmt.{h,cpp}` | Pure dependency-free codec (2MG/DC42/WOZ parse, DOS↔ProDOS, DSK↔NIB, DSK↔WOZ 5.25, PO↔WOZ 3.5). Cross-compiles into MiSTer. |
+| `support/a2/tests/` | Native round-trip + real-fixture tests (`make run`). 64 checks, no sim needed. |
+| `support/a2/tools/iigs_convert.cpp` | CLI: `po2woz`/`dsk2woz`/`woz2po`/`woz2dsk`/`classify`. Generates images for the sim. |
+| `support/a2/tools/iigs_regression.sh` | End-to-end: native suite + convert real `.po`/`.dsk` → WOZ → **boot in the Verilator sim**, screenshot, diff against saved references (`--bless` to update). Mirrors the sim's `regression.sh`. |
+
+**Validated:** `iigs_regression.sh` → PASS 4/0 — native suite green; `System.Disk.po` and
+`Tour of the Apple IIGS 2.0.po` boot (BOOTED), `Apple DOS 3.3…dsk` boots (TEXT) — all via
+WOZ produced by our codec.
+
+### Gaps / synthesizable on demand
+- A DOS-order **2MG (`image format`=0)** — all sample 2MGs are fmt 1; fake by flipping the
+  format byte to test the "DOS-order can't go in a HDD slot" branch.
+- Deliberately **wrong slot/disk combos** for the §7 guard — construct from the above
+  (e.g. `Live.Install.po` into a floppy slot must block).

--- a/support/a2/iigs_disk.cpp
+++ b/support/a2/iigs_disk.cpp
@@ -1,0 +1,333 @@
+// MiSTer integration glue for the Apple IIgs core. See iigs_disk.h.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "../../file_io.h"
+#include "../../user_io.h"
+#include "../../hardware.h"
+#include "../../menu.h"
+
+#include "iigs_fmt.h"
+#include "iigs_disk.h"
+
+// Per-slot serving state (only used for SD_TYPE_IIGS slots).
+//   mode 0 = hard disk, raw blocks at hdr_off (2MG/DC42)
+//   mode 1 = converted floppy, served from the in-memory woz buffer (read-only)
+static int        g_mode[16]    = {};
+static int64_t    g_hdr_off[16]  = {};
+static uint8_t   *g_woz[16]      = {};
+static size_t     g_woz_sz[16]   = {};
+// Converted-floppy write-back descriptor (mode 1):
+static int        g_wb_ok[16]    = {};  // write-back supported (and file writable)
+static int        g_wb_kind[16]  = {};  // 1 = 3.5", 2 = 5.25"
+static int64_t    g_wb_off[16]   = {};  // header offset within the source file
+static int        g_wb_order[16] = {};  // 5.25 source order: 0 = DOS, 1 = ProDOS
+
+// IIgs slot kinds: 0,1 = hard disk; 2 = 3.5"; 3 = 5.25". -1 = not an IIgs slot.
+static int slot_kind(int index)
+{
+	if (index == 0 || index == 1) return 0;  // HDD
+	if (index == 2) return 1;                 // 3.5"
+	if (index == 3) return 2;                 // 5.25"
+	return -1;
+}
+
+static int eqi(const char *a, const char *b) { return a && b && !strcasecmp(a, b); }
+
+int iigs_is_core(void)
+{
+	const char *n = user_io_get_core_name();
+	return n && !strcasecmp(n, "Apple-IIgs");
+}
+
+static void reject(const char *msg)
+{
+	printf("IIgs: rejecting mount: %s\n", msg);
+	InfoMessage(msg, 5000, "Wrong disk for slot");
+}
+
+void iigs_unmount(int index)
+{
+	if (index < 0 || index >= 16) return;
+	if (g_woz[index]) { free(g_woz[index]); g_woz[index] = NULL; }
+	g_woz_sz[index] = 0;
+	g_hdr_off[index] = 0;
+	g_mode[index] = 0;
+	g_wb_ok[index] = 0;
+	g_wb_kind[index] = 0;
+	g_wb_off[index] = 0;
+	g_wb_order[index] = 0;
+}
+
+// Read the entire open image into a freshly malloc'd buffer (caller frees).
+static uint8_t *read_all(fileTYPE *f, size_t *out_len)
+{
+	size_t n = (size_t)f->size;
+	uint8_t *b = (uint8_t *)malloc(n ? n : 1);
+	if (!b) return NULL;
+	FileSeek(f, 0, SEEK_SET);
+	size_t got = 0;
+	while (got < n) {
+		int r = FileReadAdv(f, b + got, n - got);
+		if (r <= 0) break;
+		got += (size_t)r;
+	}
+	FileSeek(f, 0, SEEK_SET);
+	if (got != n) { free(b); return NULL; }
+	*out_len = n;
+	return b;
+}
+
+// Build a converted WOZ for a floppy slot. Returns malloc'd buffer + size, or
+// NULL on failure. kind: 1 = 3.5", 2 = 5.25".
+static uint8_t *build_woz(int kind, const char *ext, const uint8_t *raw, size_t raw_len, size_t *out_sz)
+{
+	// Resolve the payload (strip 2MG/DC42 header) and its order.
+	const uint8_t *pay = raw;
+	size_t pay_len = raw_len;
+	int order_prodos = 0, order_nib = 0;
+
+	TwoMG m;
+	DC42 d;
+	if (twomg_parse(raw, raw_len, &m)) {
+		pay = raw + m.data_offset;
+		pay_len = m.data_len;
+		order_prodos = (m.format == 1);
+		order_nib    = (m.format == 2);
+	} else if (dc42_parse(raw, raw_len, &d)) {
+		pay = raw + 84;
+		pay_len = d.data_size;
+		order_prodos = 1;
+	} else if (raw_len == A2_NIB_IMAGE_SIZE) {
+		order_nib = 1;
+	} else if (eqi(ext, "po")) {
+		order_prodos = 1;
+	} // else .do/.dsk => DOS order
+
+	if (kind == 1) {
+		// 3.5": need an 800K ProDOS image
+		if (pay_len != A2_35_IMAGE_SIZE || order_nib) return NULL;
+		size_t cap = 2 * 1024 * 1024;
+		uint8_t *woz = (uint8_t *)malloc(cap);
+		if (!woz) return NULL;
+		size_t n = a2_po_to_woz35(woz, cap, pay);
+		if (!n) { free(woz); return NULL; }
+		*out_sz = n;
+		return woz;
+	}
+
+	// 5.25": produce a 140K DOS-order image, then encode to WOZ
+	static uint8_t dsk[A2_525_IMAGE_SIZE];
+	if (order_nib) {
+		if (pay_len != A2_NIB_IMAGE_SIZE) return NULL;
+		if (!a2_nib_to_dsk(dsk, pay)) return NULL;
+	} else {
+		if (pay_len != A2_525_IMAGE_SIZE) return NULL;
+		if (order_prodos) a2_prodos_to_dos(dsk, pay);
+		else              memcpy(dsk, pay, A2_525_IMAGE_SIZE);
+	}
+	size_t cap = 512 * 1024;
+	uint8_t *woz = (uint8_t *)malloc(cap);
+	if (!woz) return NULL;
+	size_t n = a2_dsk_to_woz525(woz, cap, dsk);
+	if (!n) { free(woz); return NULL; }
+	*out_sz = n;
+	return woz;
+}
+
+int iigs_mount(int index, const char *name, fileTYPE *f, int *out_writable)
+{
+	if (!iigs_is_core()) return IIGS_PASSTHRU;
+	int kind = slot_kind(index);
+	if (kind < 0) return IIGS_PASSTHRU;
+
+	iigs_unmount(index);
+
+	uint8_t head[128];
+	memset(head, 0, sizeof(head));
+	size_t hn = f->size < (int)sizeof(head) ? (size_t)f->size : sizeof(head);
+	FileSeek(f, 0, SEEK_SET);
+	FileReadAdv(f, head, hn);
+	FileSeek(f, 0, SEEK_SET);
+
+	const char *dot = strrchr(name, '.');
+	const char *ext = dot ? dot + 1 : NULL;
+	int wt     = woz_disk_type(head, f->size);
+	int is_nib = (f->size == A2_NIB_IMAGE_SIZE);
+	TwoMG m;
+	int is_2mg = twomg_parse(head, f->size, &m);
+	int is_dc42 = dc42_probe(head, f->size);
+
+	if (kind == 0) {
+		// ----- hard-disk slot: permissive (any ProDOS-order block image) -----
+		if (wt > 0)   { reject("Hard-disk slot needs a ProDOS block image, not a WOZ floppy."); return IIGS_REJECT; }
+		if (is_nib)   { reject("Hard-disk slot needs a ProDOS block image, not a .nib floppy."); return IIGS_REJECT; }
+		if (is_2mg && m.format != 1) { reject("This 2MG is DOS/NIB order; not a ProDOS hard-disk image."); return IIGS_REJECT; }
+		if (eqi(ext, "do")) { reject("DOS-order disk — load it in a 5.25\" drive, not a hard disk."); return IIGS_REJECT; }
+
+		int64_t off = 0;
+		if (is_2mg)       off = m.data_offset;
+		else if (is_dc42) off = 84;
+		if (off == 0) return IIGS_PASSTHRU;   // raw .po/.hdv: generic path serves it
+
+		g_mode[index]    = 0;
+		g_hdr_off[index] = off;
+		if (f->size > off) f->size -= off;     // core sees the payload size
+		*out_writable = FileCanWrite(name);
+		printf("IIgs: HDD slot %d, header offset %lld, payload %lld bytes\n",
+		       index, (long long)off, (long long)f->size);
+		return IIGS_HANDLED;
+	}
+
+	// ----- floppy slot (kind 1 = 3.5", kind 2 = 5.25") -----
+	if (wt > 0) {
+		int want = (kind == 1) ? 2 : 1;
+		if (wt != want) {
+			reject(kind == 1 ? "That's a 5.25\" WOZ — use the 5.25\" drive."
+			                 : "That's a 3.5\" WOZ — use the 3.5\" drive.");
+			return IIGS_REJECT;
+		}
+
+		// A zip-backed file is a forward-only decompression stream: every
+		// backward seek re-inflates from the start, which is far too slow for
+		// the WOZ controller's random track access and breaks flux-timing
+		// copy protection (e.g. Karateka). Load the WOZ verbatim into RAM and
+		// serve from there — byte-for-byte identical, no conversion, so the
+		// protection is preserved. Regular files keep fast random access via
+		// the passthrough path below.
+		if (f->zip) {
+			size_t n = 0;
+			uint8_t *buf = read_all(f, &n);
+			if (!buf) { reject("Could not read the WOZ from the archive."); return IIGS_REJECT; }
+			g_mode[index]   = 1;
+			g_woz[index]    = buf;
+			g_woz_sz[index] = n;
+			g_wb_ok[index]  = 0;            // read-only: cannot write back into a zip
+			f->size = (int64_t)n;
+			*out_writable = 0;
+			printf("IIgs: native WOZ from archive on slot %d -> RAM (%zu bytes), read-only\n", index, n);
+			return IIGS_HANDLED;
+		}
+
+		return IIGS_PASSTHRU;   // native WOZ on a real file: serve directly
+	}
+
+	// Need to convert. Validate geometry up front for a clear message.
+	DiskClass cls = iigs_classify(head, f->size, ext);
+	int want_cls = (kind == 1) ? DC_FLOPPY_35 : DC_FLOPPY_525;
+	if (cls != want_cls) {
+		reject(kind == 1 ? "3.5\" drive needs an 800K disk image."
+		                 : "5.25\" drive needs a 140K disk image.");
+		return IIGS_REJECT;
+	}
+
+	size_t raw_len = 0;
+	uint8_t *raw = read_all(f, &raw_len);
+	if (!raw) { reject("Could not read the disk image."); return IIGS_REJECT; }
+
+	// Determine the write-back descriptor before consuming `raw`.
+	int wb_off = 0, wb_order = (kind == 1) ? 1 : 0, wb_ok = 0;
+	TwoMG mm;
+	if (twomg_parse(raw, raw_len, &mm)) {
+		wb_off = (int)mm.data_offset;
+		if (mm.format == 2)      wb_ok = 0;                       // NIB payload: read-only
+		else { wb_ok = 1; if (kind == 2) wb_order = (mm.format == 1); }
+	} else if (dc42_probe(raw, raw_len)) {
+		wb_ok = 0;                                                // DC42: read-only (stale checksum)
+	} else if (raw_len == A2_NIB_IMAGE_SIZE) {
+		wb_ok = 0;                                                // .nib: read-only (v1)
+	} else if (kind == 2 && eqi(ext, "po")) {
+		wb_ok = 1; wb_order = 1;                                  // ProDOS-order 140K
+	} else {
+		wb_ok = 1; if (kind == 2) wb_order = 0;                   // raw .po(800K) / .do / .dsk
+	}
+	if (!FileCanWrite(name)) wb_ok = 0;
+
+	size_t woz_sz = 0;
+	uint8_t *woz = build_woz(kind, ext, raw, raw_len, &woz_sz);
+	free(raw);
+	if (!woz) { reject("Could not convert this disk to WOZ."); return IIGS_REJECT; }
+
+	g_mode[index]    = 1;
+	g_woz[index]     = woz;
+	g_woz_sz[index]  = woz_sz;
+	g_wb_ok[index]   = wb_ok;
+	g_wb_kind[index] = kind;
+	g_wb_off[index]  = wb_off;
+	g_wb_order[index] = wb_order;
+	f->size = (int64_t)woz_sz;            // core sees the WOZ size
+	*out_writable = wb_ok;                // writable only if write-back is supported
+	printf("IIgs: floppy slot %d converted to WOZ (%zu bytes), %s\n",
+	       index, woz_sz, wb_ok ? "read-write (write-back)" : "read-only");
+	return IIGS_HANDLED;
+}
+
+void iigs_read(int disk, fileTYPE *f, uint64_t lba, int ack)
+{
+	uint8_t chunk[512];
+	if (g_mode[disk] == 1) {
+		uint64_t off = lba * 512;
+		if (g_woz[disk] && off + 512 <= g_woz_sz[disk]) memcpy(chunk, g_woz[disk] + off, 512);
+		else memset(chunk, 0, 512);
+	} else {
+		if (!(FileSeek(f, (int64_t)(lba * 512 + g_hdr_off[disk]), SEEK_SET) &&
+		      FileReadAdv(f, chunk, 512) > 0))
+			memset(chunk, 0, 512);
+	}
+	EnableIO();
+	spi_w(UIO_SECTOR_RD | ack);
+	spi_block_write(chunk, user_io_get_width(), 512);
+	DisableIO();
+}
+
+void iigs_write(int disk, fileTYPE *f, uint64_t lba, int ack)
+{
+	uint8_t chunk[512];
+	EnableIO();
+	spi_w(UIO_SECTOR_WR | ack);
+	spi_block_read(chunk, user_io_get_width(), 512);
+	DisableIO();
+
+	if (g_mode[disk] == 0) {
+		// Hard disk: write straight back to the file at the header offset.
+		if (FileSeek(f, (int64_t)(lba * 512 + g_hdr_off[disk]), SEEK_SET))
+			FileWriteAdv(f, chunk, 512);
+		return;
+	}
+
+	// Converted floppy: update the in-memory WOZ, then (if write-back is
+	// supported) decode the affected track and persist it to the source image.
+	uint64_t off = lba * 512;
+	if (g_woz[disk] && off + 512 <= g_woz_sz[disk]) memcpy(g_woz[disk] + off, chunk, 512);
+	if (!g_wb_ok[disk]) return;
+
+	int t = a2_woz_track_for_lba(g_woz[disk], g_woz_sz[disk], (uint32_t)lba);
+	if (t < 0) return;   // header block (TMAP/TRKS dir) — nothing to persist
+
+	if (g_wb_kind[disk] == 1) {
+		// 3.5": decode the track's ProDOS blocks, write that block range back.
+		static uint8_t po[A2_35_IMAGE_SIZE];
+		int base = 0, cnt = 0;
+		if (a2_woz35_decode_track(g_woz[disk], g_woz_sz[disk], t, po, &base, &cnt) > 0) {
+			if (FileSeek(f, g_wb_off[disk] + (int64_t)base * 512, SEEK_SET))
+				FileWriteAdv(f, po + (size_t)base * 512, (size_t)cnt * 512);
+		}
+	} else {
+		// 5.25": decode the DOS-order track; re-skew to ProDOS if the source is .po.
+		static uint8_t dsk[A2_525_IMAGE_SIZE];
+		if (a2_woz525_decode_track(g_woz[disk], g_woz_sz[disk], t, dsk) > 0) {
+			static const int D2P[16] = { 0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15 };
+			uint8_t out[A2_TRACK_SIZE];
+			const uint8_t *src = dsk + (size_t)t * A2_TRACK_SIZE;
+			if (g_wb_order[disk] == 1)
+				for (int s = 0; s < 16; s++) memcpy(out + D2P[s] * 256, src + s * 256, 256);
+			else
+				memcpy(out, src, A2_TRACK_SIZE);
+			if (FileSeek(f, g_wb_off[disk] + (int64_t)t * A2_TRACK_SIZE, SEEK_SET))
+				FileWriteAdv(f, out, A2_TRACK_SIZE);
+		}
+	}
+}

--- a/support/a2/iigs_disk.h
+++ b/support/a2/iigs_disk.h
@@ -1,0 +1,43 @@
+// MiSTer integration glue for the Apple IIgs core disk handling.
+//
+// This is the bridge between the pure codec (iigs_fmt.{h,cpp}) and MiSTer's
+// SD-block plumbing in user_io.cpp. It is active ONLY for the "Apple-IIgs"
+// core; every other core (including the Apple II NIB flow via SD_TYPE_A2) is
+// left completely untouched.
+//
+// Slots (Apple-IIgs.sv, VDNUM=4): S0,S1 = hard disk; S2 = 3.5"; S3 = 5.25".
+
+#ifndef IIGS_DISK_H
+#define IIGS_DISK_H
+
+#include <stdint.h>
+// Relies on fileTYPE being defined already (file_io.h), matching dsk2nib_lib.h:
+// this header is reached via support.h, which is included after file_io.h.
+
+// sd_type value used to route IIgs slots into iigs_read/iigs_write. Continues
+// the series after SD_TYPE_A2 (=2) defined in user_io.cpp.
+#define SD_TYPE_IIGS 3
+
+// iigs_mount return codes.
+#define IIGS_PASSTHRU  0   // not handled — serve normally (raw .po/.hdv/native .woz)
+#define IIGS_HANDLED   1   // set up for iigs_read/iigs_write; size/sd_type adjusted
+#define IIGS_REJECT   (-1) // wrong disk for this slot — caller aborts mount (OSD shown)
+
+// True if the running core is "Apple-IIgs".
+int iigs_is_core(void);
+
+// Called from user_io_file_mount after the image is opened, for the IIgs core.
+// May convert a floppy image to WOZ (in memory) or set a header offset for a
+// 2MG/DC42 hard disk, validate the image against the slot (strict, with OSD
+// guidance on mismatch), and adjust f->size to what the core should see.
+// *out_writable is set to the read/write policy for HANDLED mounts.
+int  iigs_mount(int index, const char *name, fileTYPE *f, int *out_writable);
+
+// Release any per-slot resources (converted WOZ buffer). Safe to call anytime.
+void iigs_unmount(int index);
+
+// Block dispatch, called from user_io.cpp like a2_readDSK/a2_writeDSK.
+void iigs_read(int disk, fileTYPE *f, uint64_t lba, int ack);
+void iigs_write(int disk, fileTYPE *f, uint64_t lba, int ack);
+
+#endif // IIGS_DISK_H

--- a/support/a2/iigs_fmt.cpp
+++ b/support/a2/iigs_fmt.cpp
@@ -1,0 +1,929 @@
+// Apple IIgs disk-format conversions (pure, dependency-free codec).
+// See iigs_fmt.h and IIGS_DISK_SUPPORT.md.
+
+#include "iigs_fmt.h"
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// little/big-endian helpers
+// ---------------------------------------------------------------------------
+static inline uint16_t rd_le16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+static inline uint32_t rd_le32(const uint8_t *p) {
+	return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+static inline uint32_t rd_be32(const uint8_t *p) {
+	return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+static inline void wr_le16(uint8_t *p, uint16_t v) { p[0] = v & 0xff; p[1] = (v >> 8) & 0xff; }
+static inline void wr_le32(uint8_t *p, uint32_t v) {
+	p[0] = v & 0xff; p[1] = (v >> 8) & 0xff; p[2] = (v >> 16) & 0xff; p[3] = (v >> 24) & 0xff;
+}
+static inline void wr_be32(uint8_t *p, uint32_t v) {
+	p[0] = (v >> 24) & 0xff; p[1] = (v >> 16) & 0xff; p[2] = (v >> 8) & 0xff; p[3] = v & 0xff;
+}
+
+// ---------------------------------------------------------------------------
+// CRC32 (zlib/WOZ compatible)
+// ---------------------------------------------------------------------------
+uint32_t woz_crc32(const uint8_t *data, size_t len)
+{
+	uint32_t crc = 0xFFFFFFFFu;
+	for (size_t i = 0; i < len; i++) {
+		crc ^= data[i];
+		for (int b = 0; b < 8; b++)
+			crc = (crc >> 1) ^ (0xEDB88320u & (~(crc & 1) + 1));
+	}
+	return crc ^ 0xFFFFFFFFu;
+}
+
+// ===========================================================================
+// 2MG / 2IMG
+// ===========================================================================
+int twomg_parse(const uint8_t *buf, size_t size, TwoMG *out)
+{
+	if (size < 64 || memcmp(buf, "2IMG", 4) != 0) return 0;
+
+	uint16_t hdr_len   = rd_le16(buf + 8);
+	uint32_t format    = rd_le32(buf + 12);
+	uint32_t flags     = rd_le32(buf + 16);
+	uint32_t blocks    = rd_le32(buf + 20);
+	uint32_t data_off  = rd_le32(buf + 24);
+	uint32_t data_len  = rd_le32(buf + 28);
+
+	// data_len can be 0 for ProDOS images -- derive from block count.
+	if (data_len == 0) data_len = blocks * A2_BLOCK_SIZE;
+
+	// Validate before trusting (matches sim_blkdevice.cpp).
+	if (hdr_len != 64 || data_off < 64 ||
+	    (uint64_t)data_off + data_len > size)
+		return 0;
+
+	if (out) {
+		out->format          = format;
+		out->flags           = flags;
+		out->blocks          = blocks;
+		out->data_offset     = data_off;
+		out->data_len        = data_len;
+		out->write_protected = (flags & 0x80000000u) ? 1 : 0;
+	}
+	return 1;
+}
+
+size_t twomg_build(uint8_t *out, size_t out_cap,
+                   const uint8_t *payload, uint32_t payload_len, uint32_t format)
+{
+	size_t total = 64 + (size_t)payload_len;
+	if (out_cap < total) return 0;
+
+	memset(out, 0, 64);
+	memcpy(out, "2IMG", 4);
+	memcpy(out + 4, "MSTR", 4);                 // creator
+	wr_le16(out + 8, 64);                        // header length
+	wr_le16(out + 10, 1);                        // version
+	wr_le32(out + 12, format);                   // image format
+	wr_le32(out + 16, 0x00000100u);              // flags (volume-number-valid bit)
+	wr_le32(out + 20, payload_len / A2_BLOCK_SIZE);  // block count
+	wr_le32(out + 24, 64);                       // data offset
+	wr_le32(out + 28, payload_len);              // data length
+
+	memcpy(out + 64, payload, payload_len);
+	return total;
+}
+
+// ===========================================================================
+// DiskCopy 4.2
+// ===========================================================================
+uint32_t dc42_checksum(const uint8_t *data, size_t len)
+{
+	uint32_t chk = 0;
+	// Iterate big-endian 16-bit words: add, then rotate right by 1.
+	for (size_t i = 0; i + 1 < len; i += 2) {
+		uint16_t w = (uint16_t)((data[i] << 8) | data[i + 1]);
+		chk += w;
+		chk = (chk >> 1) | (chk << 31);
+	}
+	return chk;
+}
+
+int dc42_probe(const uint8_t *buf, size_t size)
+{
+	if (size < 84) return 0;
+	uint8_t  namelen  = buf[0];
+	uint32_t dataSize = rd_be32(buf + 0x40);
+	uint32_t tagSize  = rd_be32(buf + 0x44);
+	if (namelen > 63) return 0;
+	if (buf[0x52] != 0x01 || buf[0x53] != 0x00) return 0;   // magic 0x0100
+	if (dataSize == 0 || (dataSize & 511)) return 0;         // multiple of 512
+	if (tagSize % 12) return 0;                              // tags are 12 B/block
+	if ((uint64_t)84 + dataSize + tagSize != size) return 0; // exact size equation
+	return 1;
+}
+
+int dc42_parse(const uint8_t *buf, size_t size, DC42 *out)
+{
+	if (!dc42_probe(buf, size)) return 0;
+	if (out) {
+		out->data_size     = rd_be32(buf + 0x40);
+		out->tag_size      = rd_be32(buf + 0x44);
+		out->data_checksum = rd_be32(buf + 0x48);
+		out->tag_checksum  = rd_be32(buf + 0x4C);
+		out->disk_format   = buf[0x50];
+		out->format_byte   = buf[0x51];
+	}
+	return 1;
+}
+
+size_t dc42_build(uint8_t *out, size_t out_cap, const uint8_t *payload,
+                  uint32_t payload_len, uint8_t format_byte, const char *name)
+{
+	size_t total = 84 + (size_t)payload_len;
+	if (out_cap < total) return 0;
+
+	memset(out, 0, 84);
+	size_t nl = name ? strlen(name) : 0;
+	if (nl > 63) nl = 63;
+	out[0] = (uint8_t)nl;
+	if (nl) memcpy(out + 1, name, nl);
+
+	wr_be32(out + 0x40, payload_len);            // dataSize
+	wr_be32(out + 0x44, 0);                       // tagSize (no tags)
+	wr_be32(out + 0x48, dc42_checksum(payload, payload_len)); // dataChecksum
+	wr_be32(out + 0x4C, 0);                       // tagChecksum
+	out[0x50] = (payload_len == A2_35_IMAGE_SIZE) ? 1 : 0;   // diskFormat
+	out[0x51] = format_byte;                       // formatByte (0x24 = ProDOS)
+	out[0x52] = 0x01; out[0x53] = 0x00;            // magic
+
+	memcpy(out + 84, payload, payload_len);
+	return total;
+}
+
+// ===========================================================================
+// WOZ disk type
+// ===========================================================================
+int woz_disk_type(const uint8_t *buf, size_t size)
+{
+	if (size < 12) return -1;
+	if (memcmp(buf, "WOZ1", 4) != 0 && memcmp(buf, "WOZ2", 4) != 0) return -1;
+
+	// Walk chunks looking for INFO; disk type is INFO data byte +1.
+	size_t pos = 12;
+	while (pos + 8 <= size) {
+		uint32_t csize = rd_le32(buf + pos + 4);
+		if (memcmp(buf + pos, "INFO", 4) == 0) {
+			if (pos + 8 + 2 <= size) return buf[pos + 8 + 1];
+			return -1;
+		}
+		pos += 8 + csize;
+	}
+	return -1;
+}
+
+// ===========================================================================
+// 140K sector order (DOS 3.3 <-> ProDOS)
+// ===========================================================================
+// DOS logical sector -> ProDOS sector position within a track. Inverse pair.
+static const int DOS_TO_PRODOS[16] = { 0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15 };
+static const int PRODOS_TO_DOS[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+
+static void reorder_140k(uint8_t *dst, const uint8_t *src, const int map[16])
+{
+	for (int t = 0; t < A2_TRACKS_525; t++) {
+		const uint8_t *st = src + (size_t)t * A2_TRACK_SIZE;
+		uint8_t *dt = dst + (size_t)t * A2_TRACK_SIZE;
+		for (int s = 0; s < A2_SECTORS_PER_TRACK; s++)
+			memcpy(dt + map[s] * A2_SECTOR_SIZE, st + s * A2_SECTOR_SIZE, A2_SECTOR_SIZE);
+	}
+}
+
+void a2_dos_to_prodos(uint8_t *dst, const uint8_t *src) { reorder_140k(dst, src, DOS_TO_PRODOS); }
+void a2_prodos_to_dos(uint8_t *dst, const uint8_t *src) { reorder_140k(dst, src, PRODOS_TO_DOS); }
+
+// ===========================================================================
+// 5.25" 6-and-2 GCR (DSK <-> NIB), ported from dsk2nib_lib.cpp
+// ===========================================================================
+#define PRIMARY_BUF_LEN   256
+#define SECONDARY_BUF_LEN 86
+#define DATA_LEN          (PRIMARY_BUF_LEN + SECONDARY_BUF_LEN)
+#define GAP1_LEN          48
+#define GAP2_LEN          5
+#define BYTES_PER_NIB_SECTOR 416
+#define DEFAULT_VOLUME    254
+#define GAP_BYTE          0xff
+
+static const uint8_t addr_prolog[] = { 0xd5, 0xaa, 0x96 };
+static const uint8_t addr_epilog[] = { 0xde, 0xaa, 0xeb };
+static const uint8_t data_prolog[] = { 0xd5, 0xaa, 0xad };
+static const uint8_t data_epilog[] = { 0xde, 0xaa, 0xeb };
+
+static const int soft_interleave[16] =
+    { 0, 7, 0xE, 6, 0xD, 5, 0xC, 4, 0xB, 3, 0xA, 2, 9, 1, 8, 0xF };
+static const int phys_interleave[16] =
+    { 0, 0xD, 0xB, 9, 7, 5, 3, 1, 0xE, 0xC, 0xA, 8, 6, 4, 2, 0xF };
+
+static const uint8_t gcr6_table[0x40] = {
+	0x96, 0x97, 0x9a, 0x9b, 0x9d, 0x9e, 0x9f, 0xa6,
+	0xa7, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb2, 0xb3,
+	0xb4, 0xb5, 0xb6, 0xb7, 0xb9, 0xba, 0xbb, 0xbc,
+	0xbd, 0xbe, 0xbf, 0xcb, 0xcd, 0xce, 0xcf, 0xd3,
+	0xd6, 0xd7, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde,
+	0xdf, 0xe5, 0xe6, 0xe7, 0xe9, 0xea, 0xeb, 0xec,
+	0xed, 0xee, 0xef, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6,
+	0xf7, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
+};
+
+static inline uint8_t translate(uint8_t b) { return gcr6_table[b & 0x3f]; }
+
+static uint8_t untranslate(uint8_t x)
+{
+	const uint8_t *p = (const uint8_t *)memchr(gcr6_table, x, 0x40);
+	return p ? (uint8_t)(p - gcr6_table) : 0;
+}
+
+static void odd_even_encode(uint8_t a[2], int i)
+{
+	a[0] = ((i >> 1) & 0x55) | 0xaa;
+	a[1] = (i & 0x55) | 0xaa;
+}
+static uint8_t odd_even_decode(uint8_t b1, uint8_t b2)
+{
+	return (uint8_t)(((b1 << 1) & 0xaa) | (b2 & 0x55));
+}
+
+// Encode one 256-byte sector's data field (342 nibbles + checksum) at dest.
+static void nibbilize(const uint8_t *src, uint8_t *dest)
+{
+	uint8_t primary[PRIMARY_BUF_LEN];
+	uint8_t secondary[SECONDARY_BUF_LEN];
+	memset(secondary, 0, sizeof(secondary));
+
+	for (int i = 0; i < PRIMARY_BUF_LEN; i++) {
+		primary[i] = src[i] >> 2;
+		int index = i % SECONDARY_BUF_LEN;
+		int section = i / SECONDARY_BUF_LEN;
+		uint8_t pair = ((src[i] & 2) >> 1) | ((src[i] & 1) << 1);
+		secondary[index] |= pair << (section * 2);
+	}
+
+	int idx = 0;
+	dest[idx++] = translate(secondary[0]);
+	for (int i = 1; i < SECONDARY_BUF_LEN; i++)
+		dest[idx++] = translate(secondary[i] ^ secondary[i - 1]);
+	dest[idx++] = translate(primary[0] ^ secondary[SECONDARY_BUF_LEN - 1]);
+	for (int i = 1; i < PRIMARY_BUF_LEN; i++)
+		dest[idx++] = translate(primary[i] ^ primary[i - 1]);
+	dest[idx++] = translate(primary[PRIMARY_BUF_LEN - 1]);   // data checksum
+}
+
+// Build one full 6656-byte NIB track from a 4096-byte DOS-order track.
+static void nib_track_from_dsk(uint8_t *nibtrack, const uint8_t *dsktrack, int track)
+{
+	for (int phys = 0; phys < A2_SECTORS_PER_TRACK; phys++) {
+		// physical position -> logical sector
+		int logical = 0;
+		for (int i = 0; i < A2_SECTORS_PER_TRACK; i++)
+			if (phys_interleave[i] == phys) { logical = i; break; }
+
+		int soft = soft_interleave[logical];
+		const uint8_t *sec = dsktrack + soft * A2_SECTOR_SIZE;
+
+		uint8_t *o = nibtrack + phys * BYTES_PER_NIB_SECTOR;
+		memset(o, GAP_BYTE, GAP1_LEN);
+		o += GAP1_LEN;
+
+		// address field
+		memcpy(o, addr_prolog, 3); o += 3;
+		odd_even_encode(o, DEFAULT_VOLUME); o += 2;
+		odd_even_encode(o, track);          o += 2;
+		odd_even_encode(o, logical);        o += 2;
+		odd_even_encode(o, DEFAULT_VOLUME ^ track ^ logical); o += 2;
+		memcpy(o, addr_epilog, 3); o += 3;
+
+		memset(o, GAP_BYTE, GAP2_LEN); o += GAP2_LEN;
+
+		// data field
+		memcpy(o, data_prolog, 3); o += 3;
+		nibbilize(sec, o); o += DATA_LEN + 1;
+		memcpy(o, data_epilog, 3); o += 3;
+	}
+}
+
+void a2_dsk_to_nib(uint8_t *nib, const uint8_t *dsk)
+{
+	for (int t = 0; t < A2_TRACKS_525; t++)
+		nib_track_from_dsk(nib + (size_t)t * A2_NIB_TRACK_SIZE,
+		                   dsk + (size_t)t * A2_TRACK_SIZE, t);
+}
+
+// Parse one NIB sector out of a byte stream. Returns 1 and fills sector/track
+// on success. State machine ported from dsk2nib_lib.cpp parse_nib_sector.
+static int parse_nib_sector(const uint8_t *d, int len, uint8_t *out256, int *track, int *sector)
+{
+	int pos = 0, state = 0;
+	uint8_t primary[PRIMARY_BUF_LEN], secondary[SECONDARY_BUF_LEN], checksum;
+
+	while (pos < len) {
+		uint8_t b = d[pos++];
+		switch (state) {
+		case 0: if (b == 0xd5) state = 1; break;
+		case 1: state = (b == 0xaa) ? 2 : 0; break;
+		case 2: state = (b == 0x96) ? 3 : 0; break;
+		case 3: if (pos >= len) return 0; odd_even_decode(b, d[pos++]); state = 4; break; // volume
+		case 4: if (pos >= len) return 0; *track  = odd_even_decode(b, d[pos++]); state = 5; break;
+		case 5: if (pos >= len) return 0; *sector = odd_even_decode(b, d[pos++]); state = 6; break;
+		case 6: if (pos >= len) return 0; pos++;  state = 7; break;  // checksum (ignored)
+		case 7: if (b == 0xde) state = 8; break;
+		case 8: state = (b == 0xaa) ? 9 : 7; break;
+		case 9: if (b == 0xd5) state = 10; break;
+		case 10: state = (b == 0xaa) ? 11 : 9; break;
+		case 11: state = (b == 0xad) ? 12 : 9; break;
+		case 12: {
+			checksum = untranslate(b);
+			secondary[0] = checksum;
+			for (int i = 1; i < SECONDARY_BUF_LEN; i++) {
+				if (pos >= len) return 0;
+				checksum ^= untranslate(d[pos++]);
+				secondary[i] = checksum;
+			}
+			for (int i = 0; i < PRIMARY_BUF_LEN; i++) {
+				if (pos >= len) return 0;
+				checksum ^= untranslate(d[pos++]);
+				primary[i] = checksum;
+			}
+			if (pos >= len) return 0;
+			checksum ^= untranslate(d[pos++]);   // data checksum (ignored)
+
+			for (int i = 0; i < PRIMARY_BUF_LEN; i++) {
+				int index = i % SECONDARY_BUF_LEN;
+				uint8_t bit0, bit1;
+				switch (i / SECONDARY_BUF_LEN) {
+				case 0: bit0 = (secondary[index] & 2) > 0; bit1 = (secondary[index] & 1) > 0; break;
+				case 1: bit0 = (secondary[index] & 8) > 0; bit1 = (secondary[index] & 4) > 0; break;
+				default: bit0 = (secondary[index] & 0x20) > 0; bit1 = (secondary[index] & 0x10) > 0; break;
+				}
+				out256[i] = (primary[i] << 2) | (bit1 << 1) | bit0;
+			}
+			return 1;
+		}
+		default: state = 0; break;
+		}
+	}
+	return 0;
+}
+
+// Parse one 6656-byte NIB track into a 4096-byte DOS-order track. Returns the
+// number of sectors recovered.
+static int nib_track_to_dsk_track(const uint8_t *nt, uint8_t *dt)
+{
+	int got = 0, pos = 0;
+	while (pos < A2_NIB_TRACK_SIZE - 400) {
+		uint8_t sec[A2_SECTOR_SIZE];
+		int tr, s;
+		if (parse_nib_sector(nt + pos, A2_NIB_TRACK_SIZE - pos, sec, &tr, &s)) {
+			if (s >= 0 && s < A2_SECTORS_PER_TRACK) {
+				memcpy(dt + soft_interleave[s] * A2_SECTOR_SIZE, sec, A2_SECTOR_SIZE);
+				got++;
+			}
+			pos += BYTES_PER_NIB_SECTOR;
+		} else {
+			pos++;
+		}
+	}
+	return got;
+}
+
+int a2_nib_to_dsk(uint8_t *dsk, const uint8_t *nib)
+{
+	int ok = 1;
+	for (int t = 0; t < A2_TRACKS_525; t++) {
+		int got = nib_track_to_dsk_track(nib + (size_t)t * A2_NIB_TRACK_SIZE,
+		                                 dsk + (size_t)t * A2_TRACK_SIZE);
+		if (got < A2_SECTORS_PER_TRACK) ok = 0;
+	}
+	return ok;
+}
+
+// ===========================================================================
+// 5.25" "easy WOZ" (DOS-order DSK <-> WOZ2)
+// ===========================================================================
+// Layout (matches make_blank_woz.py): header(12) + INFO chunk(8+60) +
+// TMAP chunk(8+160) + TRKS chunk(8 + 1280 dir + BITS). First BITS block = 3.
+#define WOZ_INFO_LEN   60
+#define WOZ_TMAP_LEN   160
+#define WOZ_TRK_DIR    (160 * 8)         // 1280
+#define WOZ525_BLOCKS_PER_TRACK 13
+#define WOZ525_FIRST_BLOCK 3
+#define WOZ525_BITS    (WOZ525_BLOCKS_PER_TRACK * A2_BLOCK_SIZE * 8)  // 53248
+
+#define WOZ525_SIZE    (1536 + A2_TRACKS_525 * WOZ525_BLOCKS_PER_TRACK * A2_BLOCK_SIZE)
+
+static void woz_put_chunk_hdr(uint8_t *p, const char *id, uint32_t size)
+{
+	memcpy(p, id, 4);
+	wr_le32(p + 4, size);
+}
+
+size_t a2_dsk_to_woz525(uint8_t *woz, size_t woz_cap, const uint8_t *dsk)
+{
+	if (woz_cap < WOZ525_SIZE) return 0;
+	memset(woz, 0, WOZ525_SIZE);
+
+	// nibblize all tracks first
+	static uint8_t nib[A2_NIB_IMAGE_SIZE];
+	a2_dsk_to_nib(nib, dsk);
+
+	uint8_t *p = woz;
+	// File header (CRC filled in at the end)
+	memcpy(p, "WOZ2", 4);
+	p[4] = 0xFF; p[5] = 0x0A; p[6] = 0x0D; p[7] = 0x0A;
+	// p[8..11] CRC later
+	p += 12;
+
+	// INFO chunk
+	woz_put_chunk_hdr(p, "INFO", WOZ_INFO_LEN); p += 8;
+	uint8_t *info = p;
+	info[0] = 2;     // version
+	info[1] = 1;     // disk type 5.25"
+	info[2] = 0;     // write protected
+	info[3] = 0;     // synchronized
+	info[4] = 0;     // cleaned
+	memset(info + 5, ' ', 32);
+	memcpy(info + 5, "MiSTer IIgs easy-WOZ 5.25", 25);
+	info[37] = 1;    // sides
+	info[38] = 0;    // boot sector format
+	info[39] = 32;   // optimal bit timing (4us)
+	wr_le16(info + 44, WOZ525_BLOCKS_PER_TRACK);   // largest track
+	p += WOZ_INFO_LEN;
+
+	// TMAP chunk (quarter-track map; whole tracks at t*4 +/- 1)
+	woz_put_chunk_hdr(p, "TMAP", WOZ_TMAP_LEN); p += 8;
+	uint8_t *tmap = p;
+	memset(tmap, 0xFF, WOZ_TMAP_LEN);
+	for (int t = 0; t < A2_TRACKS_525; t++) {
+		int center = t * 4;
+		for (int off = -1; off <= 1; off++) {
+			int idx = center + off;
+			if (idx >= 0 && idx < WOZ_TMAP_LEN) tmap[idx] = (uint8_t)t;
+		}
+	}
+	p += WOZ_TMAP_LEN;
+
+	// TRKS chunk: 1280-byte dir + BITS data
+	uint32_t trks_data_len = WOZ_TRK_DIR + A2_TRACKS_525 * WOZ525_BLOCKS_PER_TRACK * A2_BLOCK_SIZE;
+	woz_put_chunk_hdr(p, "TRKS", trks_data_len); p += 8;
+	uint8_t *trk_dir = p;                    // 160 * 8
+	uint8_t *bits = p + WOZ_TRK_DIR;
+	int block = WOZ525_FIRST_BLOCK;
+	for (int t = 0; t < A2_TRACKS_525; t++) {
+		uint8_t *e = trk_dir + t * 8;
+		wr_le16(e + 0, (uint16_t)block);                 // starting block
+		wr_le16(e + 2, WOZ525_BLOCKS_PER_TRACK);          // block count
+		wr_le32(e + 4, WOZ525_BITS);                      // bit count
+		// BITS = the 6656-byte NIB track, byte-aligned (each nibble byte = 8 bits)
+		memcpy(bits + (size_t)t * WOZ525_BLOCKS_PER_TRACK * A2_BLOCK_SIZE,
+		       nib + (size_t)t * A2_NIB_TRACK_SIZE, A2_NIB_TRACK_SIZE);
+		block += WOZ525_BLOCKS_PER_TRACK;
+	}
+
+	// CRC32 over everything after byte 12
+	uint32_t crc = woz_crc32(woz + 12, WOZ525_SIZE - 12);
+	wr_le32(woz + 8, crc);
+	return WOZ525_SIZE;
+}
+
+// Locate a chunk by id; returns pointer to its data and fills *out_size, or NULL.
+static const uint8_t *woz_find_chunk(const uint8_t *woz, size_t size,
+                                     const char *id, uint32_t *out_size)
+{
+	size_t pos = 12;
+	while (pos + 8 <= size) {
+		uint32_t csize = rd_le32(woz + pos + 4);
+		if (memcmp(woz + pos, id, 4) == 0) {
+			if (out_size) *out_size = csize;
+			return woz + pos + 8;
+		}
+		pos += 8 + csize;
+	}
+	return NULL;
+}
+
+int a2_woz525_to_dsk(uint8_t *dsk, const uint8_t *woz, size_t woz_size)
+{
+	if (woz_disk_type(woz, woz_size) != 1) return 0;
+	const uint8_t *trks = woz_find_chunk(woz, woz_size, "TRKS", NULL);
+	if (!trks) return 0;
+
+	static uint8_t nib[A2_NIB_IMAGE_SIZE];
+	memset(nib, 0, sizeof(nib));
+
+	for (int t = 0; t < A2_TRACKS_525; t++) {
+		const uint8_t *e = trks + t * 8;
+		uint16_t start_block = rd_le16(e + 0);
+		uint16_t block_cnt   = rd_le16(e + 2);
+		if (block_cnt == 0) continue;
+		size_t off = (size_t)start_block * A2_BLOCK_SIZE;
+		if (off + A2_NIB_TRACK_SIZE > woz_size) return 0;
+		memcpy(nib + (size_t)t * A2_NIB_TRACK_SIZE, woz + off, A2_NIB_TRACK_SIZE);
+	}
+	return a2_nib_to_dsk(dsk, nib);
+}
+
+// Decode a single 5.25" track from a WOZ into dsk (143360) at track*4096.
+int a2_woz525_decode_track(const uint8_t *woz, size_t woz_size, int track, uint8_t *dsk)
+{
+	if (woz_disk_type(woz, woz_size) != 1) return 0;
+	const uint8_t *trks = woz_find_chunk(woz, woz_size, "TRKS", NULL);
+	if (!trks || track < 0 || track >= A2_TRACKS_525) return 0;
+	const uint8_t *e = trks + track * 8;
+	uint16_t start_block = rd_le16(e + 0);
+	uint16_t block_cnt   = rd_le16(e + 2);
+	if (block_cnt == 0) return 0;
+	size_t off = (size_t)start_block * A2_BLOCK_SIZE;
+	if (off + A2_NIB_TRACK_SIZE > woz_size) return 0;
+	return nib_track_to_dsk_track(woz + off, dsk + (size_t)track * A2_TRACK_SIZE);
+}
+
+// Map a WOZ file LBA (512-block index) to its track index, or -1 (header/unmapped).
+int a2_woz_track_for_lba(const uint8_t *woz, size_t woz_size, uint32_t lba)
+{
+	const uint8_t *trks = woz_find_chunk(woz, woz_size, "TRKS", NULL);
+	if (!trks) return -1;
+	for (int t = 0; t < 160; t++) {
+		const uint8_t *e = trks + t * 8;
+		uint16_t sb = rd_le16(e + 0);
+		uint16_t bc = rd_le16(e + 2);
+		if (bc == 0) continue;
+		if (lba >= sb && lba < (uint32_t)sb + bc) return t;
+	}
+	return -1;
+}
+
+// ===========================================================================
+// 3.5" 800K Apple zoned GCR (PO <-> WOZ2)
+// Algorithm ported from Clemens (clem_disk.c), itself from CiderPress Nibble35.
+// ===========================================================================
+#define NT35            160              // nib tracks (80 cyl x 2 sides)
+#define TAG35           12               // tag bytes prepended to each sector
+
+// physical sector position -> logical (ProDOS) sector, per speed region (2:1)
+static const int phys_to_logical_35[5][16] = {
+	{ 0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11, -1, -1, -1, -1 },
+	{ 0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, -1, -1, -1, -1, -1 },
+	{ 0, 5, 1, 6, 2, 7, 3, 8, 4,  9, -1, -1, -1, -1, -1, -1 },
+	{ 0, 5, 1, 6, 2, 7, 3, 8, 4, -1, -1, -1, -1, -1, -1, -1 },
+	{ 0, 4, 1, 5, 2, 6, 3, 7, -1, -1, -1, -1, -1, -1, -1, -1 },
+};
+static const int sectors_per_region_35[5] = { 12, 11, 10, 9, 8 };
+static const int region_track_start_35[6] = { 0, 32, 64, 96, 128, 160 };
+
+static int region_of_track(int nt)
+{
+	for (int r = 0; r < 5; r++)
+		if (nt < region_track_start_35[r + 1]) return r;
+	return 4;
+}
+// base ProDOS block index for nib track nt (cumulative sectors before it)
+static int base_block_of_track(int nt)
+{
+	int base = 0;
+	for (int k = 0; k < nt; k++) base += sectors_per_region_35[region_of_track(k)];
+	return base;
+}
+
+// reverse 6-and-2 table (disk byte 0x80..0xFF -> 6-bit value; 0x80 = invalid)
+static uint8_t from_gcr6[128];
+static void init_from_gcr6(void)
+{
+	static int done = 0;
+	if (done) return;
+	memset(from_gcr6, 0x80, sizeof(from_gcr6));
+	for (int i = 0; i < 0x40; i++) from_gcr6[gcr6_table[i] - 0x80] = (uint8_t)i;
+	done = 1;
+}
+static inline uint8_t un62(uint8_t disk) { return (disk & 0x80) ? from_gcr6[disk - 0x80] : 0x80; }
+
+// ---- bit writer (MSB-first), matching Clemens' bit ordering ----
+typedef struct { uint8_t *buf; size_t cap; uint32_t bit; } BitW;
+static void bw_bits(BitW *w, uint32_t val, int nbits)
+{
+	for (int i = nbits - 1; i >= 0; i--) {
+		size_t byte = w->bit >> 3;
+		int off = 7 - (int)(w->bit & 7);
+		if (byte < w->cap) {
+			if (val & (1u << i)) w->buf[byte] |= (1 << off);
+			else                 w->buf[byte] &= ~(1 << off);
+		}
+		w->bit++;
+	}
+}
+static inline void bw_byte(BitW *w, uint8_t v)   { bw_bits(w, v, 8); }
+static inline void bw_sync(BitW *w, int cnt)     { for (int i = 0; i < cnt; i++) bw_bits(w, 0xFF, 10); }
+static inline void bw_62(BitW *w, uint8_t v)     { bw_byte(w, gcr6_table[v & 0x3f]); }
+
+// Encode one 512-byte sector's data field (12 tag + 512 data -> GCR + checksum).
+static void encode_data_35(BitW *w, const uint8_t *buf)
+{
+	uint8_t s0[175], s1[175], s2[175];
+	uint8_t data[524];
+	unsigned chk[3] = { 0, 0, 0 };
+	unsigned di = 0, si = 0;
+	uint8_t v;
+
+	memset(data, 0, TAG35);
+	memcpy(data + TAG35, buf, 512);
+
+	while (di < 524) {
+		chk[0] = (chk[0] & 0xff) << 1;
+		if (chk[0] & 0x100) chk[0]++;
+		v = data[di++];
+		chk[2] += v;
+		if (chk[0] & 0x100) { chk[2]++; chk[0] &= 0xff; }
+		s0[si] = (v ^ chk[0]) & 0xff;
+
+		v = data[di++];
+		chk[1] += v;
+		if (chk[2] > 0xff) { chk[1]++; chk[2] &= 0xff; }
+		s1[si] = (v ^ chk[2]) & 0xff;
+
+		if (di < 524) {
+			v = data[di++];
+			chk[0] += v;
+			if (chk[1] > 0xff) { chk[0]++; chk[1] &= 0xff; }
+			s2[si] = (v ^ chk[1]) & 0xff;
+			si++;
+		}
+	}
+	s2[si++] = 0;
+
+	for (unsigned i = 0; i < si; i++) {
+		uint8_t top = ((s0[i] & 0xc0) >> 2) | ((s1[i] & 0xc0) >> 4) | ((s2[i] & 0xc0) >> 6);
+		bw_62(w, top);
+		bw_62(w, s0[i]);
+		bw_62(w, s1[i]);
+		if (i < si - 1) bw_62(w, s2[i]);
+	}
+	uint8_t top = ((chk[0] & 0xc0) >> 6) | ((chk[1] & 0xc0) >> 4) | ((chk[2] & 0xc0) >> 2);
+	bw_62(w, top);
+	bw_62(w, chk[2]);
+	bw_62(w, chk[1]);
+	bw_62(w, chk[0]);
+}
+
+// Decode one sector's 699-byte GCR data field back to 512 bytes. 1 ok.
+static int decode_data_35(const uint8_t *gcr, uint8_t *out512)
+{
+	uint8_t s0[175], s1[175], s2[175];
+	const uint8_t *p = gcr;
+	for (int i = 0; i < 175; i++) {
+		uint8_t b = un62(*p++); if (b == 0x80) return 0;
+		uint8_t r0 = un62(*p++); if (r0 == 0x80) return 0;
+		uint8_t r1 = un62(*p++); if (r1 == 0x80) return 0;
+		uint8_t r2 = 0;
+		if (i < 174) { r2 = un62(*p++); if (r2 == 0x80) return 0; }
+		s0[i] = (uint8_t)(((b << 2) & 0xc0) | r0);
+		s1[i] = (uint8_t)(((b << 4) & 0xc0) | r1);
+		s2[i] = (uint8_t)(((b << 6) & 0xc0) | r2);
+	}
+	unsigned chk[3] = { 0, 0, 0 };
+	uint8_t data[524];
+	int di = 0;
+	for (int i = 0; i < 175; i++) {
+		chk[0] = (chk[0] & 0xff) << 1;
+		if (chk[0] & 0x100) chk[0]++;
+		uint8_t v0 = s0[i] ^ chk[0];
+		chk[2] += v0;
+		if (chk[0] & 0x100) { chk[2]++; chk[0] &= 0xff; }
+		data[di++] = v0;
+
+		uint8_t v1 = s1[i] ^ chk[2];
+		chk[1] += v1;
+		if (chk[2] >= 0x100) { chk[1]++; chk[2] &= 0xff; }
+		data[di++] = v1;
+		if (di == 524) break;
+
+		uint8_t v2 = s2[i] ^ chk[1];
+		chk[0] += v2;
+		if (chk[1] >= 0x100) { chk[0]++; chk[1] &= 0xff; }
+		data[di++] = v2;
+	}
+	memcpy(out512, data + TAG35, 512);
+	return 1;
+}
+
+// Self-sync gap sizes (sync byte counts), derived from Clemens GAP1=500,GAP3=53.
+#define GAP1_SYNC_35 ((500 * 8) / 10)
+#define GAP3_SYNC_35 ((53  * 8) / 10)
+
+static void encode_track_35(BitW *w, int nt, const uint8_t *po)
+{
+	int region = region_of_track(nt);
+	int count = sectors_per_region_35[region];
+	int ltrack = nt / 2;
+	int side = nt % 2;
+	int base = base_block_of_track(nt);
+	uint8_t side_track64 = (uint8_t)((side << 5) | (ltrack >> 6));
+	uint8_t fmt = (uint8_t)(0x20 | 0x2);   // double-sided, interleave 2
+
+	bw_byte(w, 0xff);
+	bw_sync(w, GAP1_SYNC_35);
+
+	for (int phys = 0; phys < count; phys++) {
+		int lsec = phys_to_logical_35[region][phys];
+		const uint8_t *src = po + (size_t)(base + lsec) * 512;
+
+		bw_byte(w, 0xff);
+		// address field
+		bw_byte(w, 0xd5); bw_byte(w, 0xaa); bw_byte(w, 0x96);
+		bw_62(w, (uint8_t)ltrack);
+		bw_62(w, (uint8_t)lsec);
+		bw_62(w, side_track64);
+		bw_62(w, fmt);
+		bw_62(w, (uint8_t)(ltrack ^ lsec ^ side_track64 ^ fmt));
+		bw_byte(w, 0xde); bw_byte(w, 0xaa); bw_byte(w, 0xff);
+		bw_sync(w, 4);
+		bw_byte(w, 0xff);
+		// data field
+		bw_byte(w, 0xd5); bw_byte(w, 0xaa); bw_byte(w, 0xad);
+		bw_62(w, (uint8_t)lsec);            // spare byte
+		encode_data_35(w, src);
+		bw_byte(w, 0xde); bw_byte(w, 0xaa);
+		if (phys + 1 < count) {
+			bw_byte(w, 0xff); bw_byte(w, 0xff); bw_byte(w, 0xff);
+			bw_sync(w, GAP3_SYNC_35);
+		}
+	}
+}
+
+size_t a2_po_to_woz35(uint8_t *woz, size_t woz_cap, const uint8_t *po)
+{
+	const size_t bits_start = 1536;          // block 3
+	if (woz_cap < bits_start) return 0;
+	memset(woz, 0, bits_start);
+
+	// header
+	memcpy(woz, "WOZ2", 4);
+	woz[4] = 0xFF; woz[5] = 0x0A; woz[6] = 0x0D; woz[7] = 0x0A;
+
+	// INFO chunk
+	uint8_t *p = woz + 12;
+	woz_put_chunk_hdr(p, "INFO", WOZ_INFO_LEN); p += 8;
+	uint8_t *info = p;
+	info[0] = 2; info[1] = 2;               // version, disk type 3.5"
+	memset(info + 5, ' ', 32);
+	memcpy(info + 5, "MiSTer IIgs easy-WOZ 3.5", 24);
+	info[37] = 2;                            // sides
+	info[38] = 0;
+	info[39] = 16;                           // bit timing (2us)
+	p += WOZ_INFO_LEN;
+
+	// TMAP chunk (1:1 for 160 tracks)
+	woz_put_chunk_hdr(p, "TMAP", WOZ_TMAP_LEN); p += 8;
+	for (int i = 0; i < WOZ_TMAP_LEN; i++) p[i] = (uint8_t)i;
+	p += WOZ_TMAP_LEN;
+
+	// TRKS chunk header (size filled after we know total BITS)
+	uint8_t *trks_hdr = p;
+	uint8_t *trk_dir = p + 8;
+	memset(trk_dir, 0, WOZ_TRK_DIR);
+
+	static uint8_t tmp[16 * 1024];
+	int block = WOZ525_FIRST_BLOCK;
+	int largest = 0;
+	for (int nt = 0; nt < NT35; nt++) {
+		memset(tmp, 0, sizeof(tmp));
+		BitW w = { tmp, sizeof(tmp), 0 };
+		encode_track_35(&w, nt, po);
+		uint32_t bits = w.bit;
+		uint32_t bytes = (bits + 7) / 8;
+		uint16_t blocks = (uint16_t)((bytes + A2_BLOCK_SIZE - 1) / A2_BLOCK_SIZE);
+		size_t off = (size_t)block * A2_BLOCK_SIZE;
+		if (off + (size_t)blocks * A2_BLOCK_SIZE > woz_cap) return 0;
+		memset(woz + off, 0, (size_t)blocks * A2_BLOCK_SIZE);
+		memcpy(woz + off, tmp, bytes);
+
+		uint8_t *e = trk_dir + nt * 8;
+		wr_le16(e + 0, (uint16_t)block);
+		wr_le16(e + 2, blocks);
+		wr_le32(e + 4, bits);
+		block += blocks;
+		if (blocks > largest) largest = blocks;
+	}
+	wr_le16(info + 44, (uint16_t)largest);    // largest track (now known)
+
+	uint32_t trks_data_len = WOZ_TRK_DIR + (uint32_t)(block - WOZ525_FIRST_BLOCK) * A2_BLOCK_SIZE;
+	woz_put_chunk_hdr(trks_hdr, "TRKS", trks_data_len);
+
+	size_t total = (size_t)block * A2_BLOCK_SIZE;
+	uint32_t crc = woz_crc32(woz + 12, total - 12);
+	wr_le32(woz + 8, crc);
+	return total;
+}
+
+// Frame a track's WOZ BITS into disk bytes (simple self-sync framer).
+static int frame_track(const uint8_t *bits, uint32_t bit_count, uint8_t *out, int out_cap)
+{
+	int n = 0;
+	uint8_t reg = 0;
+	for (uint32_t i = 0; i < bit_count; i++) {
+		int bit = (bits[i >> 3] >> (7 - (i & 7))) & 1;
+		reg = (uint8_t)((reg << 1) | bit);
+		if (reg & 0x80) {
+			if (n < out_cap) out[n++] = reg;
+			reg = 0;
+		}
+	}
+	return n;
+}
+
+// Decode a single 3.5" track nt into po (819200). Reports the ProDOS block range
+// written via *base_block / *block_count. Returns the number of sectors decoded.
+int a2_woz35_decode_track(const uint8_t *woz, size_t woz_size, int nt, uint8_t *po,
+                          int *base_block, int *block_count)
+{
+	init_from_gcr6();
+	if (nt < 0 || nt >= NT35) return 0;
+	const uint8_t *trks = woz_find_chunk(woz, woz_size, "TRKS", NULL);
+	if (!trks) return 0;
+
+	const uint8_t *e = trks + nt * 8;
+	uint16_t start_block = rd_le16(e + 0);
+	uint16_t blk_cnt     = rd_le16(e + 2);
+	uint32_t bit_count   = rd_le32(e + 4);
+	if (blk_cnt == 0 || bit_count == 0) return 0;
+	size_t off = (size_t)start_block * A2_BLOCK_SIZE;
+	if (off + (size_t)blk_cnt * A2_BLOCK_SIZE > woz_size) return 0;
+
+	static uint8_t bytes[20 * 1024];
+	int n = frame_track(woz + off, bit_count, bytes, sizeof(bytes));
+	int base = base_block_of_track(nt);
+	int want = sectors_per_region_35[region_of_track(nt)];
+	int got = 0;
+
+	int i = 0;
+	while (i + 3 < n && got < want) {
+		if (bytes[i] == 0xd5 && bytes[i + 1] == 0xaa && bytes[i + 2] == 0xad) {
+			int dpos = i + 4;                        // skip mark(3) + spare(1)
+			if (dpos + 699 > n) break;
+			uint8_t lsec = un62(bytes[i + 3]);        // logical sector from spare byte
+			if (lsec < (uint8_t)want) {
+				uint8_t sec[512];
+				if (decode_data_35(bytes + dpos, sec)) {
+					memcpy(po + (size_t)(base + lsec) * 512, sec, 512);
+					got++;
+				}
+			}
+			i = dpos + 699;
+		} else {
+			i++;
+		}
+	}
+	if (base_block)  *base_block = base;
+	if (block_count) *block_count = want;
+	return got;
+}
+
+int a2_woz35_to_po(uint8_t *po, const uint8_t *woz, size_t woz_size)
+{
+	if (woz_disk_type(woz, woz_size) != 2) return 0;
+	int placed = 0;
+	for (int nt = 0; nt < NT35; nt++)
+		placed += a2_woz35_decode_track(woz, woz_size, nt, po, NULL, NULL);
+	return placed == (A2_35_IMAGE_SIZE / 512) ? 1 : 0;
+}
+
+// ===========================================================================
+// classification
+// ===========================================================================
+static int ext_is(const char *ext, const char *want)
+{
+	return ext && strcmp(ext, want) == 0;
+}
+
+DiskClass iigs_classify(const uint8_t *buf, size_t size, const char *ext)
+{
+	// content probes first
+	int wt = woz_disk_type(buf, size);
+	if (wt == 1) return DC_FLOPPY_525;
+	if (wt == 2) return DC_FLOPPY_35;
+
+	TwoMG m;
+	if (twomg_parse(buf, size, &m)) {
+		if (m.format == 2) return DC_FLOPPY_525;          // NIB payload
+		if (m.data_len == A2_525_IMAGE_SIZE) return DC_FLOPPY_525;
+		if (m.data_len == A2_35_IMAGE_SIZE)  return DC_FLOPPY_35;
+		return DC_HDD;
+	}
+
+	if (dc42_probe(buf, size)) {
+		uint32_t ds = rd_be32(buf + 0x40);
+		if (ds == A2_35_IMAGE_SIZE || ds == 409600) return DC_FLOPPY_35;
+		return DC_HDD;
+	}
+
+	// bare images by size/extension
+	if (ext_is(ext, "nib") || size == A2_NIB_IMAGE_SIZE) return DC_FLOPPY_525;
+	if (size == A2_525_IMAGE_SIZE) return DC_FLOPPY_525;
+	if (size == A2_35_IMAGE_SIZE)  return DC_FLOPPY_35;   // §4 edge: 800K assumed floppy
+	if (ext_is(ext, "hdv") || ext_is(ext, "po")) return DC_HDD;
+	if (size > 0 && (size % A2_BLOCK_SIZE) == 0) return DC_HDD;
+	return DC_UNKNOWN;
+}

--- a/support/a2/iigs_fmt.h
+++ b/support/a2/iigs_fmt.h
@@ -1,0 +1,129 @@
+// Apple IIgs disk-format conversions (pure, dependency-free codec).
+//
+// These functions translate between the disk-image formats users have on disk
+// and the two formats the IIgs core consumes on the wire: raw ProDOS blocks
+// (hard disks) and WOZ (floppies). See IIGS_DISK_SUPPORT.md for the design.
+//
+// This header intentionally depends on nothing from MiSTer (no fileTYPE, no
+// SPI) so the codec can be unit-tested natively on a dev machine. The MiSTer
+// integration layer (the a2_read*/a2_write* glue, like dsk2nib_lib.cpp) wraps
+// these buffer-in/buffer-out functions.
+
+#ifndef IIGS_FMT_H
+#define IIGS_FMT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---- canonical geometry ----
+#define A2_SECTOR_SIZE        256
+#define A2_SECTORS_PER_TRACK  16
+#define A2_TRACKS_525         35
+#define A2_TRACK_SIZE         (A2_SECTORS_PER_TRACK * A2_SECTOR_SIZE)   // 4096
+#define A2_525_IMAGE_SIZE     (A2_TRACKS_525 * A2_TRACK_SIZE)           // 143360
+#define A2_NIB_TRACK_SIZE     6656
+#define A2_NIB_IMAGE_SIZE     (A2_TRACKS_525 * A2_NIB_TRACK_SIZE)       // 232960
+#define A2_BLOCK_SIZE         512
+#define A2_35_IMAGE_SIZE      819200                                    // 1600 * 512
+
+// ---- device classification ----
+typedef enum {
+	DC_UNKNOWN = 0,
+	DC_HDD,          // raw ProDOS blocks, any size
+	DC_FLOPPY_525,   // 140K logical / NIB / 5.25" WOZ
+	DC_FLOPPY_35,    // 800K logical / 3.5" WOZ
+} DiskClass;
+
+// Classify a disk image from its leading bytes + size (+ optional extension,
+// lowercase, no dot, may be NULL). Probes content first (WOZ/2MG/DC42 magic),
+// falls back to size/extension for bare images. See IIGS_DISK_SUPPORT.md §4.
+DiskClass iigs_classify(const uint8_t *buf, size_t size, const char *ext);
+
+// ---- 2MG / 2IMG ----
+typedef struct {
+	uint32_t format;          // 0=DOS,1=ProDOS,2=NIB,3=CP/M
+	uint32_t flags;           // bit31 = write-protected
+	uint32_t blocks;
+	uint32_t data_offset;     // header_offset to strip
+	uint32_t data_len;        // payload size (excludes trailing chunks)
+	int      write_protected;
+} TwoMG;
+
+// Parse + validate a 2MG header. Returns 1 on success (out filled), 0 if not a
+// valid 2MG. Mirrors the validation in sim_blkdevice.cpp.
+int twomg_parse(const uint8_t *buf, size_t size, TwoMG *out);
+
+// Build a minimal 2MG wrapping payload. Writes 64-byte header + payload into
+// out (must hold 64 + payload_len). Returns total bytes written, or 0 on error.
+size_t twomg_build(uint8_t *out, size_t out_cap,
+                   const uint8_t *payload, uint32_t payload_len, uint32_t format);
+
+// ---- DiskCopy 4.2 (big-endian header). Detected by content, never extension. ----
+typedef struct {
+	uint32_t data_size;
+	uint32_t tag_size;
+	uint32_t data_checksum;
+	uint32_t tag_checksum;
+	uint8_t  disk_format;
+	uint8_t  format_byte;
+} DC42;
+
+// Returns 1 if buf is a structurally valid DC42 (magic + size equation +
+// modulo/range invariants), else 0. Safe against raw Apple II images.
+int dc42_probe(const uint8_t *buf, size_t size);
+int dc42_parse(const uint8_t *buf, size_t size, DC42 *out);   // 1 ok
+// DiskCopy data/tag checksum: rotate-right-add over big-endian 16-bit words.
+uint32_t dc42_checksum(const uint8_t *data, size_t len);
+// Build a DC42 (no tags) wrapping payload. name may be NULL.
+size_t dc42_build(uint8_t *out, size_t out_cap, const uint8_t *payload,
+                  uint32_t payload_len, uint8_t format_byte, const char *name);
+
+// ---- WOZ ----
+// Returns INFO disk type: 1 = 5.25", 2 = 3.5", or -1 if not a WOZ file.
+int woz_disk_type(const uint8_t *buf, size_t size);
+// zlib-compatible CRC32 (poly 0xEDB88320), init 0.
+uint32_t woz_crc32(const uint8_t *data, size_t len);
+
+// ---- 140K sector order (DOS 3.3 <-> ProDOS) ----
+// dst and src are 143360-byte 5.25" images; in-place safe only if dst!=src.
+void a2_dos_to_prodos(uint8_t *dst, const uint8_t *src);
+void a2_prodos_to_dos(uint8_t *dst, const uint8_t *src);
+
+// ---- 5.25" 6-and-2 GCR (DSK <-> NIB) ----
+// dsk is 143360 bytes in DOS order; nib is 232960 bytes. Ported from the live
+// dsk2nib_lib.cpp path so encode/decode are exact inverses.
+void a2_dsk_to_nib(uint8_t *nib, const uint8_t *dsk);
+int  a2_nib_to_dsk(uint8_t *dsk, const uint8_t *nib);   // 1 if all tracks parsed
+
+// ---- 5.25" "easy WOZ" (DOS-order DSK <-> WOZ2) ----
+// Builds a fully-allocated standard-layout WOZ2 (all 35 tracks present) so the
+// core can read and write it; trivially reversible. Returns bytes written / 0.
+size_t a2_dsk_to_woz525(uint8_t *woz, size_t woz_cap, const uint8_t *dsk);
+int    a2_woz525_to_dsk(uint8_t *dsk, const uint8_t *woz, size_t woz_size);
+
+// ---- 3.5" 800K (ProDOS-order PO <-> WOZ2), Apple zoned GCR ----
+// po is an 819200-byte ProDOS-order image (double-sided, 1600 blocks). The WOZ
+// is a standard 160-track WOZ2; encode/decode are exact inverses. Apple 3.5"
+// GCR (6-and-2 + 3-register scrambling checksum) ported from Clemens/CiderPress.
+// Buffer the WOZ at >= 1.4MB. Returns bytes written / 0.
+size_t a2_po_to_woz35(uint8_t *woz, size_t woz_cap, const uint8_t *po);
+int    a2_woz35_to_po(uint8_t *po, const uint8_t *woz, size_t woz_size);
+
+// ---- per-track decode + LBA mapping (for floppy write-back) ----
+// Map a WOZ file LBA (512-block index) to its track index, or -1 (header/unmapped).
+int a2_woz_track_for_lba(const uint8_t *woz, size_t woz_size, uint32_t lba);
+// 3.5": decode one track into po (819200); reports the ProDOS block range written.
+int a2_woz35_decode_track(const uint8_t *woz, size_t woz_size, int track, uint8_t *po,
+                          int *base_block, int *block_count);
+// 5.25": decode one track into dsk (143360) at track*4096 (16 sectors, DOS order).
+int a2_woz525_decode_track(const uint8_t *woz, size_t woz_size, int track, uint8_t *dsk);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IIGS_FMT_H

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2154,6 +2154,23 @@ int user_io_file_mount(const char *name, unsigned char index, char pre, int pre_
 					}
 				}
 
+				// Apple IIgs: classify/validate/convert the image for its slot.
+				if (ret && iigs_is_core())
+				{
+					int iigs_w = writable;
+					int r = iigs_mount(index, name, &sd_image[index], &iigs_w);
+					if (r == IIGS_REJECT)
+					{
+						FileClose(&sd_image[index]);
+						ret = 0;
+					}
+					else if (r == IIGS_HANDLED)
+					{
+						sd_type[index] = SD_TYPE_IIGS;
+						writable = iigs_w;
+					}
+				}
+
 				if (ret && is_c128())
 				{
 					printf("Disk image type: %d\n", img_type);
@@ -3258,6 +3275,12 @@ void user_io_poll()
 				//if (op) printf("A2 %x %llu on %d\n", op,lba, disk);
 				if (op == 2) a2_writeDSK(&sd_image[disk], lba, ack);
 				else if (op & 1) a2_readDSK(&sd_image[disk], lba, ack);
+				else break;
+			}
+			else if ( sd_type[disk] == SD_TYPE_IIGS)
+			{
+				if (op == 2) iigs_write(disk, &sd_image[disk], lba, ack);
+				else if (op & 1) iigs_read(disk, &sd_image[disk], lba, ack);
 				else break;
 			}
 			else if ((blks == G64_BLOCK_COUNT_1541+1 || blks == G64_BLOCK_COUNT_1571+1) && sd_type[disk]==SD_TYPE_C64)


### PR DESCRIPTION
This patch is for the future IIgs core. It will auto convert a few emulation formats to work with the new core. It removes headers from 2mg files so they can be loaded as a hard drive. It will convert 2mg and dsk files to woz format. 