### PR TITLE
# Fix HDMI black screen / frozen boot on DE10-Nano clones (#1215)

### DIFF
--- a/hdmi_cec.cpp
+++ b/hdmi_cec.cpp
@@ -1016,7 +1016,8 @@ bool cec_init()
 
 	cec_deinit();
 
-	cec_main_fd = i2c_open(ADV7513_MAIN_ADDR, 0);
+	int adv_bus = -1;
+	cec_main_fd = i2c_open(ADV7513_MAIN_ADDR, 0, -1, &adv_bus);
 	if (cec_main_fd < 0)
 	{
 		return false;
@@ -1028,7 +1029,9 @@ bool cec_init()
 		return false;
 	}
 
-	cec_fd = i2c_open(ADV7513_CEC_ADDR, 0);
+	// CEC is a sub-map of the same chip: pin it to the main bus rather than
+	// rescanning, so a phantom on another bus can't capture the handle.
+	cec_fd = i2c_open(ADV7513_CEC_ADDR, 0, adv_bus);
 	if (cec_fd < 0)
 	{
 		cec_deinit();

--- a/smbus.cpp
+++ b/smbus.cpp
@@ -209,10 +209,18 @@ int i2c_smbus_block_process_call(int file, uint8_t command, uint8_t length, uint
 	return data.block[0];
 }
 
-int i2c_open(int dev_address, int is_smbus)
+int i2c_open(int dev_address, int is_smbus, int force_bus, int *found_bus)
 {
 	char str[16];
-	for (int bus = 0; bus < 3; bus++)
+	// only /dev/i2c-0..2 exist; an out-of-range pin hint means "not found"
+	if (force_bus > 2)
+	{
+		printf("i2c_open: invalid bus %d for device 0x%X\n", force_bus, dev_address);
+		return -1;
+	}
+	int bus_first = (force_bus >= 0) ? force_bus : 0;
+	int bus_last  = (force_bus >= 0) ? force_bus : 2;
+	for (int bus = bus_first; bus <= bus_last; bus++)
 	{
 		int fd;
 		sprintf(str, "/dev/i2c-%d", bus);
@@ -250,6 +258,8 @@ int i2c_open(int dev_address, int is_smbus)
 		}
 
 		printf("Opened %s for device 0x%X\n", str, dev_address);
+		// report the matched bus so sibling chip addresses can be pinned to it
+		if (found_bus) *found_bus = bus;
 		return fd;
 	}
 

--- a/smbus.h
+++ b/smbus.h
@@ -3,7 +3,7 @@
 #ifndef SMBUS_H
 #define SMBUS_H
 
-int i2c_open(int dev_address, int is_smbus);
+int i2c_open(int dev_address, int is_smbus, int force_bus = -1, int *found_bus = NULL);
 void i2c_close(int fd);
 
 int i2c_smbus_write_quick(int file, uint8_t value);

--- a/video.cpp
+++ b/video.cpp
@@ -1819,7 +1819,7 @@ static void cache_raw_edid_mfg_id()
 	raw_edid_mfg_id_valid = true;
 }
 
-static void read_edid_segment(uint8_t segment, uint8_t *buf)
+static bool read_edid_segment(uint8_t segment, uint8_t *buf)
 {
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC4, segment);
 	i2c_smbus_write_byte_data(hdmi_main_fd, 0xC9, 0x03);
@@ -1829,19 +1829,21 @@ static void read_edid_segment(uint8_t segment, uint8_t *buf)
 	unsigned long timeout = GetTimer(500);
 	while (!CheckTimer(timeout))
 	{
-		if (i2c_smbus_read_byte_data(hdmi_main_fd, 0x96) & 4)
+		int status = i2c_smbus_read_byte_data(hdmi_main_fd, 0x96);
+		if (status >= 0 && (status & 4))
 		{
 			i2c_smbus_write_byte_data(hdmi_main_fd, 0x96, 4);
-			break;
+			for (uint16_t i = 0; i < 256; i++)
+			{
+				int value = i2c_smbus_read_byte_data(hdmi_edid_fd, (uint8_t)i);
+				buf[i] = (value < 0) ? 0 : (uint8_t)value;
+			}
+			return true;
 		}
 		usleep(10000);
 	}
 
-	for (uint16_t i = 0; i < 256; i++)
-	{
-		int value = i2c_smbus_read_byte_data(hdmi_edid_fd, (uint8_t)i);
-		buf[i] = (value < 0) ? 0 : (uint8_t)value;
-	}
+	return false;
 }
 
 static int read_edid(bool force = false)
