### PR TITLE
Avoid SPD update work for Info overlays

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -7924,7 +7924,7 @@ void MenuHide()
 
 int menu_present()
 {
-	return (menustate != MENU_NONE1) && (menustate != MENU_NONE2);
+	return (menustate != MENU_NONE1) && (menustate != MENU_NONE2) && (menustate != MENU_INFO);
 }
 
 void Info(const char *message, int timeout, int width, int height, int frame)


### PR DESCRIPTION
Fixes #1127.

This updates "menu_present()" so transient "Info()" overlays are not treated as actual menu presence.

The issue discussion identified that "Info()" can toggle the menu-present state and trigger "spd_config_update()" work, causing main-thread spikes. "MENU_INFO" is now excluded from "menu_present()", so Info overlays do not cause that unnecessary menu-state transition.

This is intentionally a narrow fix:

- no offloading or threading changes
- no HDMI/I2C register behavior changes
- no timing architecture changes
- no hardware/core changes

Call-site review:

- actual menus still return true and preserve menu-open/menu-close behavior
- the SPD update path no longer treats "MENU_INFO" overlays as menu presence
- HDMI CEC real-menu navigation behavior is preserved
- Info overlays now behave like no actual menu is open for CEC handling, which is reasonable because they are transient notifications

Changed file:

- "menu.cpp"

Validation performed:

- reviewed "menu_present()" behavior
- reviewed "menu_present()" call sites, including SPD update and HDMI CEC key handling paths
- "git diff --check"
- "git diff --cached --check"
- "git show --check HEAD"

A full Main_MiSTer build was not run because this Windows environment does not have "make" or the required "arm-none-linux-gnueabihf-*" cross-toolchain available.

No MiSTer hardware validation was performed.