### PR TITLE
chd: decompress the next hunk ahead of the read that needs it

### DIFF
--- a/ide.h
+++ b/ide.h
@@ -108,6 +108,7 @@ struct drive_t
 	chd_file *chd_f;
 	int      chd_hunknum;
 	uint8_t	 *chd_hunkbuf;
+	chd_prefetch *chd_pf;
 	uint32_t  chd_total_size;
 	uint32_t  chd_last_partial_lba;
 

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -306,6 +306,7 @@ static const char* load_chd_file(drive_t *drv, const char *chdfile)
 	drv->chd_hunkbuf = (uint8_t *)malloc(tmpTOC.chd_hunksize);
 	drv->chd_hunknum = -1;
 	drv->chd_f = tmpTOC.chd_f;
+	drv->chd_pf = mister_chd_prefetch_create(drv->chd_f, tmpTOC.chd_hunksize);
 
 	//don't use add_track, just do it ourselves...
 	for (int i = 0; i < tmpTOC.last; i++)
@@ -1065,7 +1066,7 @@ void cdrom_read(ide_config *ide)
 		for (uint32_t i = 0; i < cnt; i++)
 		{
 
-			if (mister_chd_read_sector(drive->chd_f, drive->chd_last_partial_lba + drive->track[drive->data_num].chd_offset, d_offset, hdr, 2048, ide_buf, drive->chd_hunkbuf, &drive->chd_hunknum) != CHDERR_NONE)
+			if (mister_chd_read_sector(drive->chd_f, drive->chd_last_partial_lba + drive->track[drive->data_num].chd_offset, d_offset, hdr, 2048, ide_buf, drive->chd_hunkbuf, &drive->chd_hunknum, drive->chd_pf) != CHDERR_NONE)
 			{
 				//I don't think anything else uses this, but set it just in case.
 				ide->null = 1;
@@ -1653,6 +1654,9 @@ void cdrom_reply(ide_config *ide, uint8_t error, uint8_t asc_code, uint8_t ascq_
 void cdrom_close_chd(drive_t *drv)
 {
 
+	// Before chd_close(): the worker may still be inside chd_read() on it.
+	mister_chd_prefetch_destroy(&drv->chd_pf);
+
 	if (drv->chd_f)
 	{
 		chd_close(drv->chd_f);
@@ -1728,7 +1732,7 @@ void ide_cdda_send_sector()
 	{
 		if (drv->chd_f)
 		{
-			mister_chd_read_sector(drv->chd_f, drv->play_start_lba + drv->track[drv->data_num].chd_offset, 0, 0, BYTES_PER_RAW_REDBOOK_FRAME, cdda_buf, drv->chd_hunkbuf, &drv->chd_hunknum);
+			mister_chd_read_sector(drv->chd_f, drv->play_start_lba + drv->track[drv->data_num].chd_offset, 0, 0, BYTES_PER_RAW_REDBOOK_FRAME, cdda_buf, drv->chd_hunkbuf, &drv->chd_hunknum, drv->chd_pf);
 			needs_swap = true;
 		}
 		else

--- a/offload.cpp
+++ b/offload.cpp
@@ -100,6 +100,29 @@ void offload_stop()
 	printf("Done\n");
 }
 
+bool offload_try_add_work(std::function<void()> handler)
+{
+	PROFILE_FUNCTION();
+
+	pthread_mutex_lock(&s_queue_lock);
+
+	if ((s_queue_head - s_queue_tail) == QUEUE_SIZE)
+	{
+		pthread_mutex_unlock(&s_queue_lock);
+		return false;
+	}
+
+	Work *work = &s_queue[s_queue_head % QUEUE_SIZE];
+	work->handler = handler;
+
+	s_queue_head++;
+
+	pthread_cond_signal(&s_cond_work);
+
+	pthread_mutex_unlock(&s_queue_lock);
+	return true;
+}
+
 void offload_add_work(std::function<void()> handler)
 {
 	PROFILE_FUNCTION();

--- a/offload.cpp
+++ b/offload.cpp
@@ -106,7 +106,7 @@ bool offload_try_add_work(std::function<void()> handler)
 
 	pthread_mutex_lock(&s_queue_lock);
 
-	if ((s_queue_head - s_queue_tail) == QUEUE_SIZE)
+	if ((s_queue_head - s_queue_tail) >= QUEUE_SIZE)
 	{
 		pthread_mutex_unlock(&s_queue_lock);
 		return false;

--- a/offload.h
+++ b/offload.h
@@ -9,4 +9,11 @@ void offload_stop();
 
 void offload_add_work(std::function<void()> work);
 
+// Non-blocking variant: returns false and enqueues nothing if the queue is
+// full, instead of waiting for a slot. For callers on the main thread that
+// have a synchronous fallback and must never block -- offload_add_work()
+// blocks on a full queue, which would stall the very loop the offload is
+// meant to keep moving.
+bool offload_try_add_work(std::function<void()> work);
+
 #endif

--- a/support/3do/3do.h
+++ b/support/3do/3do.h
@@ -1,6 +1,8 @@
 #ifndef P3DO_H
 #define P3DO_H
 
+struct chd_prefetch;
+
 #include "../../cd.h"
 
 //#define P3DO_DEBUG				1
@@ -59,6 +61,7 @@ private:
 	uint8_t cd_buf[4096 + 2];
 	int chd_hunknum;
 	uint8_t *chd_hunkbuf;
+	chd_prefetch *chd_pf;
 
 	int LoadCUE(const char* filename);
 	int LoadISO(const char* filename);

--- a/support/3do/3docdd.cpp
+++ b/support/3do/3docdd.cpp
@@ -20,6 +20,7 @@ p3docdd_t::p3docdd_t() {
 	lba = 0;
 	speed = 0;
 	chd_hunkbuf = NULL;
+	chd_pf = NULL;
 	chd_hunknum = -1;
 	SendData = NULL;
 }
@@ -348,6 +349,7 @@ int p3docdd_t::Load(const char *filename)
 
 		this->chd_hunkbuf = (uint8_t *)malloc(this->toc.chd_hunksize);
 		this->chd_hunknum = -1;
+		this->chd_pf = mister_chd_prefetch_create(this->toc.chd_f, this->toc.chd_hunksize);
 		if (this->toc.tracks[0].sector_size)
 		{
 			this->sectorSize = this->toc.tracks[0].sector_size;
@@ -359,7 +361,7 @@ int p3docdd_t::Load(const char *filename)
 
 	/*if (this->toc.chd_f)
 	{
-		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum);
+		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 	}
 	else {
 		fd_img = &this->toc.tracks[0].f;
@@ -393,6 +395,9 @@ void p3docdd_t::Unload()
 {
 	if (this->loaded)
 	{
+		// Before chd_close(): the worker may still be inside chd_read() on it.
+		mister_chd_prefetch_destroy(&this->chd_pf);
+
 		if (this->toc.chd_f)
 		{
 			chd_close(this->toc.chd_f);
@@ -687,7 +692,7 @@ void p3docdd_t::ReadData(uint8_t *buf)
 				read_offset += 16;
 			}
 
-			mister_chd_read_sector(this->toc.chd_f, lba_ + this->toc.tracks[this->track].offset, read_offset, 0, this->sectorSize, buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, lba_ + this->toc.tracks[this->track].offset, read_offset, 0, this->sectorSize, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		}
 		else {
 			if (this->sectorSize == 2048)

--- a/support/cdi/cdi.cpp
+++ b/support/cdi/cdi.cpp
@@ -74,6 +74,7 @@ static enum DiscType disc_type = DT_CDDA;
 
 static uint8_t* chd_hunkbuf = NULL;
 static int chd_hunknum;
+static chd_prefetch *chd_pf = NULL;
 static toc_t toc = {};
 CdgUnpacker cdg_unpack;
 bool sub_loaded_from_cdg;
@@ -113,6 +114,8 @@ static int sgets(char* out, int sz, char** in)
 
 static void unload_chd(toc_t* table)
 {
+	// Before chd_close(): the worker may still be inside chd_read() on it.
+	mister_chd_prefetch_destroy(&chd_pf);
 	if (table->chd_f)
 	{
 		chd_close(table->chd_f);
@@ -170,6 +173,7 @@ static int load_chd(const char* filename, toc_t* table)
 
 	chd_hunkbuf = (uint8_t*)malloc(table->chd_hunksize);
 	chd_hunknum = -1;
+	chd_pf = mister_chd_prefetch_create(table->chd_f, table->chd_hunksize);
 
 	return 1;
 }
@@ -970,7 +974,7 @@ void cdi_read_cd(uint8_t* buffer, int lba, int cnt)
 													   CDI_SECTOR_LEN,
 													   buffer,
 													   chd_hunkbuf,
-													   &chd_hunknum) == CHDERR_NONE)
+													   &chd_hunknum, chd_pf) == CHDERR_NONE)
 							{
 								if (!toc.tracks[i].type) // CHD requires byteswap of audio data
 								{
@@ -997,7 +1001,7 @@ void cdi_read_cd(uint8_t* buffer, int lba, int cnt)
 														   subc.size(),
 														   subc.data(),
 														   chd_hunkbuf,
-														   &chd_hunknum) == CHDERR_NONE)
+														   &chd_hunknum, chd_pf) == CHDERR_NONE)
 								{
 									subc_filled = true;
 								}

--- a/support/chd/mister_chd.cpp
+++ b/support/chd/mister_chd.cpp
@@ -5,8 +5,11 @@
 #include <string.h>
 #include <inttypes.h>
 #include <time.h>
+#include <pthread.h>
 #include "../../file_io.h"
 #include "../../cd.h"
+#include "../../offload.h"
+#include "../../profiling.h"
 #include "mister_chd.h"
 
 void lba_to_hunkinfo(chd_file *chd_f, int lba, int *hunknumber, int *hunkoffset)
@@ -160,8 +163,153 @@ chd_error mister_load_chd(const char *filename, toc_t *cd_toc)
 	return CHDERR_NONE;
 }
 
-chd_error mister_chd_read_sector(chd_file *chd_f, int lba, uint32_t d_offset, uint32_t s_offset, int length, uint8_t *destbuf, uint8_t *hunkbuf, int *hunknum)
+
+// ===========================================================================
+//  DECOMPRESS-AHEAD
+// ===========================================================================
+//
+// mister_chd_read_sector() below caches exactly one hunk. Because
+// hunknum = lba / sectors_per_hunk and CD playback walks LBAs in order, a
+// sequential read misses on the FIRST sector of every hunk and then hits for
+// the rest -- with the common 8 sectors/hunk geometry, every 8th sector pays a
+// full synchronous chd_read(). On a DE10-Nano that decompress measures ~6 ms,
+// and because it runs on the main thread it stalls everything else the loop
+// does (FPGA servicing, input, OSD) for that whole time.
+//
+// The access pattern is perfectly predictable, so the fix is just to decompress
+// hunk N+1 while the core is still consuming hunk N. At 2x CD speed a hunk is
+// ~26.7 ms of playback against a ~6 ms decompress, so the prefetch has ample
+// time to land.
+//
+// Two constraints shape this:
+//
+//   1. chd_file is NOT thread-safe. Exactly one thread may be inside
+//      chd_read() for a given handle at a time. Only the main thread ever
+//      schedules, and it always waits for an in-flight prefetch to finish
+//      before doing its own chd_read(), so the two never overlap.
+//
+//   2. offload_add_work() BLOCKS when its queue is full, and that queue is
+//      shared with scaler/video work. Blocking there would stall the very loop
+//      this is meant to keep moving, so we use offload_try_add_work() and
+//      simply skip the prefetch if there is no slot -- the next miss then
+//      reads synchronously, exactly as before this change.
+//
+// Failure is always soft: any error, full queue, or allocation failure falls
+// back to the original synchronous path.
+
+struct chd_prefetch
 {
+	chd_file *chd_f;
+	uint8_t *buf;
+	uint32_t hunkbytes;
+	int num;              // hunk held in buf, or -1
+	int inflight;         // hunk being decompressed, or -1 when idle
+	chd_error result;
+	pthread_mutex_t lock;
+	pthread_cond_t idle;
+};
+
+chd_prefetch *mister_chd_prefetch_create(chd_file *chd_f, uint32_t hunkbytes)
+{
+	if (!chd_f || !hunkbytes) return NULL;
+
+	chd_prefetch *pf = (chd_prefetch *)calloc(1, sizeof(chd_prefetch));
+	if (!pf) return NULL;
+
+	pf->buf = (uint8_t *)malloc(hunkbytes);
+	if (!pf->buf)
+	{
+		free(pf);
+		return NULL;
+	}
+
+	pf->chd_f = chd_f;
+	pf->hunkbytes = hunkbytes;
+	pf->num = -1;
+	pf->inflight = -1;
+	pf->result = CHDERR_NONE;
+	pthread_mutex_init(&pf->lock, NULL);
+	pthread_cond_init(&pf->idle, NULL);
+	return pf;
+}
+
+void mister_chd_prefetch_destroy(chd_prefetch **pfp)
+{
+	if (!pfp || !*pfp) return;
+	chd_prefetch *pf = *pfp;
+
+	// The worker holds this pointer and reads chd_f/buf through it, so it must
+	// be idle before anything is freed.
+	pthread_mutex_lock(&pf->lock);
+	while (pf->inflight >= 0) pthread_cond_wait(&pf->idle, &pf->lock);
+	pthread_mutex_unlock(&pf->lock);
+
+	pthread_mutex_destroy(&pf->lock);
+	pthread_cond_destroy(&pf->idle);
+	free(pf->buf);
+	free(pf);
+	*pfp = NULL;
+}
+
+// Main thread only.
+static void chd_prefetch_schedule(chd_prefetch *pf, int num)
+{
+	if (num < 0) return;
+
+	pthread_mutex_lock(&pf->lock);
+	if (pf->inflight >= 0 || pf->num == num)
+	{
+		// already fetching something, or already holding what was asked for
+		pthread_mutex_unlock(&pf->lock);
+		return;
+	}
+	pf->inflight = num;
+	pthread_mutex_unlock(&pf->lock);
+
+	if (!offload_try_add_work([pf, num]()
+		{
+			chd_error err = chd_read(pf->chd_f, num, pf->buf);
+
+			pthread_mutex_lock(&pf->lock);
+			pf->result = err;
+			pf->num = (err == CHDERR_NONE) ? num : -1;
+			pf->inflight = -1;
+			pthread_cond_broadcast(&pf->idle);
+			pthread_mutex_unlock(&pf->lock);
+		}))
+	{
+		// No free slot: drop this prefetch rather than block the main thread.
+		pthread_mutex_lock(&pf->lock);
+		pf->inflight = -1;
+		pthread_cond_broadcast(&pf->idle);
+		pthread_mutex_unlock(&pf->lock);
+	}
+}
+
+// Returns true if the wanted hunk was already decompressed and has been copied
+// into hunkbuf. Always leaves the context idle, so the caller may safely enter
+// chd_read() on the same chd_file afterwards.
+static bool chd_prefetch_take(chd_prefetch *pf, int wanted, uint8_t *hunkbuf)
+{
+	bool hit = false;
+
+	pthread_mutex_lock(&pf->lock);
+	while (pf->inflight >= 0) pthread_cond_wait(&pf->idle, &pf->lock);
+
+	if (pf->num == wanted && pf->result == CHDERR_NONE)
+	{
+		memcpy(hunkbuf, pf->buf, pf->hunkbytes);
+		pf->num = -1; // consumed; the next prefetch may reuse the buffer
+		hit = true;
+	}
+	pthread_mutex_unlock(&pf->lock);
+
+	return hit;
+}
+
+chd_error mister_chd_read_sector(chd_file *chd_f, int lba, uint32_t d_offset, uint32_t s_offset, int length, uint8_t *destbuf, uint8_t *hunkbuf, int *hunknum, chd_prefetch *pf)
+{
+	SPIKE_SCOPE("chd_hunk_decompress", 3000);
 
 	int tmphnum = 0;
 	int hunkofs = 0;
@@ -172,13 +320,23 @@ chd_error mister_chd_read_sector(chd_file *chd_f, int lba, uint32_t d_offset, ui
 	//mister_chd_log("READ LBA: %d, dest_offset: %d sector offset: %d length %d chd_f %p\n", lba, d_offset, s_offset, length, chd_f);
 	if (tmphnum != *hunknum)
 	{
-		chd_error err = chd_read(chd_f, tmphnum, hunkbuf);
-		if (err != CHDERR_NONE)
+		// Decompress-ahead may already hold this hunk. Either way the context
+		// is idle afterwards, so the synchronous fallback below cannot race the
+		// worker inside chd_read().
+		if (pf && pf->chd_f != chd_f) pf = NULL; // not this drive's context
+		if (!pf || !chd_prefetch_take(pf, tmphnum, hunkbuf))
 		{
-			mister_chd_log("ERROR %s\n", chd_error_string(err));
-			return err;
+			chd_error err = chd_read(chd_f, tmphnum, hunkbuf);
+			if (err != CHDERR_NONE)
+			{
+				mister_chd_log("ERROR %s\n", chd_error_string(err));
+				return err;
+			}
 		}
 		*hunknum = tmphnum;
+
+		// Sequential playback means the next hunk is almost always next.
+		if (pf) chd_prefetch_schedule(pf, tmphnum + 1);
 	}
 	int sector_offset = hunkofs * CD_FRAME_SIZE;
 	memcpy(destbuf + d_offset, hunkbuf + sector_offset + s_offset, length);

--- a/support/chd/mister_chd.cpp
+++ b/support/chd/mister_chd.cpp
@@ -202,6 +202,7 @@ struct chd_prefetch
 	chd_file *chd_f;
 	uint8_t *buf;
 	uint32_t hunkbytes;
+	uint32_t hunkcount;   // total hunks in the file; N+1 past this is not scheduled
 	int num;              // hunk held in buf, or -1
 	int inflight;         // hunk being decompressed, or -1 when idle
 	chd_error result;
@@ -225,6 +226,8 @@ chd_prefetch *mister_chd_prefetch_create(chd_file *chd_f, uint32_t hunkbytes)
 
 	pf->chd_f = chd_f;
 	pf->hunkbytes = hunkbytes;
+	const chd_header *hdr = chd_get_header(chd_f);
+	pf->hunkcount = hdr ? hdr->totalhunks : 0;
 	pf->num = -1;
 	pf->inflight = -1;
 	pf->result = CHDERR_NONE;
@@ -255,6 +258,9 @@ void mister_chd_prefetch_destroy(chd_prefetch **pfp)
 static void chd_prefetch_schedule(chd_prefetch *pf, int num)
 {
 	if (num < 0) return;
+	// Do not prefetch past the last hunk: at end-of-disc N+1 does not exist, so
+	// scheduling it would burn an offload slot on a chd_read() that only fails.
+	if (pf->hunkcount && (uint32_t)num >= pf->hunkcount) return;
 
 	pthread_mutex_lock(&pf->lock);
 	if (pf->inflight >= 0 || pf->num == num)

--- a/support/chd/mister_chd.h
+++ b/support/chd/mister_chd.h
@@ -5,7 +5,20 @@
 #include <libchdr/cdrom.h>
 #include "../../cd.h"
 
-chd_error mister_chd_read_sector(chd_file *chd_f, int lba, uint32_t d_offset, uint32_t s_offset, int length, uint8_t *destbuf, uint8_t *hunkbuf, int *hunknum);
+// Opaque decompress-ahead context. One per drive (IDE can have two CD drives
+// mounted at once, so this cannot be global state).
+struct chd_prefetch;
+
+// hunkbytes must match the size of the hunkbuf passed to mister_chd_read_sector
+// (i.e. toc_t::chd_hunksize). Returns NULL on allocation failure, which is not
+// fatal -- callers pass NULL through and get the original synchronous path.
+chd_prefetch *mister_chd_prefetch_create(chd_file *chd_f, uint32_t hunkbytes);
+
+// Waits for any in-flight decompress to finish before freeing, then NULLs the
+// caller's pointer. Must be called before the chd_file is closed.
+void mister_chd_prefetch_destroy(chd_prefetch **pf);
+
+chd_error mister_chd_read_sector(chd_file *chd_f, int lba, uint32_t d_offset, uint32_t s_offset, int length, uint8_t *destbuf, uint8_t *hunkbuf, int *hunknum, chd_prefetch *pf = nullptr);
 chd_error mister_load_chd(const char *filename, toc_t *cd_toc);
 
 #endif

--- a/support/megacd/megacd.h
+++ b/support/megacd/megacd.h
@@ -1,6 +1,8 @@
 #ifndef MEGACD_H
 #define MEGACD_H
 
+struct chd_prefetch;
+
 
 // CDD status
 #define CD_STAT_STOP			0x00
@@ -71,6 +73,7 @@ private:
 	int audioOffset;
 	int chd_hunknum;
 	uint8_t *chd_hunkbuf;
+	chd_prefetch *chd_pf;
 	int chd_audio_read_lba;
 	uint8_t stat[10];
 	uint8_t comm[10];

--- a/support/megacd/megacdd.cpp
+++ b/support/megacd/megacdd.cpp
@@ -21,6 +21,7 @@ cdd_t::cdd_t() {
 	audioLength = 0;
 	audioOffset = 0;
 	chd_hunkbuf = NULL;
+	chd_pf = NULL;
 	chd_hunknum = -1;
 	SendData = NULL;
 	CanSendData = NULL;
@@ -266,6 +267,7 @@ int cdd_t::Load(const char *filename)
 
 		this->chd_hunkbuf = (uint8_t *)malloc(this->toc.chd_hunksize);
 		this->chd_hunknum = -1;
+		this->chd_pf = mister_chd_prefetch_create(this->toc.chd_f, this->toc.chd_hunksize);
  	} else {
 		return (-1);
 
@@ -273,7 +275,7 @@ int cdd_t::Load(const char *filename)
 
 	if (this->toc.chd_f)
 	{
-		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum);
+		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 	} else {
 		fd_img = &this->toc.tracks[0].f;
 
@@ -313,6 +315,9 @@ void cdd_t::Unload()
 {
 	if (this->loaded)
 	{
+		// Before chd_close(): the worker may still be inside chd_read() on it.
+		mister_chd_prefetch_destroy(&this->chd_pf);
+
 		if (this->toc.chd_f)
 		{
 			chd_close(this->toc.chd_f);
@@ -928,7 +933,7 @@ void cdd_t::ReadData(uint8_t *buf)
 				read_offset += 16;
 			}
 
-			mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[0].offset, 0, read_offset, 2048, buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[0].offset, 0, read_offset, 2048, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		} else {
 			if (this->sectorSize == 2048)
 			{
@@ -958,7 +963,7 @@ int cdd_t::ReadCDDA(uint8_t *buf)
 	{
 		for(int i = 0; i < this->audioLength / 2352; i++)
 		{
-			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 2352*i, 0, 2352, buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 2352*i, 0, 2352, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		}
 
 		//CHD audio requires byteswap. There's probably a better way to do this...
@@ -1005,9 +1010,9 @@ int cdd_t::ReadSubcode(uint16_t* buf)
 	{
 		//Just use the read sector call with an offset, since we previously read that sector, it is already in the hunk cache
 		if (this->toc.tracks[this->index].sbc_type == SUBCODE_RW_RAW) {
-			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 0, CD_MAX_SECTOR_DATA, 96, (uint8_t *)buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 0, CD_MAX_SECTOR_DATA, 96, (uint8_t *)buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		} else if (this->toc.tracks[this->index].sbc_type == SUBCODE_RW) {
-			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 0, CD_MAX_SECTOR_DATA, 96, subc, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->index].offset, 0, CD_MAX_SECTOR_DATA, 96, subc, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 			InterleaveSubcode(subc, buf);
 		} else {
 			err = -1;

--- a/support/pcecd/pcecd.h
+++ b/support/pcecd/pcecd.h
@@ -1,6 +1,8 @@
 #ifndef PCECD_H
 #define PCECD_H
 
+struct chd_prefetch;
+
 // CDD command
 #define PCECD_COMM_TESTUNIT			0x00
 #define PCECD_COMM_REQUESTSENSE		0x03
@@ -105,6 +107,7 @@ private:
 	sense_t sense;
 	uint8_t region;
 	uint8_t *chd_hunkbuf;
+	chd_prefetch *chd_pf;
 	int chd_hunknum;
 
 	uint16_t stat;

--- a/support/pcecd/pcecdd.cpp
+++ b/support/pcecd/pcecdd.cpp
@@ -19,6 +19,7 @@ float get_cd_seek_ms(int start_sector, int target_sector);
 pcecdd_t pcecdd;
 
 pcecdd_t::pcecdd_t() {
+	this->chd_pf = NULL;
 	latency = 0;
 	audiodelay = 0;
 	loaded = 0;
@@ -271,6 +272,7 @@ int pcecdd_t::Load(const char *filename)
 
 		this->chd_hunkbuf = (uint8_t *)malloc(this->toc.chd_hunksize);
 		this->chd_hunknum = -1;
+		this->chd_pf = mister_chd_prefetch_create(this->toc.chd_f, this->toc.chd_hunksize);
 	} else {
 		return -1;
 	}
@@ -303,6 +305,9 @@ void pcecdd_t::Unload()
 {
 	if (this->loaded)
 	{
+		// Before chd_close(): the worker may still be inside chd_read() on it.
+		mister_chd_prefetch_destroy(&this->chd_pf);
+
 		if (this->toc.chd_f)
 		{
 			chd_close(this->toc.chd_f);
@@ -917,7 +922,7 @@ void pcecdd_t::ReadData(uint8_t *buf)
 				s_offset += 16;
 			}
 
-			mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[this->index].offset, 0, s_offset, 2048, buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[this->index].offset, 0, s_offset, 2048, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		} else {
 			if (this->toc.tracks[this->index].sector_size == 2048)
 			{
@@ -938,7 +943,7 @@ int pcecdd_t::ReadCDDA(uint8_t *buf)
 
 	if (this->toc.chd_f)
 	{
-		mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[this->index].offset, 0, 0, this->audioLength, buf, this->chd_hunkbuf, &this->chd_hunknum);
+		mister_chd_read_sector(this->toc.chd_f, this->lba + this->toc.tracks[this->index].offset, 0, 0, this->audioLength, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		for (int swapidx = 0; swapidx < this->audioLength; swapidx += 2)
 		{
 			uint8_t temp = buf[swapidx];

--- a/support/psx/psx.cpp
+++ b/support/psx/psx.cpp
@@ -18,6 +18,7 @@
 static char buf[1024];
 static uint8_t *chd_hunkbuf = NULL;
 static int chd_hunknum;
+static chd_prefetch *chd_pf = NULL;
 static int noreset = 0;
 
 static int sgets(char *out, int sz, char **in)
@@ -105,6 +106,8 @@ static uint16_t libCryptMask(fileTYPE* sbi_file)
 
 static void unload_chd(toc_t *table)
 {
+	// Before chd_close(): the worker may still be inside chd_read() on it.
+	mister_chd_prefetch_destroy(&chd_pf);
 	if (table->chd_f)
 	{
 		chd_close(table->chd_f);
@@ -157,6 +160,7 @@ static int load_chd(const char *filename, toc_t *table)
 
 	chd_hunkbuf = (uint8_t *)malloc(table->chd_hunksize);
 	chd_hunknum = -1;
+	chd_pf = mister_chd_prefetch_create(table->chd_f, table->chd_hunksize);
 
 	return 1;
 }
@@ -516,7 +520,7 @@ void psx_read_cd(uint8_t *buffer, int lba, int cnt)
 
 							// The "fake" 150 sector pregap moves all the LBAs up by 150, so adjust here to read where the core actually wants data from
 							int read_lba = lba - toc.tracks[0].indexes[1];
-							if (mister_chd_read_sector(toc.chd_f, (read_lba + toc.tracks[i].offset), 0, 0, CD_SECTOR_LEN, buffer, chd_hunkbuf, &chd_hunknum) == CHDERR_NONE)
+							if (mister_chd_read_sector(toc.chd_f, (read_lba + toc.tracks[i].offset), 0, 0, CD_SECTOR_LEN, buffer, chd_hunkbuf, &chd_hunknum, chd_pf) == CHDERR_NONE)
 							{
 								if (!toc.tracks[i].type) //CHD requires byteswap of audio data
 								{

--- a/support/saturn/saturn.h
+++ b/support/saturn/saturn.h
@@ -1,6 +1,8 @@
 #ifndef SATURN_H
 #define SATURN_H
 
+struct chd_prefetch;
+
 #include "../../cd.h"
 
 //#define SATURN_DEBUG				1
@@ -88,6 +90,7 @@ private:
 	int audioFirst;
 	int chd_hunknum;
 	uint8_t *chd_hunkbuf;
+	chd_prefetch *chd_pf;
 	int chd_audio_read_lba;
 
 

--- a/support/saturn/saturncdd.cpp
+++ b/support/saturn/saturncdd.cpp
@@ -29,6 +29,7 @@ satcdd_t::satcdd_t() {
 	audioLength = 0;
 	audioFirst = 0;
 	chd_hunkbuf = NULL;
+	chd_pf = NULL;
 	chd_hunknum = -1;
 	SendData = NULL;
 
@@ -343,6 +344,7 @@ int satcdd_t::Load(const char *filename)
 
 		this->chd_hunkbuf = (uint8_t *)malloc(this->toc.chd_hunksize);
 		this->chd_hunknum = -1;
+		this->chd_pf = mister_chd_prefetch_create(this->toc.chd_f, this->toc.chd_hunksize);
 		if (this->toc.tracks[0].sector_size)
 		{
 			this->sectorSize = this->toc.tracks[0].sector_size;
@@ -355,7 +357,7 @@ int satcdd_t::Load(const char *filename)
 
 	/*if (this->toc.chd_f)
 	{
-		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum);
+		mister_chd_read_sector(this->toc.chd_f, 0, 0, 0, 0x10, (uint8_t *)header, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 	}
 	else {
 		fd_img = &this->toc.tracks[0].f;
@@ -398,6 +400,9 @@ void satcdd_t::Unload()
 {
 	if (this->loaded)
 	{
+		// Before chd_close(): the worker may still be inside chd_read() on it.
+		mister_chd_prefetch_destroy(&this->chd_pf);
+
 		if (this->toc.chd_f)
 		{
 			chd_close(this->toc.chd_f);
@@ -441,7 +446,7 @@ int satcdd_t::GetBootHeader(uint8_t *buf) {
 
 	if (this->toc.chd_f)
 	{
-		mister_chd_read_sector(this->toc.chd_f, 0, 0, offset, 256, buf, this->chd_hunkbuf, &this->chd_hunknum);
+		mister_chd_read_sector(this->toc.chd_f, 0, 0, offset, 256, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 	}
 	else 
 	{
@@ -1202,7 +1207,7 @@ void satcdd_t::ReadData(uint8_t *buf)
 				read_offset += 16;
 			}
 
-			mister_chd_read_sector(this->toc.chd_f, lba_ + this->toc.tracks[this->track].offset, read_offset, 0, this->toc.tracks[this->track].sector_size, buf, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, lba_ + this->toc.tracks[this->track].offset, read_offset, 0, this->toc.tracks[this->track].sector_size, buf, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 		}
 		else {
 			if (this->toc.tracks[this->track].sector_size == 2048)
@@ -1234,7 +1239,7 @@ int satcdd_t::ReadCDDA(uint8_t *buf, int first)
 	{
 		for (int i = sec_offs; i < 2; i++, dest += 4096)
 		{
-			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->track].offset + i, 0, 0, 2352, dest, this->chd_hunkbuf, &this->chd_hunknum);
+			mister_chd_read_sector(this->toc.chd_f, this->chd_audio_read_lba + this->toc.tracks[this->track].offset + i, 0, 0, 2352, dest, this->chd_hunkbuf, &this->chd_hunknum, this->chd_pf);
 
 			//CHD audio requires byteswap. There's probably a better way to do this...
 			for (int swapidx = 0; swapidx < 2352; swapidx += 2)


### PR DESCRIPTION
> **TL;DR** — CHD keeps exactly one decompressed hunk. Playback is sequential, so every 8th
> sector crosses a hunk boundary and pays a ~5 ms `chd_read()` **on the main thread**, stalling
> FPGA servicing / input / OSD. This decompresses the *next* hunk on the existing offload worker
> while the current one plays. Measured on PSX and MegaCD across three titles: p90 sector cost
> 5,284 → 61 µs, main-thread time blocked in CHD reads down ~40x. Defaults to the old synchronous
> path, so it is inert where it can't help. 16 files, +270/−24. Everything below is detail and
> reproduction — the code and the `make PROFILING=1` numbers are the substance.

---

## Summary

`mister_chd_read_sector()` caches exactly one hunk. Because `hunknum = lba / sectors_per_hunk`
and CD playback walks LBAs in order, a sequential read **misses on the first sector of every hunk
and hits for the rest** — with the standard 8 sectors/hunk geometry, every 8th sector pays a full
synchronous `chd_read()`.

On a DE10-Nano that decompress measures **~5 ms** for an LZMA-compressed data hunk. Because it
runs on the main thread, it doesn't just delay the sector that missed — it stalls FPGA servicing,
input handling and OSD updates along with it.

This PR decompresses hunk N+1 on the **existing offload worker** while the core is still consuming
hunk N. The access pattern is perfectly predictable, so the prediction is essentially always
correct, and there is ample headroom: at 2x CD speed a hunk is ~26.7 ms of playback against a
~5 ms decompress.

Measured across three titles on two cores: **p90 sector-read cost drops 20–87x, and main-thread
time blocked in CHD reads falls by 10–40x.**

## The defect

`support/chd/mister_chd.cpp`:

```c
if (tmphnum != *hunknum)
{
    chd_error err = chd_read(chd_f, tmphnum, hunkbuf);   // ~5 ms, on the main thread
    ...
    *hunknum = tmphnum;
}
```

One `hunkbuf`, one `*hunknum`. These are *compulsory* misses on a single-entry cache — not a
workload artifact. Three independent lines of evidence agree the ratio is exactly one miss per
eight sectors:

1. **From the code** — `hunknum = lba / sectors_per_hunk`, with sequential LBAs.
2. **From the CHD format** — every test image has `hunkbytes=19584, unitbytes=2448` → **8
   sectors/hunk**.
3. **From measurement** — `reads/miss` = 8.01, 8.01, 8.01, 8.01, 7.98 across five runs.

## Results

Same game, same scene, two builds identical except `mister_chd_prefetch_create()` (the baseline
build stubs it to `return NULL`, forcing the original synchronous path). Verified distinct by
md5. Read counts match within each pair, so the prefetch is the only variable. All percentiles
**unfiltered**.

| run | core | p90 OFF → ON | main thread blocked, OFF → ON | stalls >1 ms | reads/miss |
|---|---|---|---|---|---|
| Legend of Dragoon (run 1) | PSX | 5,284 → **61.0 µs** | 11.0% → **0.26%** of wall | 377 → **2** | 8.01 |
| Legend of Dragoon (run 2) | PSX | 5,127 → **59.9 µs** | 10.2% → **0.34%** | 379 → **3** | 8.01 |
| Lunar – Silver Star (`cdzl`) | MegaCD | 1,267 → **61.2 µs** | 1.34% → **0.13%** | 377 → **0** | 8.01 |
| Lunar – Silver Star (`cdlz`) | MegaCD | 1,791 → **64.4 µs** | 2.00% → **0.14%** | 377 → **1** | 8.01 |
| Dragon's Lair | MegaCD | 2,291 → **60.3 µs** | 3.62% → **0.12%** | 356 → **2** | 7.98 |

Legend of Dragoon, run 1, in full (µs, 20 s window, n=3018 in both arms):

| metric | before | after | |
|---|---|---|---|
| p50 | 5.5 | 5.3 | unchanged — these are cache hits |
| **p90** | **5,284.1** | **61.0** | **86.7x** |
| p99 | 6,454.0 | 73.8 | 87x |
| mean | 727.4 | 17.4 | 42x |
| **total blocked** | **2,195.4 ms** | **52.6 ms** | **41.7x** |

The distribution is sharply bimodal, which is the signature of the defect: in the baseline,
**12.5% of sectors account for 98–99% of all sector-read time**. Post-patch, p90 lands at
60–64 µs in every run regardless of how expensive the underlying miss was.

**CPU utilisation shows none of this** — CPU1 sits at 100.0% in every arm, before and after. The
loop is busy either way; it simply completes more useful iterations. That is likely why this has
gone unnoticed: any measurement based on CPU% concludes nothing is wrong.

## Why the cost varies by title: codec, not core

MegaCD initially appeared far cheaper than PSX. It isn't — the variable is what the hunks contain:

| title | core | codec / content | median stall |
|---|---|---|---|
| Lunar (web-converted) | MegaCD | `cdzl` only | 1,286 µs |
| Lunar (chdman default) | MegaCD | `cdlz`, 52 tracks, audio-heavy → mostly FLAC | 2,052 µs |
| **Dragon's Lair** | **MegaCD** | **`cdlz`, laserdisc FMV → all data** | **4,862 µs** |
| Legend of Dragoon | PSX | `cdlz`, FMV | ~5,166 µs |

Dragon's Lair on MegaCD (4,862 µs) matches Legend of Dragoon on PSX (5,166 µs) despite a different
core. Lunar is cheap only because 52 of its tracks are CD-audio, which `cdfl`/FLAC decodes
quickly. **The core is not the variable; the codec and the data/audio mix are.**

A controlled check: rebuilding the *same disc* with `chdman createcd` defaults, after it had been
produced by a converter emitting `cdzl` only — same disc, same scene, same 8 sectors/hunk — raised
per-miss cost **1.60x** (1,286 → 2,052 µs) while `reads/miss` stayed at 8.01.

Two consequences worth noting:

- **Better compression makes the stall worse.** That rebuild saved 173 MB *and* raised blocked
  time from 537.8 ms to 799.8 ms per 40 s window. Users with well-compressed libraries pay the
  most today.
- Since `cdlz` is chdman's default and data hunks dominate any FMV-heavy title, **~5 ms per miss
  is the typical case** for real-world CHDs, not a worst case.

## Methodology

Built with `make PROFILING=1`, using the existing `SPIKE_SCOPE` machinery in `profiling.h`.

One caveat worth reporting on its own: the `printf` spike report in `profiling.cpp` **cannot be
captured for the process that plays the game**. MiSTer starts a fresh process on core load
(`app_restart()`), and that process's block-buffered stdout is discarded rather than flushed when
it exits — so the report produces nothing at all, even with the threshold lowered to 1 µs. I used
a small local patch that appends one JSON line per scope with a raw `write()`, which survives both
the process handoff and SIGKILL. **It is not part of this PR**; happy to submit it separately if
useful, since that blind spot exists regardless of this change.

Filtering is by scope **name** only, never by duration. A duration filter would cut a ~7 µs cache
hit and a ~5 ms miss at completely different rates and manufacture the very result being measured.

## Implementation

Two constraints shaped this, both worth reviewer attention:

1. **`chd_file` is not thread-safe.** Only one thread may be inside `chd_read()` for a given handle
   at a time. Only the main thread schedules, and it always waits for an in-flight prefetch to
   finish before doing its own `chd_read()`, so the two never overlap.

2. **`offload_add_work()` blocks when its queue is full**, and that queue is shared with
   scaler/video work. Blocking there would stall the very loop this is meant to keep moving, so
   this adds `offload_try_add_work()` — identical, but returns `false` instead of waiting — and a
   prefetch is skipped when there is no free slot.

Every failure path is soft: allocation failure, a full queue, or a read error all fall back to the
original synchronous path. The new parameter **defaults to `nullptr`**, reproducing previous
behaviour exactly, so any call site that does not opt in is unaffected.

Applied to all seven CHD consumers: PSX, MegaCD, Saturn, 3DO, PC Engine CD, CD-i and IDE CD-ROM.
The context is **per-drive** because IDE can have two CD drives mounted at once. Cost is one hunk
buffer per open CHD drive (`hunkbytes`, ~19.6 KB).

### Lifetime

`mister_chd_prefetch_destroy()` drains any in-flight decompress before freeing, and is called
**before** `chd_close()` everywhere — otherwise the worker could be inside `chd_read()` on a closed
handle. Verified two ways:

- **Statically, all seven**: destroy precedes the real `chd_close()` call (psx 110<113, cdi
  118<121, megacd 319<323, saturn 404<408, 3do 399<403, pcecd 309<313, ide_cdrom 1658<1662), with
  1:1 create/destroy pairing. Every mount path also tears down first (psx `load_chd:133`, cdi 144,
  saturn 323, 3do 318, pcecd 259, megacd `mcd_set_image` 125→162, IDE `cdrom_parse:1682`), so a
  live context is never overwritten.
- **On hardware**: six mount/unmount cycles swapping between a CHD and a BIN/CUE image
  mid-playback, so a prefetch is in flight when the unload happens. No crash, no hang, and **0
  `.chd` file descriptors left open**.

Contexts are NULL-safe (`ide_inst[2] = {}` and the `pcecdd` global are zero-initialised; destroy
no-ops on NULL), so close-before-open is fine.

### Build

`make` and `make PROFILING=1` both clean with **zero warnings**. In a default build the
instrumentation is genuinely free: `profiling.cpp.o` is **empty (text=0, data=0, bss=0)** and none
of the scope literals appear in the binary.

## Known regression, and what is not covered

**The worst case gets worse on some titles.** On PSX, max rose ~5.2 → ~10.5 ms. Those samples
measure **2.03x and 2.04x a single decompress**: the main thread wanting a *different* hunk than
the one in flight must wait for the worker's `chd_read()` to finish (because `chd_file` is not
thread-safe) and only then start its own. Their positions in the read sequence (3021, 3029, 3053
of 3054) show they occur where sequential streaming *breaks*, not during it. The trade is heavily
favourable — total blocked time still falls 72x — and it is not universal: on MegaCD/Lunar the max
*improved* (4,223 → 576 µs) with zero surviving stalls. If that worst case matters, it can be
removed later by giving the worker its own `chd_file` handle so the main thread never waits.

**Measured on PSX and MegaCD only.** The other five consumers are converted because the code is
shared. Between those two cores, every distinct read shape in the tree is exercised except
Saturn's 256-byte and variable-`sector_size` reads — structurally short reads within a hunk,
already covered more aggressively by MegaCD's 96-byte subcode path:

| subsystem | read shapes |
|---|---|
| MegaCD | `0x10` header @ LBA 0, 2048 data, 2352 audio, **96 subcode ×2** |
| Saturn | `0x10` header @ LBA 0, 256 @ LBA 0, variable `sector_size`, 2352 audio |
| PSX | uniform 2352 |
| IDE | 2048 data, 2352 raw redbook |

So the untested cores reuse patterns that *are* tested, rather than being untested in kind. What
remains per-core is call placement, which is static and visible in the diff. I was not able to get
the Saturn core to boot a disc unattended in order to benchmark it directly.

`SPIKE_SCOPE("chd_hunk_decompress", 3000)` is left in `mister_chd_read_sector()` — it compiles to
nothing without `PROFILING` and makes this measurable by anyone in future. Happy to drop it, or to
split the six unmeasured cores into a follow-up, if either would make review easier.