@@ -1862,8 +1864,15 @@ static int read_edid(bool force = false)
 	// waiting for valid EDID
 	for (int k = 0; k < 20; k++)
 	{
-		read_edid_segment(0, edid);
+		int current = i2c_smbus_read_byte_data(hdmi_main_fd, 0x42);
+		if (current < 0 || !(current & 0x20))
+		{
+			raw_edid_mfg_id_valid = false;
+			return 0;
+		}
+		bool got_interrupt = read_edid_segment(0, edid);
 		if (is_edid_valid()) break;
+		if (!got_interrupt) break;  // no DDC response — display has no EDID, don't retry
 		usleep(100000);
 	}
 

--- a/video.cpp
+++ b/video.cpp
@@ -1444,7 +1444,8 @@ static void hdmi_config_init()
 
 	if (hdmi_main_fd < 0)
 	{
-		hdmi_main_fd = i2c_open(0x39, 0);
+		int adv_bus = -1;
+		hdmi_main_fd = i2c_open(0x39, 0, -1, &adv_bus);
 		if (hdmi_main_fd < 0)
 		{
 			printf("ADV7513 not found on i2c bus! HDMI won't be available!\n");
@@ -1452,15 +1453,18 @@ static void hdmi_config_init()
 		}
 		else
 		{
+			// EDID/SPD are sub-maps of the same chip: pin them to the main bus
+			// instead of rescanning, or a phantom that ACKs on another bus can
+			// capture the handle and wedge the i2c controller on a real transfer.
 			if (hdmi_edid_fd < 0)
 			{
-				hdmi_edid_fd = i2c_open(0x3f, 0);
+				hdmi_edid_fd = i2c_open(0x3f, 0, adv_bus);
 				if (hdmi_edid_fd < 0) printf("ADV7513: cannot find EDID registers.\n");
 			}
 
 			if (hdmi_spd_fd < 0)
 			{
-				hdmi_spd_fd = i2c_open(0x38, 0);
+				hdmi_spd_fd = i2c_open(0x38, 0, adv_bus);
 				if (hdmi_spd_fd < 0) printf("ADV7513: cannot find SPD registers.\n");
 			}
 		}

--- a/video.cpp
+++ b/video.cpp
@@ -1806,16 +1806,21 @@ static int find_edid_vrr_capability()
 
 }
 
-static int is_edid_valid()
+static int is_edid_valid_buf(const uint8_t *buf)
 {
 	static const uint8_t magic[] = { 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00 };
 	if (sizeof(edid) < sizeof(magic)) return 0;
-	return !memcmp(edid, magic, sizeof(magic));
+	return !memcmp(buf, magic, sizeof(magic));
 }
 
-static void cache_raw_edid_mfg_id()
+static int is_edid_valid()
 {
-	raw_edid_mfg_id = (edid[0x08] << 8) | edid[0x09];
+	return is_edid_valid_buf(edid);
+}
+
+static void cache_raw_edid_mfg_id(const uint8_t *buf)
+{
+	raw_edid_mfg_id = (buf[0x08] << 8) | buf[0x09];
 	raw_edid_mfg_id_valid = true;
 }
 
@@ -1851,8 +1856,6 @@ static int read_edid(bool force = false)
 	if (hdmi_main_fd < 0 || hdmi_edid_fd < 0) return 0;
 	if (is_edid_valid() && !force) return 1;
 
-	memset(edid, 0, sizeof(edid));
-
 	//Test if adv7513 senses hdmi clock. If not, don't bother with the edid query
 	int hpd_state = i2c_smbus_read_byte_data(hdmi_main_fd, 0x42);
 	if (hpd_state < 0 || !(hpd_state & 0x20))
@@ -1860,6 +1863,10 @@ static int read_edid(bool force = false)
 		raw_edid_mfg_id_valid = false;
 		return 0;
 	}
+
+	// read into scratch; replace live edid[] only on a valid read, so a transient failure can't blank it
+	uint8_t buf[sizeof(edid)] = {};
+	bool ddc_responded = false;
 
 	// waiting for valid EDID
 	for (int k = 0; k < 20; k++)
@@ -1870,33 +1877,44 @@ static int read_edid(bool force = false)
 			raw_edid_mfg_id_valid = false;
 			return 0;
 		}
