### PR TITLE
fix: use requested asset extension in findGameAsset

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -2241,7 +2241,7 @@ int findGameAsset(char *path, size_t path_len, const char *rom_path, uint32_t ro
 {
 	path[0] = 0;
 
-	if (!strcasestr(rom_path, ".zip"))
+	if (!strcasestr(rom_path, ext))
 	{
 		snprintf(path, path_len, "%s", getFullPath(rom_path));
 		char *p = strrchr(path, '.');


### PR DESCRIPTION
`findGameAsset()` is now shared by cheats and game manuals, but it still used a cheat-specific `.zip` check before deriving the same-basename asset path. For manual lookups, this meant a zipped ROM path could prevent the helper from checking the expected `.pdf` candidate next to the ROM.

This PR fixes that.
