### PR TITLE
Remove ypbpr from MiSter.ini

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -2,7 +2,6 @@
 ;debug=1               ; set to 1 to enable debugging messages, 2 - write to /tmp/debug.txt. Default is 0(disabled).
 key_menu_as_rgui=0     ; set to 1 to make the MENU key map to RGUI in Minimig (e.g. for Right Amiga)
 forced_scandoubler=0   ; set to 1 to run scandoubler on VGA output always (depends on core).
-;ypbpr=0               ; set to 1 for YPbPr on VGA output. (obsolete. see vga_mode)
 vga_mode=rgb           ; supported modes: rgb, ypbpr, svideo, cvbs, and subcarrier (for external rgb converters). rgb is default.
 ntsc_mode=0            ; Only for S-Video and CVBS vga_mode. 0 - normal NTSC, 1 - PAL-60, 2 - PAL-M.
 composite_sync=1       ; set to 1 for composite sync on HSync signal of VGA output.


### PR DESCRIPTION
There may be a good reason why this is still in here, but just in case there is not, I think it's worth pulling out of the ini default to help avoid confusion. 

This would just be an ini-only change to ensure backwards compatibility.