### PR TITLE
Second mouse generic

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -1461,6 +1461,7 @@ typedef struct
 
 	uint8_t  led;
 	uint8_t  mouse;
+	uint8_t  mouse_port; // dual-mouse: 2nd physical mouse -> COM3 serial mouse (port 2); 0 = unset (->PS/2)
 	uint8_t  axis_edge[256];
 	int8_t   axis_pos[256];
 
@@ -2023,6 +2024,12 @@ static int mouse_req = 0;
 static int mouse_x = 0;
 static int mouse_y = 0;
 static int mouse_w = 0;
+// second mouse (ao486 COM3 serial mouse) - dual-mouse support
+static unsigned char mice2_btn = 0;
+static int mouse2_req = 0;
+static int mouse2_x = 0;
+static int mouse2_y = 0;
+static int mouse2_w = 0;
 static int mouse_emu = 0;
 static int kbd_mouse_emu = 0;
 static int mouse_sniper = 0;
@@ -2127,9 +2134,17 @@ static void uinp_check_key()
 	}
 }
 
-static void mouse_cb(int16_t x = 0, int16_t y = 0, int16_t w = 0)
+static void mouse_cb(int16_t x = 0, int16_t y = 0, int16_t w = 0, int port = 0)
 {
-	if (grabbed)
+	if (!grabbed) return;
+	if (port >= 2) // dual-mouse: route to ao486 COM3 serial mouse (port 2)
+	{
+		mouse2_x += x;
+		mouse2_y += y;
+		mouse2_w += w;
+		mouse2_req |= 1;
+	}
+	else
 	{
 		mouse_x += x;
 		mouse_y += y;
@@ -2138,9 +2153,11 @@ static void mouse_cb(int16_t x = 0, int16_t y = 0, int16_t w = 0)
 	}
 }
 
-static void mouse_btn_req()
+static void mouse_btn_req(int port = 0)
 {
-	if (grabbed) mouse_req |= 2;
+	if (!grabbed) return;
+	if (port >= 2) mouse2_req |= 2;
+	else mouse_req |= 2;
 }
 
 static inline void joy_clamp(int* value, const int min, const int max)
@@ -2963,8 +2980,11 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int 
 			{
 				int mask = 1 << (ev->code - BTN_MOUSE);
 				if (input[dev].ds_mouse_emu && mask == 1) mask = 2;
-				mice_btn = (ev->value) ? (mice_btn | mask) : (mice_btn & ~mask);
-				mouse_btn_req();
+				if (input[dev].mouse_port >= 2) // dual-mouse: port 2 (COM3) buttons
+					mice2_btn = (ev->value) ? (mice2_btn | mask) : (mice2_btn & ~mask);
+				else
+					mice_btn = (ev->value) ? (mice_btn | mask) : (mice_btn & ~mask);
+				mouse_btn_req(input[dev].mouse_port);
 			}
 			return;
 		}
@@ -4241,6 +4261,23 @@ void mergedevs()
 			}
 		}
 	}
+
+	// dual-mouse: assign each physical pointer mouse a port by enumeration order
+	// (1st mouse -> PS/2/port 1, 2nd -> COM3 serial mouse/port 2). Pure USB mice
+	// never get a joystick player number, so we track the port separately on the
+	// bound base (eventN) device that motion/buttons resolve to. A single mouse
+	// stays port 1, preserving today's behavior.
+	int mouse_order = 0;
+	for (int i = 0; i < NUMDEV; i++) input[i].mouse_port = 0;
+	for (int i = 0; i < NUMDEV; i++)
+	{
+		if (input[i].mouse && input[i].quirk != QUIRK_MSSP)
+		{
+			int base = (input[i].bind >= 0) ? input[i].bind : i;
+			if (!input[base].mouse_port)
+				input[base].mouse_port = (++mouse_order >= 2) ? 2 : 1;
+		}
+	}
 }
 
 // Jammasd/J-PAC/I-PAC have shifted keys: when 1P start is kept pressed, it acts as a shift key,
@@ -4379,7 +4416,7 @@ static void send_mouse_with_throttle(int dev, int xval, int yval, int8_t wval)
 	yval = input[i].accy / throttle;
 	input[i].accy -= yval * throttle;
 
-	mouse_cb(xval, yval, wval);
+	mouse_cb(xval, yval, wval, input[dev].mouse_port); // dual-mouse: split by assigned port
 }
 
 static uint32_t touch_rel = 0;
@@ -6401,6 +6438,23 @@ int input_poll(int getchar)
 			mouse_x = 0;
 			mouse_y = 0;
 			mouse_w = 0;