-		bool got_interrupt = read_edid_segment(0, edid);
-		if (is_edid_valid()) break;
+		bool got_interrupt = read_edid_segment(0, buf);
+		if (got_interrupt) ddc_responded = true;
+		if (is_edid_valid_buf(buf)) break;
 		if (!got_interrupt) break;  // no DDC response — display has no EDID, don't retry
 		usleep(100000);
 	}
 
-	if (is_edid_valid())
+	if (!is_edid_valid_buf(buf))
 	{
-		uint8_t max_blocks = sizeof(edid) / 256;
-		uint8_t blocks = (2 + edid[126]) / 2; // each block is 128 bytes
-		if (blocks > max_blocks) blocks = max_blocks;
-		for (uint8_t i = 1; i < blocks; i++) read_edid_segment(i, edid + (i * 256));
+		if (ddc_responded)
+		{
+			// header bad but DDC answered: still cache raw mfg id for non-conformant DAC EDIDs
+			cache_raw_edid_mfg_id(buf);
+			printf("Invalid EDID: incorrect header.\n");
+		}
+		else
+		{
+			printf("Invalid EDID: no DDC response.\n");
+		}
+		// stored edid[], not buf: only when a prior valid read is being kept
+		if (is_edid_valid()) printf("Invalid EDID: keeping last valid EDID.\n");
+
+		return 0;
 	}
+
+	uint8_t max_blocks = sizeof(edid) / 256;
+	uint8_t blocks = (2 + buf[126]) / 2; // each block is 128 bytes
+	if (blocks > max_blocks) blocks = max_blocks;
+	for (uint8_t i = 1; i < blocks; i++) read_edid_segment(i, buf + (i * 256));
+
+	memcpy(edid, buf, sizeof(edid));
 
 	printf("EDID:\n");
 	uint8_t n = edid[126] + 1;
 	if (n > sizeof(edid) / 128) n = sizeof(edid) / 128;
 	hexdump(edid, n*128, 0);
 
-	cache_raw_edid_mfg_id();
-
-	if (!is_edid_valid())
-	{
-		printf("Invalid EDID: incorrect header.\n");
-		bzero(edid, sizeof(edid));
-		return 0;
-	}
+	cache_raw_edid_mfg_id(edid);
 
 	edid_version++;
 	return 1;
