### PR TITLE
ide: fix ATAPI CD-ROM in Win9x (UNIT ATTENTION root cause); restore real-mode OAKCDROM

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -160,14 +160,11 @@ void ide_get_regs(ide_config *ide)
 
 void ide_set_regs(ide_config *ide)
 {
-	if (!(ide->regs.status & (ATA_STATUS_BSY | ATA_STATUS_ERR))) ide->regs.status |= ATA_STATUS_DSC;
-
-	// For ATAPI (packet) devices, status bit 4 is the SERVICE bit, not DSC. We never run
-	// overlapped commands, so SERVICE must read 0. Force it low for CD drives, matching 86Box
-	// ide_status() which masks DSC out of every ATAPI status read (hdc_ide.c). Win9x ESDI_506
-	// otherwise reads the permanent bit-4 as "overlapped-command SERVICE pending", rejects the
-	// channel, and the device fails to start (Device Manager Code 10).
-	if (ide->drive[ide->regs.drv].cd) ide->regs.status &= ~ATA_STATUS_DSC;
+	// Auto-assert DSC for non-CD drives only; let each ATAPI command set its own status.
+	if (!ide->drive[ide->regs.drv].cd && !(ide->regs.status & (ATA_STATUS_BSY | ATA_STATUS_ERR)))
+	{
+		ide->regs.status |= ATA_STATUS_DSC;
+	}
 
 	uint8_t data[12] =
 	{
@@ -1016,7 +1013,8 @@ void ide_io(int num, int req)
 		else if (ide->state == IDE_STATE_WAIT_PKT_RD)
 		{
 			if (ide->regs.pkt_cnt) cdrom_read(ide);
-			else cdrom_reply(ide, 0);
+			// A successful data-phase completion must report GOOD, not UNIT ATTENTION.
+			else cdrom_reply(ide, 0, 0, 0, false);
 		}
 		else if (ide->state == IDE_STATE_WAIT_PKT_MODE)
 		{
@@ -1049,7 +1047,8 @@ void ide_io(int num, int req)
 
 		ide_get_regs(ide);
 		ide->regs.head = 0;
-		ide->regs.error = 0;
+		// ATAPI posts diagnostic code 01h after a bus reset; an ATA HDD posts 0.
+		ide->regs.error = ide->drive[ide->regs.drv].cd ? 1 : 0;
 		ide->regs.sector = 1;
 		ide->regs.sector_count = 1;
 		ide->regs.cylinder = (!ide->drive[ide->regs.drv].present) ? 0xFFFF : ide->drive[ide->regs.drv].cd ? 0xEB14 : 0x0000;

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1579,11 +1579,14 @@ int cdrom_handle_cmd(ide_config *ide)
 		ide->regs.sector_count = 1;
 		ide->regs.cylinder = 0xEB14;
 		ide->regs.head = 0;
+		// ATAPI diagnostic code 01h after DEVICE RESET.
+		ide->regs.error = 1;
 		ide->regs.io_size = 0;
-		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_DSC;
+		// Present status 0x00 (no DRDY/DSC), matching real ATAPI HW; routes OAKCDROM to signature detect.
+		ide->regs.status = 0;
 		ide_set_regs(ide);
 		break;
-	
+
 		case 0xEF: // set features
 		switch(ide->regs.features)
 		{


### PR DESCRIPTION
## Summary

This corrects and supersedes #1221. That PR fixed the Win9x protected‑mode **Device Manager "Code 10"** on the ATAPI CD‑ROM's IDE controller by globally stripping the DSC/SERVICE status bit (`0x10`) for CD drives. That worked around the symptom but had two problems, and this PR addresses the actual root cause instead.

## What was wrong with the #1221 approach

**1. It broke real‑mode CD detection.** `OAKCDROM.SYS` — the DOS / Win9x‑setup ATAPI driver — keys off the explicit status byte the device presents after an **ATAPI DEVICE RESET (cmd 08h)** to decide a drive is present. The blanket DSC strip in `ide_set_regs()` clobbered that byte, so real‑mode boots reported **"No drives found"** and you could no longer install Win9x from CD or use the CD under plain DOS. (Disassembly of `OAKCDROM.SYS` confirmed it gates detection on the post‑reset status.)

**2. The Code 10 was never a DSC problem.** Stripping DSC only *masked* the real bug. With DSC behaviour fully decoupled, Win9x still Code‑10'd until the actual cause below was fixed.

## The real root cause

Tracing the Win9x `ESDI_506` channel‑init sequence on the CD shows a **successful ATAPI INQUIRY completing with a spurious UNIT ATTENTION**:

```
A0 PACKET(INQUIRY) -> 0x48 (want packet) -> 0x4C cyl=0x0024 (36 bytes of data delivered)
                                          -> 0x45 err=0x60  (CHECK CONDITION / UNIT ATTENTION)
```

`INQUIRY` and `REQUEST SENSE` are **exempt** from the media‑change gate precisely so they deliver their data even with a media change pending — and `cdrom_handle_pkt()` correctly lets them through. But the data‑phase completion in `IDE_STATE_WAIT_PKT_RD` called `cdrom_reply(ide, 0)` using the header default `unit_attention = true`; with the mount's media‑change flag still pending, `cdrom_reply()` stamped `CHECK CONDITION / err=0x60` onto the **already‑successful** transfer.

`ESDI_506` reads "INQUIRY returned its data **and** failed" as a contradiction → concludes the controller is dead → refuses to start the channel → **Code 10** (no CD‑ROM node, bang on the secondary Std IDE/ESDI controller). Both **Bochs** and **86Box** return GOOD status for INQUIRY here — that was the divergence.

## The fix

- **`ide_set_regs()`** — replace the global DSC strip with *auto‑assert DSC for non‑CD drives only*, and let each ATAPI command publish its own (DSC‑free) status. This satisfies both OAK and Win9x without any blanket bit‑4 policy.
- **ATAPI DEVICE RESET (cmd 08h)** — present status `0x00` (no DRDY/DSC), matching real ATAPI hardware (an ATAPI device does not assert DRDY). This routes real‑mode `OAKCDROM.SYS` to its signature‑detect path (cyl `0xEB14`).
- **`IDE_STATE_WAIT_PKT_RD` completion** — pass `unit_attention = false` so a successful data phase reports GOOD. The pending media‑change UA is **still** correctly delivered on the first *non‑exempt* command (e.g. TEST UNIT READY → `cdrom_nodisk`), which clears the flag — so eject/swap notification is unchanged.
- **Post ATAPI diagnostic code 01h** in the error register after a bus reset; a stale `ABRT` was otherwise read by `ESDI_506` as a failed power‑on self‑test.

No RTL/core change is required — this is entirely in the HPS `Main_MiSTer` ATAPI handling.

## Testing (DE10‑Nano, ao486 core)

- **Win98 SE, protected mode:** Device Manager shows **CDROM → "MiSTer CDROM"** enumerated, and **both** "Standard IDE/ESDI Hard Disk Controller" entries are clean — **Code 10 is gone**.
- **Real‑mode `OAKCDROM.SYS`:** the CD is detected and **MSCDEX assigns it drive `D:`** (`Drive D: = Driver OEMCD001`), i.e. the regression #1221 introduced is also resolved.

Both guests now pass on a single binary, with no DSC trade‑off.