+		}
+	}
+
+	// dual-mouse: emit the 2nd mouse as a COM3 serial mouse (only set when a 2nd
+	// mouse is assigned; user_io_mouse2 is a no-op on non-ao486 cores)
+	if (mouse2_req)
+	{
+		static uint32_t old_time2 = 0;
+		uint32_t time = GetTimer(0);
+		if ((time - old_time2 > 15) || (mouse2_req & 2))
+		{
+			old_time2 = time;
+			user_io_mouse2(mice2_btn, mouse2_x, mouse2_y, mouse2_w);
+			mouse2_req = 0;
+			mouse2_x = 0;
+			mouse2_y = 0;
+			mouse2_w = 0;
 		}
 	}
 

--- a/input.cpp
+++ b/input.cpp
@@ -1665,6 +1665,23 @@ static char has_led(int fd)
 	return test_bit(EV_LED, evtype_b) ? 1 : 0;
 }
 
+// True if the evdev node reports real keyboard keys. Some combo devices
+// (e.g. 8BitDo Retro Keyboard) also expose a phantom mouse interface with
+// REL_X/REL_Y + mouse buttons; that interface enumerates as /dev/input/mouseN
+// and would otherwise steal mouse port 1 from a real USB mouse. We use this to
+// skip such phantoms during dual-mouse port assignment.
+static char dev_is_keyboard(int fd)
+{
+	unsigned char keybit[(KEY_MAX + 7) / 8];
+	if (fd < 0) return 0;
+
+	memset(&keybit, 0, sizeof(keybit));
+	if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keybit)), keybit) < 0) return 0;
+
+	// alphabetic keys present == a genuine keyboard (a real mouse only has BTN_*)
+	return (test_bit(KEY_A, keybit) && test_bit(KEY_Z, keybit) && test_bit(KEY_SPACE, keybit)) ? 1 : 0;
+}
+
 static char leds_state = 0;
 void set_kbdled(int mask, int state)
 {
@@ -4274,6 +4291,11 @@ void mergedevs()
 		if (input[i].mouse && input[i].quirk != QUIRK_MSSP)
 		{
 			int base = (input[i].bind >= 0) ? input[i].bind : i;
+			// Skip phantom mice exposed by keyboards (e.g. 8BitDo Retro Keyboard):
+			// they enumerate before real USB mice and would steal port 1, forcing
+			// both real mice onto port 2 (the serial mouse). Leave them at port 0
+			// (-> PS/2) so the real mice split cleanly across ports 1 and 2.
+			if (dev_is_keyboard(pool[base].fd)) continue;
 			if (!input[base].mouse_port)
 				input[base].mouse_port = (++mouse_order >= 2) ? 2 : 1;
 		}

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -4128,26 +4128,29 @@ void user_io_mouse(unsigned char b, int16_t x, int16_t y, int16_t w)
 	}
 }
 
-// Second mouse for ao486, delivered to the core as a COM3 serial mouse
-// (UIO_MOUSE2 -> hps_io 0x07 -> serial_mouse generator -> UART3 RX). Only ao486
-// decodes this command; other cores ignore it. Emitted only when a 2nd physical
-// mouse is assigned to player 2 (see input.cpp mouse_port). Sends raw signed
-// deltas + buttons; the FPGA synthesizes the Microsoft 1200-baud serial frames.
+// Second mouse, delivered to the core over UIO_MOUSE2 (0x07). This is a
+// core-agnostic facility: the wire layout mirrors user_io_mouse (dx, dy,
+// buttons, wheel as four signed bytes), and any core that decodes 0x07 in its
+// hps_io gets a second mouse with no further userspace changes. A core that
+// does NOT decode 0x07 simply ignores it (an unrecognised UIO command is a
+// no-op, exactly like mouse #1's UIO_MOUSE on a core that ignores it), so it is
+// safe to emit unconditionally. It is only emitted when a 2nd physical mouse is
+// actually assigned to player 2 (see input.cpp mouse_port).
+//
+// Current consumers: Minimig (real mouse on Amiga controller port 2) and ao486
+// (synthesized Microsoft serial mouse on a selectable COM port). Minimig uses
+// all four bytes; ao486 reads dx/dy/buttons and ignores the wheel byte.
 void user_io_mouse2(unsigned char b, int16_t x, int16_t y, int16_t w)
 {
-	(void)w;
 	if (osd_is_visible && !is_menu()) return;
-	if (!is_x86()) return;
 
 	register_activity();
 
-	int16_t cx = (x < -127) ? -127 : (x > 127) ? 127 : x;
-	int16_t cy = (y < -127) ? -127 : (y > 127) ? 127 : y;
-
 	spi_uio_cmd_cont(UIO_MOUSE2);
-	spi_w((uint8_t)cx);    // dx  -> hps_io byte_cnt 1 (io_din[7:0])
-	spi_w((uint8_t)cy);    // dy  -> hps_io byte_cnt 2
-	spi_w(b & 0x07);       // btn -> hps_io byte_cnt 3
+	spi8((x < -127) ? -127 : (x > 127) ? 127 : x); // dx     -> byte_cnt 1
+	spi8((y < -127) ? -127 : (y > 127) ? 127 : y); // dy     -> byte_cnt 2
+	spi8(b & 0x07);                                 // btns   -> byte_cnt 3
+	spi8((w < -127) ? -127 : (w > 127) ? 127 : w); // wheel  -> byte_cnt 4
 	DisableIO();
 }
 

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -4128,6 +4128,29 @@ void user_io_mouse(unsigned char b, int16_t x, int16_t y, int16_t w)
 	}
 }
 
