### PR TITLE
ide: fix ATAPI CD-ROM failing in Win9x protected mode (Device Manager Code 10)

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -162,6 +162,13 @@ void ide_set_regs(ide_config *ide)
 {
 	if (!(ide->regs.status & (ATA_STATUS_BSY | ATA_STATUS_ERR))) ide->regs.status |= ATA_STATUS_DSC;
 
+	// For ATAPI (packet) devices, status bit 4 is the SERVICE bit, not DSC. We never run
+	// overlapped commands, so SERVICE must read 0. Force it low for CD drives, matching 86Box
+	// ide_status() which masks DSC out of every ATAPI status read (hdc_ide.c). Win9x ESDI_506
+	// otherwise reads the permanent bit-4 as "overlapped-command SERVICE pending", rejects the
+	// channel, and the device fails to start (Device Manager Code 10).
+	if (ide->drive[ide->regs.drv].cd) ide->regs.status &= ~ATA_STATUS_DSC;
+
 	uint8_t data[12] =
 	{
 		(uint8_t)((ide->drive[ide->regs.drv].cd) ? 0x80 : ide->regs.io_size),


### PR DESCRIPTION
## Problem

Under Windows 95/98 an ATAPI CD-ROM on the AO486 core is detected but its IDE channel gets a yellow bang with **Code 10** ("This device cannot start"). `C:\WINDOWS\IOS.LOG` reports:

```
ESDI access to drive failed (IRQ?), so punting. Unit number 02 going through real mode drivers.
```

The CD falls back to MS-DOS Compatibility Mode. DOS CD drivers (which **poll**) work fine; the Win9x protected-mode port driver (`ESDI_506.PDR`, interrupt-driven) rejects the device.

## Root cause

`ide_set_regs()` unconditionally synthesizes status **bit 4** as DSC for every device:

```c
if (!(ide->regs.status & (ATA_STATUS_BSY | ATA_STATUS_ERR))) ide->regs.status |= ATA_STATUS_DSC;
```

For an **ATAPI (packet) device, bit 4 is the SERVICE bit, not DSC.** Since the core never runs overlapped/queued commands, SERVICE must read 0. 86Box models this explicitly — `ide_status()` masks DSC out of every ATAPI status read and substitutes the overlap-service bit, which is 0 for a non-overlapped device (`src/disk/hdc_ide.c`):

```c
ret = (ret & ~DSC_STAT) | (ide->service << 4);
```

Reporting a permanent **SERVICE=1** makes `ESDI_506` read the device as having an overlapped-command service pending that it never requested, so it rejects the channel — even though the completion IRQ was delivered (a hardware trace on a DE10-Nano confirmed IRQ15 is asserted and taken by the CPU during the probe; the failure is the status-byte semantics, above the IRQ layer).

## Fix

Strip DSC for CD drives in `ide_set_regs()`, matching 86Box's ATAPI status masking:

```c
if (ide->drive[ide->regs.drv].cd) ide->regs.status &= ~ATA_STATUS_DSC;
```

This is the complete fix — one line plus a comment. The ATA HDD path is untouched.

## Testing

DE10-Nano, Windows 98 SE, CD-ROM as secondary master: with this change the CD enumerates in Device Manager with **no Code 10** and uses the protected-mode driver. DOS-mode CD access (already working) is unaffected, as is the primary HDD channel.