### PR TITLE
video: re-apply pixel-rep/VIC/sync after HDMI re-init

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -1687,6 +1687,13 @@ static uint8_t last_sync_invert = 0xff;
 static uint8_t last_pr_flags = 0xff;
 static uint8_t last_vic_mode = 0xff;
 
+static void hdmi_invalidate_mode_cache()
+{
+	last_sync_invert = 0xff;
+	last_pr_flags = 0xff;
+	last_vic_mode = 0xff;
+}
+
 static void hdmi_config_set_mode(vmode_custom_t *vm)
 {
 	PROFILE_FUNCTION();
@@ -2731,6 +2738,8 @@ void video_reinit()
 	printf("*** Video re-initialization.\n");
 
 	hdmi_config_init();
+	// re-init resets 0x17/0x3B/0x3C - re-apply, or video stays black if any of them changed
+	hdmi_invalidate_mode_cache();
 	hdmi_config_set_hdr();
 
 	support_FHD = 0;


### PR DESCRIPTION
An HPD event can trigger video_reinit() even when the EDID is unchanged. hdmi_config_init() resets 0x17/0x3B/0x3C, but hdmi_config_set_mode() caches those and skips re-writing unchanged values — so the chip keeps the init default (0x3B=0x80, auto pixel-repetition) instead of the mode's value. On low-res direct_video the sink syncs but shows black.

<details>
<summary>V7513 reg dump, row 0x30 (offset 0x3B = pixel repetition):</summary>

```
working : 30: 00 00 00 00 00 40 D9 0A 00 2D 00 40 00 00 00 00   <- 0x3B = 0x40 (manual pr)
re-init : 30: 00 00 00 00 00 40 D9 0A 00 2D 00 80 00 00 00 00   <- 0x3B = 0x80 (auto, init default)
```
</details>

**Fix**: invalidate the set_mode cache after hdmi_config_init() so it re-applies those registers to the freshly-reset chip.

Related: #1223 (same symptom; this addresses the root cause without changing edid_version).

Co-authored with @TheJesusFish , as we were running builds with traces so we could debug the error, as I couldn't reproduce it. (lack the specific hardware causing this)

---
*Full disclosure: this fix was developed with the assistance of AI (Claude).*