### PR TITLE
Fix OSD page flip when waking from osd_timeout in menu core

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -1230,8 +1230,17 @@ void HandleUI(void)
 		static int menu_visible = 1;
 		static unsigned long timeout = 0;
 		static unsigned long off_timeout = 0;
+		static uint32_t wake_release = 0;
 		if (!video_fb_state() && cfg.fb_terminal)
 		{
+			if (wake_release)
+			{
+				uint32_t wr = wake_release;
+				wake_release = 0;
+				if (c == wr) c = 0;
+				else if (!c) wake_release = wr;
+			}
+
 			if (timeout && CheckTimer(timeout))
 			{
 				timeout = 0;
@@ -1261,6 +1270,10 @@ void HandleUI(void)
 				timeout = 0;
 				if (menu_visible <= 0)
 				{
+					// some keys (F12/ESC/Back) act on release, so swallow the
+					// wake-up key's release too, otherwise it flips the OSD
+					// to the system settings page
+					if (c && !(c & UPSTROKE)) wake_release = c | UPSTROKE;
 					c = 0;
 					menu_visible = 1;
 					video_menu_bg(user_io_status_get("[3:1]"));


### PR DESCRIPTION
## Bug

In the menu core with `osd_timeout` set (>= 5), the OSD hides after the timeout while on the cores page. Pressing a key wakes it back up and the keypress is supposed to be swallowed — but only the key *press* is swallowed. Keys that act on *release* (F12 / a controller button mapped to menu, ESC, controller back button) still deliver their release event to the menu handler after the OSD is re-shown. The release registers as a menu/back action, which flips the OSD from the cores page to the system settings page.

**To reproduce:** in the main menu, let the OSD time out and disappear, then press the menu button. The OSD reappears on the System Settings page instead of the cores page it was on.

## Fix

Remember which key woke the OSD and swallow that key's release as well. The pending swallow survives idle polls, is consumed by the matching release, and is discarded if any other key event arrives first, so it cannot eat an unrelated release later.

Tested on a DE10-Nano (`osd_timeout=30`): waking via keyboard F12, ESC, Enter, arrows, Backspace, and via controller menu-mapped button, back button, A button, and d-pad — the OSD now always returns showing the cores page, and normal page cycling while the OSD is visible is unaffected.