### PR TITLE
Atari800: automatically load the file with the SID data for PokeyMax

### DIFF
--- a/support/atari8bit/atari800.cpp
+++ b/support/atari8bit/atari800.cpp
@@ -2731,6 +2731,8 @@ void atari800_init()
 	}
 	sprintf(mainpath, "%s/boot3.rom", home);
 	user_io_file_tx(mainpath, 3 << 6);
+	sprintf(mainpath, "%s/sid_data.bin", home);
+	user_io_file_tx(mainpath, 7);
 	atari800_reset();
 }
 


### PR DESCRIPTION
Very minor thing, this is something that is needed for the upcoming Atari800 core with the PokeyMax support integrated (PR coming shortly after this), all the explanations will be provided there.