+// Second mouse for ao486, delivered to the core as a COM3 serial mouse
+// (UIO_MOUSE2 -> hps_io 0x07 -> serial_mouse generator -> UART3 RX). Only ao486
+// decodes this command; other cores ignore it. Emitted only when a 2nd physical
+// mouse is assigned to player 2 (see input.cpp mouse_port). Sends raw signed
+// deltas + buttons; the FPGA synthesizes the Microsoft 1200-baud serial frames.
+void user_io_mouse2(unsigned char b, int16_t x, int16_t y, int16_t w)
+{
+	(void)w;
+	if (osd_is_visible && !is_menu()) return;
+	if (!is_x86()) return;
+
+	register_activity();
+
+	int16_t cx = (x < -127) ? -127 : (x > 127) ? 127 : x;
+	int16_t cy = (y < -127) ? -127 : (y > 127) ? 127 : y;
+
+	spi_uio_cmd_cont(UIO_MOUSE2);
+	spi_w((uint8_t)cx);    // dx  -> hps_io byte_cnt 1 (io_din[7:0])
+	spi_w((uint8_t)cy);    // dy  -> hps_io byte_cnt 2
+	spi_w(b & 0x07);       // btn -> hps_io byte_cnt 3
+	DisableIO();
+}
+
 /* usb modifer bits:
 0     1     2    3    4     5     6    7
 LCTRL LSHIFT LALT LGUI RCTRL RSHIFT RALT RGUI

--- a/user_io.h
+++ b/user_io.h
@@ -18,7 +18,7 @@
 #define UIO_MOUSE       0x04  // -"-
 #define UIO_KEYBOARD    0x05  // -"-
 #define UIO_KBD_OSD     0x06  // keycodes used by OSD only
-#define UIO_MOUSE2      0x07  // ao486: second mouse -> COM3 serial mouse (dual-mouse)
+#define UIO_MOUSE2      0x07  // second mouse (dual-mouse); any core decoding it
 
 // 0x08 - 0x0F - core specific
 
@@ -208,7 +208,7 @@ uint32_t user_io_get_uart_mode();
 
 uint32_t user_io_get_activity_seq();
 void user_io_mouse(unsigned char b, int16_t x, int16_t y, int16_t w);
-void user_io_mouse2(unsigned char b, int16_t x, int16_t y, int16_t w); // ao486 COM3 serial mouse (dual-mouse)
+void user_io_mouse2(unsigned char b, int16_t x, int16_t y, int16_t w); // 2nd mouse, UIO_MOUSE2 (dual-mouse)
 void user_io_kbd(uint16_t key, int press);
 char* user_io_create_config_name(int with_ver = 0);
 int user_io_get_joy_transl();

--- a/user_io.h
+++ b/user_io.h
@@ -18,6 +18,7 @@
 #define UIO_MOUSE       0x04  // -"-
 #define UIO_KEYBOARD    0x05  // -"-
 #define UIO_KBD_OSD     0x06  // keycodes used by OSD only
+#define UIO_MOUSE2      0x07  // ao486: second mouse -> COM3 serial mouse (dual-mouse)
 
 // 0x08 - 0x0F - core specific
 
@@ -207,6 +208,7 @@ uint32_t user_io_get_uart_mode();
 
 uint32_t user_io_get_activity_seq();
 void user_io_mouse(unsigned char b, int16_t x, int16_t y, int16_t w);
+void user_io_mouse2(unsigned char b, int16_t x, int16_t y, int16_t w); // ao486 COM3 serial mouse (dual-mouse)
 void user_io_kbd(uint16_t key, int press);
 char* user_io_create_config_name(int with_ver = 0);
 int user_io_get_joy_transl();


### PR DESCRIPTION
Mouse support, currently tested for the Minimig and AO486 core. Makes mouse control work in Lemmings and Settlers on the Amiga core, and it makes Setters 1 and 2 work with two mouse controllers in DOS on the AO486 core.

But the way it is implemented here should make it possible for other cores to reuse.