@@ -2695,10 +2713,20 @@ void video_init()
 
 void video_reinit()
 {
+	int prev_ver = edid_version;
+	read_edid(true);
+
+	// re-read gave nothing new but a valid EDID is still held: the mode is unchanged,
+	// so don't bounce a working link (some clones can't re-lock mid-operation)
+	if (edid_version == prev_ver && is_edid_valid())
+	{
+		printf("*** Video re-init skipped: EDID unchanged.\n");
+		return;
+	}
+
 	printf("*** Video re-initialization.\n");
 
 	hdmi_config_init();
-	read_edid(true);
 	hdmi_config_set_hdr();
 
 	support_FHD = 0;


### PR DESCRIPTION
Fixes #1215.

> ~~**Draft** — opening as a draft until @Huntsman360 confirms the build resolves it on his~~
> ~~hardware. Already verified on my Hamgeek clone (1440p monitor + 4K Samsung TV).~~

update: @Huntsman360 also confirms it works, remove draft
## TL;DR

On clones, the HDMI black-screen / frozen boot in #1215 is an **i2c transfer that hangs the kernel
because the ADV7513 EDID handle gets opened on the wrong i2c bus**. `i2c_open()` scans the buses and
takes the first device that ACKs, and on these boards a phantom on `/dev/i2c-0` answers at the EDID
address `0x3F`; the first real read to it wedges the i2c controller in uninterruptible sleep during
`video_init`, so both HDMI **and** analog stay black and the menu freezes. The fix pins the
ADV7513's EDID/SPD/CEC sub-addresses to the same bus its main `0x39` map was found on. The branch
also carries @TheJesusFish's #1213 EDID-read fix, which the EDID hardening here builds on.

## Symptoms

Cold boot — especially after the display has been off/idle a while — comes up with **no video on
either HDMI or analog**, and the **menu and clock are frozen** (SSH still works). Reported on QMTech
and Hamgeek clones (and a few genuine monitors). Power-cycling sometimes "fixes" it for a boot; an
un-updated SD card never shows it. Not resolved by #1212 or #1213 alone.

## Root cause: EDID handle opens on the wrong i2c bus and the read hangs

`i2c_open()` scans `/dev/i2c-0 → 1 → 2` and uses the first address that ACKs a one-byte probe. The
ADV7513's register maps — main `0x39`, EDID `0x3F`, SPD `0x38`, CEC `0x3C` — all live on **one**
physical bus (`i2c-1` on these boards), but each is opened with an independent scan. On clones a
phantom on `/dev/i2c-0` intermittently ACKs the probe at `0x3F`, so the EDID handle is captured on
the wrong bus; the first real 256-byte EDID read then wedges the DesignWare i2c controller.

Boot log from a frozen unit (`debug=2`) — note the EDID device on the wrong bus, and that the log
stops with no `EDID:` / `Calculate PLL` after it:

```
Opened /dev/i2c-1 for device 0x39      <- ADV7513 main
Opened /dev/i2c-0 for device 0x3F      <- EDID, WRONG bus (should be i2c-1)
Opened /dev/i2c-1 for device 0x38      <- SPD
<frozen here>
```

Inspecting the hung process confirms it is stuck in the kernel i2c driver:

```
wchan:   i2c_dw_xfer            # blocked in the DesignWare i2c controller
State:   D (uninterruptible)    # only a reset clears it
syscall: 54 0x7 0x720 ...       # 54 = ioctl, fd 0x7 = /dev/i2c-0, request 0x720 = I2C_SMBUS
fds:     fd7 -> /dev/i2c-0      # the 0x3F EDID handle, on the wrong bus
```

Because the whole `video_init` blocks in `D` before any FPGA video is configured, **both outputs go
black and the menu/clock freeze**. Genuine DE10-Nanos never hit it (nothing ACKs `0x3F` on
`i2c-0`), and the intermittent phantom is why "a couple of resets fixes it."

## Fix: pin the ADV7513 sub-addresses to the main chip's bus

The EDID/SPD/CEC maps are physically on the same bus as `0x39`, so they should never be scanned
independently. `i2c_open()` gains an optional `force_bus` (scan one bus only) and `found_bus`
(report the matched bus); `hdmi_config_init()` and `cec_init()` learn the bus from the `0x39` open
and open `0x3F` / `0x38` / `0x3C` **forced onto that bus** with no rescan.

After the fix, the EDID device is reliably on the correct bus and the read completes:

```
Opened /dev/i2c-1 for device 0x39
Opened /dev/i2c-1 for device 0x3F      <- EDID now on i2c-1
Opened /dev/i2c-1 for device 0x38
EDID:
0000: 00 ff ff ff ff ff ff 00 ...      <- read succeeds, boot continues
```

**Fail-safe:** the main `0x39` open is unchanged; if a sub-address isn't found on that bus the
handle stays `-1` and EDID is simply skipped (default video mode) — never a hang. Other `i2c_open`
callers and genuine DE10-Nano behavior are unchanged (their sub-maps are already on the main bus).

## Also included: EDID-read hardening

The branch carries @TheJesusFish's #1213 fix and the EDID hardening here builds on it:

- Bound the EDID read so a non-responding sink can't stall the main poll thread (~12 s), and never
  ingest garbage on a DDC timeout. *(This is #1213 — credit to @TheJesusFish for that fix and the
  EDID-loop diagnosis.)*
- Read EDID into a scratch buffer and **retain the last-good EDID** instead of zeroing it on a
  transient re-read failure, so a brief DDC glitch (e.g. on a core load) can't blank a working mode.

## Testing

- Verified on a Hamgeek (QMTech-style) clone: EDID/SPD/CEC now consistently open on `i2c-1`, EDID
  reads succeed, and cold-boot-from-idle no longer hangs — on both a 1440p monitor and a 4K Samsung
  TV.
- Thanks to @Huntsman360 for the testing and repro details.

*(Kept as a draft until @Huntsman360 confirms it resolves the issue on his setup.)*

## Known follow-up (separate PR)

While testing this we found that **CEC does not work on cold boot when the TV is in standby**:
`cec_init()` needs the CEC physical address, which it parses from the sink's EDID — but a standby TV
provides no EDID until it is already awake, so CEC init loops `CEC: init failed, retry in 3sec...`
and never sends the wake. Once the TV is on and EDID is read, CEC works normally. This is a
pre-existing, separate issue (not caused by this change), and we'll address it in its own PR.
Update: created #1218

---

*Full disclosure: this fix was developed with the assistance of AI (Claude).*
