### PR TITLE
Fix EDID re-init bug

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -2732,33 +2732,13 @@ void video_reinit()
 
 	printf("*** Video re-initialization.\n");
 
-	// Snapshot the ADV7513-relevant config state before video_mode_load() has
-	// a chance to update it (dvi_mode auto-detect, direct_video auto-detect, etc.)
-	vmode_custom_t prev_def = v_def;
-	int prev_dvi    = cfg.dvi_mode;
-	int prev_direct = cfg.direct_video;
-	int prev_ltd    = cfg.hdmi_limited;
-	int prev_96k    = cfg.hdmi_audio_96k;
+	hdmi_config_init();
+	hdmi_config_set_hdr();
 
 	support_FHD = 0;
 	video_mode_load(true);
+
 	video_cfg_init();
-
-	// hdmi_config_init() writes a full register dump to the ADV7513 and causes
-	// a brief TMDS glitch that prevents a downstream scaler from re-locking.
-	// Skip it when the EDID change didn't alter any output-facing parameter —
-	// the common scaler profile-change case where timing and HDMI mode are
-	// identical but the scaler exposes a different EDID.
-	bool hw_changed = (cfg.dvi_mode     != prev_dvi)
-	               || (cfg.direct_video  != prev_direct)
-	               || (cfg.hdmi_limited  != prev_ltd)
-	               || (cfg.hdmi_audio_96k != prev_96k)
-	               || memcmp(v_def.item + 1, prev_def.item + 1, 8 * sizeof(uint32_t)) != 0;
-
-	if (hw_changed)
-		hdmi_config_init();
-
-	hdmi_config_set_hdr();
 	video_set_mode(&v_def, 0);
 	user_io_send_buttons(1);
 	video_mode_adjust(1);

--- a/video.cpp
+++ b/video.cpp
@@ -1911,6 +1911,8 @@ static int read_edid(bool force = false)
 	if (blocks > max_blocks) blocks = max_blocks;
 	for (uint8_t i = 1; i < blocks; i++) read_edid_segment(i, buf + (i * 256));
 
+	bool content_changed = !is_edid_valid() || memcmp(edid, buf, sizeof(edid)) != 0;
+
 	memcpy(edid, buf, sizeof(edid));
 
 	printf("EDID:\n");
@@ -1920,7 +1922,7 @@ static int read_edid(bool force = false)
 
 	cache_raw_edid_mfg_id(edid);
 
-	edid_version++;
+	if (content_changed) edid_version++;
 	return 1;
 }
 
@@ -3968,9 +3970,9 @@ void video_menu_bg(int n, int idle)
 		n = menu_bg;
 		idle = cached_idle;
 
-		imlib_context_set_image(bg1); imlib_free_image(); bg1 = 0;
-		imlib_context_set_image(bg2); imlib_free_image(); bg2 = 0;
-		imlib_context_set_image(curtain); imlib_free_image(); curtain = 0;
+		if (bg1)      { imlib_context_set_image(bg1);      imlib_free_image(); bg1      = 0; }
+		if (bg2)      { imlib_context_set_image(bg2);      imlib_free_image(); bg2      = 0; }
+		if (curtain)  { imlib_context_set_image(curtain);  imlib_free_image(); curtain  = 0; }
 	}
 	else
 	{

--- a/video.cpp
+++ b/video.cpp
@@ -2732,13 +2732,33 @@ void video_reinit()
 
 	printf("*** Video re-initialization.\n");
 
-	hdmi_config_init();
-	hdmi_config_set_hdr();
+	// Snapshot the ADV7513-relevant config state before video_mode_load() has
+	// a chance to update it (dvi_mode auto-detect, direct_video auto-detect, etc.)
+	vmode_custom_t prev_def = v_def;
+	int prev_dvi    = cfg.dvi_mode;
+	int prev_direct = cfg.direct_video;
+	int prev_ltd    = cfg.hdmi_limited;
+	int prev_96k    = cfg.hdmi_audio_96k;
 
 	support_FHD = 0;
 	video_mode_load(true);
-
 	video_cfg_init();
+
+	// hdmi_config_init() writes a full register dump to the ADV7513 and causes
+	// a brief TMDS glitch that prevents a downstream scaler from re-locking.
+	// Skip it when the EDID change didn't alter any output-facing parameter —
+	// the common scaler profile-change case where timing and HDMI mode are
+	// identical but the scaler exposes a different EDID.
+	bool hw_changed = (cfg.dvi_mode     != prev_dvi)
+	               || (cfg.direct_video  != prev_direct)
+	               || (cfg.hdmi_limited  != prev_ltd)
+	               || (cfg.hdmi_audio_96k != prev_96k)
+	               || memcmp(v_def.item + 1, prev_def.item + 1, 8 * sizeof(uint32_t)) != 0;
+
+	if (hw_changed)
+		hdmi_config_init();
+
+	hdmi_config_set_hdr();
 	video_set_mode(&v_def, 0);
 	user_io_send_buttons(1);
 	video_mode_adjust(1);


### PR DESCRIPTION
Waiting for @pablopen to chime in and make sure this route doesn't break any of their fixes.

Another fun EDID bug that I asked our good friend Claude to look at.

In a nut (as I understand), when a scaler or dac re-inits and the EDID is the same, the sync can get locked and the screen will stay black. Main still runs, but you'll never get video.

The main binary that this code produces fixes the bug. Is is the best way to write the fix? I have no idea.