### PR TITLE
ide: assert DSC on ATAPI SEEK so VIDE-CDD.SYS stops stalling (#1239)

### DIFF
--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1390,7 +1390,7 @@ void cdrom_handle_pkt(ide_config *ide)
 		dbg_printf("** Seek\n");
 		drv->playing = 0;
 		drv->paused = 0;
-		cdrom_reply(ide, 0);
+		cdrom_reply(ide, 0, 0, 0, true, ATA_STATUS_DSC);
 		break;
 
 	case 0x1B: //START STOP UNIT
@@ -1618,7 +1618,7 @@ int cdrom_handle_cmd(ide_config *ide)
 
 
 //error is the atapi sense_key
-void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code, uint8_t ascq_code, bool unit_attention)
+void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code, uint8_t ascq_code, bool unit_attention, uint8_t extra_status)
 {
 	ide->state = IDE_STATE_IDLE;
 	ide->regs.sector_count = 3;
@@ -1629,7 +1629,7 @@ void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code, uint8_t ascq_
 	}
 	else
 	{
-		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ | (error ? ATA_STATUS_ERR : 0);
+		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ | (error ? ATA_STATUS_ERR : 0) | extra_status;
 		ide->regs.error = error << 4;
 		ide->drive[ide->regs.drv].atapi_sense_key = error;
 		ide->drive[ide->regs.drv].atapi_asc_code = asc_code;

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -50,6 +50,7 @@
 #define CD_ASC_CODE_COMMAND_SEQUENCE_ERR 0x2C
 #define CD_ASC_CODE_ILLEGAL_OPCODE 0x20
 #define CD_ASC_CODE_ILLEGAL_FIELD_CMD_PACKET 0x24
+#define CD_ASC_CODE_MEDIUM_MAY_HAVE_CHANGED 0x28
 
 
 typedef struct
@@ -1216,6 +1217,12 @@ static int get_sense(drive_t *drv)
 
 	default:
 		set_sense(drv->atapi_sense_key, drv->atapi_asc_code, drv->atapi_ascq_code);
+		if (drv->atapi_sense_key == CD_ERR_UNIT_ATTENTION)
+		{
+			drv->atapi_sense_key = 0;
+			drv->atapi_asc_code = 0;
+			drv->atapi_ascq_code = 0;
+		}
 		break;
 	}
 
@@ -1626,6 +1633,9 @@ void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code, uint8_t ascq_
 		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ | ATA_STATUS_ERR;
 		ide->regs.error = (CD_ERR_UNIT_ATTENTION << 4) | ATA_ERR_MC;
 		ide->drive[ide->regs.drv].mcr_flag = false;
+		ide->drive[ide->regs.drv].atapi_sense_key = CD_ERR_UNIT_ATTENTION;
+		ide->drive[ide->regs.drv].atapi_asc_code = CD_ASC_CODE_MEDIUM_MAY_HAVE_CHANGED;
+		ide->drive[ide->regs.drv].atapi_ascq_code = 0;
 	}
 	else
 	{

--- a/ide_cdrom.h
+++ b/ide_cdrom.h
@@ -3,7 +3,7 @@
 
 int cdrom_handle_cmd(ide_config *ide);
 void cdrom_handle_pkt(ide_config *ide);
-void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code = 0, uint8_t ascq_code = 0, bool unit_attention = true);
+void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code = 0, uint8_t ascq_code = 0, bool unit_attention = true, uint8_t extra_status = 0);
 void cdrom_read(ide_config *ide);
 void cdrom_mode_select(ide_config *ide);
 void ide_cdda_send_sector();


### PR DESCRIPTION
Fixes #1239.

## The bug

Mounting a CD and accessing it from MS-DOS with **VIDE-CDD.SYS + MSCDEX** stalls ~1 minute on the first access after every mount. OAKCDROM.SYS is unaffected. @atomontage bisected it to 230b7bd (#1221) and b29f171 (#1224) — both mine.

## Root cause

**VIDE-CDD.SYS polls the DSC status bit after every ATAPI SEEK, and both of those commits stopped asserting it.**

SFF-8020i — the ATAPI CD-ROM spec these DOS-era drivers target — defines status bit 4 as **DSC, "drive seek complete"**. SEEK is asynchronous: it returns immediately and the drive raises DSC once the head has arrived, so a driver issues SEEK and then polls DSC. VIDE-CDD does exactly that. #1221 and #1224 both stopped auto-asserting bit 4 for CD drives, so DSC never arrives and the driver waits out its full **30 s command timeout on every seek**.

I instrumented the host side and traced ATAPI packet commands on a DE10-Nano. The correlation is exact: **3 SEEKs, 3 stalls of exactly 30.0 s, one immediately after each SEEK.** Nothing else stalls — TEST UNIT READY completes with a byte-identical status 314 times and is always fine, because nothing else waits on bit 4. That's also why OAKCDROM is unaffected: it doesn't use SEEK this way.

## Why the fix isn't just "put the bit back"

For a **packet** device bit 4 is **SERVICE**, not DSC, and Win9x's ESDI_506 rejects the channel (Device Manager Code 10) if it ever reads as a standing 1 — which is what #1221 was fixing in the first place. `ide.h` documents both meanings on the same bit (`ATA_STATUS_DSC` / `ATA_STATUS_SERV`).

I built and tested a blanket restore on hardware: it cures VIDE-CDD **and brings the Code 10 straight back** (Win98 issues INQUIRY, then goes silent).

So this PR publishes bit 4 **only from the SEEK completion**, where it means DSC, and leaves every other status read at 0. `cdrom_reply()` gains an `extra_status` parameter; SEEK passes `ATA_STATUS_DSC`. Nothing else in the ATAPI path changes. It's 4 changed lines.

(It has to be a parameter rather than a second `ide_set_regs()` call, because `ATA_STATUS_IRQ` is our internal "rise IRQ" flag — publishing twice would double-fire the interrupt.)

## Measured on hardware

DE10-Nano, identical 135 s window, DOS reading files off a CD in a loop:

| | Release 20260707 | + this PR |
|---|---|---|
| 30 s stalls | 3 (one per SEEK) | **0** |
| CD sector reads | 1045 | **5205** |
| reads/sec | 7.8 | **38.3** |

Regression-tested on the same rig:

- **Win98 SE protected mode** — ATAPI channel still enumerated and polled for the full run, same `DEVICE RESET → INQUIRY → MODE SENSE ×2 → TEST UNIT READY` sequence as the current release. No Code 10.
- **OAKCDROM.SYS real mode** — byte-identical packet trace to the current release.

## Second commit (separate bug, not the cause of #1239)

`cdrom_reply()`'s media-change UNIT ATTENTION branch sets the ATA error register to sense key 6 but never stores the matching sense data, so the guest's mandatory REQUEST SENSE comes back **NO SENSE** — the drive fails a command with UNIT ATTENTION and then reports that nothing is wrong. This commit stores sense key 6 / ASC 0x28 (MEDIUM MAY HAVE CHANGED) / ASCQ 0 and clears it once reported, matching what 86Box does.

To be clear, this is **not** what caused the stall — the trace shows the guest getting NO SENSE back and recovering anyway. It's kept as its own commit so the #1239 fix stays bisectable, and can be dropped if you'd rather take it separately.
