### PR TITLE
minimig: A2065 Ethernet card support

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -6191,7 +6191,7 @@ void HandleUI(void)
 
 	case MENU_MINIMIG_CHIPSET1:
 		helptext_idx = HELPTEXT_CHIPSET;
-		menumask = 0x3FF;
+		menumask = 0x7FF;
 		OsdSetTitle("System");
 		parentstate = menustate;
 
@@ -6237,8 +6237,13 @@ void HandleUI(void)
 		strcat(s, (minimig_config.memory & 0x40) ? "enabled " : "disabled");
 		OsdWrite(m++, s, menusub == 8, 0);
 
+		OsdWrite(m++, "", 0, 0);
+		strcpy(s, " Ethernet : ");
+		strcat(s, a2065_iface_msg(a2065_get_iface()));
+		OsdWrite(m++, s, menusub == 9, 0);
+
 		for (int i = m; i < OsdGetSize() - 1; i++) OsdWrite(i, "", 0, 0);
-		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 9, 0);
+		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 10, 0);
 
 		menustate = MENU_MINIMIG_CHIPSET2;
 		break;
@@ -6369,6 +6374,22 @@ void HandleUI(void)
 				menustate = MENU_MINIMIG_CHIPSET1;
 			}
 			else if (menusub == 9)
+			{
+				// A2065 ethernet: OFF -> eth0 -> eth1 -> macvlan -> tap0,
+				// skipping anything this box cannot support (no second NIC,
+				// no tun driver, no macvlan). OFF and eth0 always qualify, so
+				// the walk always lands somewhere.
+				int m2 = a2065_get_iface();
+				for (int i = 0; i < A2065_MODES; i++)
+				{
+					m2 = minus ? (m2 + A2065_MODES - 1) % A2065_MODES
+					           : (m2 + 1) % A2065_MODES;
+					if (a2065_mode_available(m2)) break;
+				}
+				a2065_set_iface(m2);
+				menustate = MENU_MINIMIG_CHIPSET1;
+			}
+			else if (menusub == 10)
 			{
 				menustate = MENU_MINIMIG_MAIN1;
 				menusub = 6;

--- a/support.h
+++ b/support.h
@@ -3,6 +3,7 @@
 #include "support/minimig/minimig_boot.h"
 #include "support/minimig/minimig_fdd.h"
 #include "support/minimig/minimig_share.h"
+#include "support/minimig/minimig_a2065.h"
 
 // SharpMz support
 #include "support/sharpmz/sharpmz.h"

--- a/support/minimig/minimig_a2065.cpp
+++ b/support/minimig/minimig_a2065.cpp
@@ -1,0 +1,581 @@
+// A2065 ZorroII Ethernet card — host half.
+//
+// See minimig_a2065.h for the architecture summary. This file owns the
+// interface selection persisted from the OSD, the DDR3 mailbox mapping, and
+// the per-pass work: draining the register doorbell and moving received frames
+// into the Amiga's ring.
+//
+// Everything here runs in Main's single thread, driven by a2065_poll() from
+// the poll loop. Nothing blocks and nothing is unbounded.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <time.h>
+#include <fcntl.h>
+
+#include "../../shmem.h"
+#include "../../user_io.h"
+#include "../../file_io.h"
+
+#include "minimig_a2065.h"
+#include "minimig_a2065_types.h"
+#include "minimig_a2065_debug.h"
+#include "minimig_a2065_ddr3.h"
+#include "minimig_a2065_boardram.h"
+
+extern void registers_reset(void);
+extern void registers_set_boardram(volatile uint8_t *ram);
+extern void registers_set_fakemac(const uint8_t *mac);
+extern void registers_get_fakemac(uint8_t *out);
+extern void registers_set_on_interrupt(void (*fn)(void));
+extern void registers_set_on_transmit(int (*fn)(void));
+extern uint16_t registers_csr0(void);
+extern uint16_t registers_csr(int n);
+extern uint16_t registers_mode(void);
+extern void chip_wput(uint8_t reg_offset, uint16_t v);
+extern int  do_transmit(void);
+extern void gotfunc(const uint8_t *data, int len);
+extern int  rings_rx_has_space(void);
+extern void mac_set_addresses(const uint8_t *fake, const uint8_t *real);
+extern int  ethernet_open(const char *iface, int promiscuous);
+extern void ethernet_close(void);
+extern int  ethernet_recv(uint8_t *buf, int maxlen);
+extern int  ethernet_recv_nb(uint8_t *buf, int maxlen);
+extern void ethernet_get_mac(uint8_t *mac_out);
+extern int  ethernet_read_iface_mac(const char *iface, uint8_t *out);
+extern int  ethernet_set_mac_filter(const uint8_t *mac);
+extern void ethernet_clear_filter(void);
+extern void ethernet_packet_stats(unsigned long *packets, unsigned long *drops);
+extern void rings_get_rx_stats(unsigned long *deliv, unsigned long *rxoff, unsigned long *ringfull);
+extern void mac_get_real(uint8_t *out);
+extern int  ethernet_iface_present(const char *iface);
+extern int  ethernet_iface_carrier(const char *iface);
+extern void ethernet_offload_off(const char *iface);
+extern void ethernet_offload_on(const char *iface);
+extern int  ethernet_set_iface_mac(const char *iface, const uint8_t *mac);
+extern int  ethernet_macvlan_available(const char *parent);
+extern int  ethernet_macvlan_create(const char *parent, const char *name, const uint8_t *mac);
+extern void ethernet_macvlan_delete(const char *name);
+extern void ethernet_dhcpcd_deny(const char *iface);
+
+// Delivery mode.
+//   DIRECT  dedicated NIC carries the Amiga MAC, non-promiscuous, no filter
+//   BPF     NIC shared with MiSTer: promiscuous plus a cBPF filter so
+//           off-target traffic is dropped before the userspace copy
+//   MACVLAN macvlan child of the onboard NIC, carrying the Amiga MAC
+//   TAP     tap device, host-side routing/bridging
+enum { MODE_DIRECT = 0, MODE_BPF = 1, MODE_MACVLAN = 2, MODE_TAP = 3 };
+
+// Name of the macvlan child created for MODE_MACVLAN.
+#define MACVLAN_NAME "ve-amiga"
+
+// The selection is kept in core status bits (A2065_STATUS_OPT). Minimig is
+// excluded from the generic status-word config load, and the mm_configTYPE
+// blob can't grow (its loader does an exact sizeof() check), so the field is
+// persisted next to the numbered Minimig config slots instead.
+static char *a2065_cfg_name(int num)
+{
+	static char name[128];
+	if (num) sprintf(name, "%s%d.a2065", user_io_get_core_name(), num);
+	else     sprintf(name, "%s.a2065",   user_io_get_core_name());
+	return name;
+}
+
+static volatile uint8_t *map = NULL;
+static int card_up = 0;
+
+static const char *iface_name = "eth0";
+static const char *parent_name = "eth0";
+static int mode = 0;
+static int created_macvlan = 0;
+static int prom_active = 0;     // BPF filter detached for Amiga-side MODE_PROM
+
+// Set while a batch of received frames is being written into the ring, to
+// suppress the per-frame CSR-shadow push and interrupt; one INT2 is raised for
+// the whole batch instead.
+static int rx_batching = 0;
+
+int a2065_eth1_present(void)
+{
+	return access("/sys/class/net/eth1", F_OK) == 0;
+}
+
+// Probe results, resolved once and cached. The macvlan probe shells out to
+// `ip link add`, far too costly to repeat on every OSD redraw.
+static int tap_avail = -1;
+static int macvlan_avail = -1;
+
+// Is this mode usable on this box? tun/tap and macvlan may be built in (=y),
+// built as modules (=m) or absent entirely, so both are probed for the
+// capability itself rather than for a loaded module — on a kernel with
+// CONFIG_TUN=y there is no module to find, yet tap works fine.
+int a2065_mode_available(int mode)
+{
+	switch (mode)
+	{
+	case A2065_ETH1:
+		return a2065_eth1_present();
+
+	case A2065_TAP:
+		if (tap_avail < 0)
+		{
+			// Opening the node proves the driver is there; it creates no
+			// interface until TUNSETIFF, so this is free of side effects.
+			int fd = open("/dev/net/tun", O_RDWR);
+			tap_avail = (fd >= 0);
+			if (fd >= 0) close(fd);
+		}
+		return tap_avail;
+
+	case A2065_MACVLAN:
+		if (macvlan_avail < 0) macvlan_avail = ethernet_macvlan_available("eth0");
+		return macvlan_avail;
+
+	default:
+		// OFF always, and eth0 is the DE10-Nano's onboard NIC — always there.
+		return 1;
+	}
+}
+
+const char *a2065_iface_msg(int mode)
+{
+	switch (mode)
+	{
+	case A2065_ETH0:    return "eth0";
+	case A2065_ETH1:    return "eth1";
+	case A2065_MACVLAN: return "macvlan";
+	case A2065_TAP:     return "tap0";
+	default:            return "OFF";
+	}
+}
+
+int a2065_get_iface(void)
+{
+	int mode = (int)user_io_status_get(A2065_STATUS_OPT);
+	if (mode >= A2065_MODES) mode = A2065_OFF;
+
+	// A selection that this box cannot support (second NIC unplugged, no tun
+	// driver, no macvlan) falls back to off — never to eth0, since moving the
+	// Amiga onto the NIC carrying MiSTer's own address should always be a
+	// deliberate choice.
+	if (!a2065_mode_available(mode)) mode = A2065_OFF;
+
+	return mode;
+}
+
+void a2065_cfg_save(int num)
+{
+	uint8_t mode = (uint8_t)a2065_get_iface();
+	FileSaveConfig(a2065_cfg_name(num), &mode, sizeof(mode));
+}
+
+void a2065_cfg_load(int num)
+{
+	// No stored selection for this slot means the card has never been enabled
+	// here, so leave it off. Opting in is explicit: the card only comes up
+	// once a mode has been chosen in the OSD and the config slot saved.
+	uint8_t mode = A2065_OFF;
+
+	uint8_t saved;
+	if (FileLoadConfig(a2065_cfg_name(num), &saved, sizeof(saved)) && saved < A2065_MODES)
+		mode = saved;
+
+	// A stored mode this box can no longer support falls back to off rather
+	// than quietly moving the Amiga onto MiSTer's own NIC.
+	if (!a2065_mode_available(mode)) mode = A2065_OFF;
+
+	user_io_status_set(A2065_STATUS_OPT, mode);
+}
+
+static uint64_t rd64(unsigned long off)
+{
+	uint64_t val;
+	memcpy(&val, (void *)(map + off), 8);
+	return val;
+}
+
+static void wr64(unsigned long off, uint64_t val)
+{
+	memcpy((void *)(map + off), &val, 8);
+}
+
+static void push_csr_shadow(void)
+{
+	uint16_t c0 = registers_csr0();
+	uint16_t c1 = registers_csr(1);
+	uint16_t c2 = registers_csr(2);
+	uint16_t c3 = registers_csr(3);
+
+	uint64_t packed = (uint64_t)c0
+	                | ((uint64_t)c1 << 16)
+	                | ((uint64_t)c2 << 32)
+	                | ((uint64_t)c3 << 48);
+	wr64(DDR3_CSR_OFF, packed);
+}
+
+static void update_int_state(void)
+{
+	uint16_t csr0 = registers_csr0();
+
+	wr64(DDR3_INT_OFF, ((csr0 & CSR0_INTR) && (csr0 & CSR0_INEA)) ? 1 : 0);
+}
+
+static void on_interrupt_cb(void)
+{
+	if (rx_batching) return;   // defer until the whole RX batch is delivered
+	push_csr_shadow();
+	update_int_state();
+}
+
+static int on_transmit_cb(void)
+{
+	int r = do_transmit();
+	push_csr_shadow();
+	update_int_state();
+	return r;
+}
+
+// Move whatever the socket already has into the Amiga's receive ring.
+//
+// Non-blocking, and bounded: this runs from Main's poll loop, which is
+// single-threaded and also services the core, the UI and input, so it must
+// hand control back promptly rather than sit on the socket. Anything left
+// over stays in the kernel's buffer and is picked up next time round.
+//
+// Frames are taken in a batch with the per-frame interrupt suppressed, and
+// one INT2 raised at the end: a server's TSO pair then lands together and the
+// Amiga acknowledges it immediately instead of arming its delayed-ACK timer.
+#define RX_BATCH_MAX 64
+
+static void a2065_drain_rx(void)
+{
+	static uint8_t rxbuf[MAX_PACKET_SIZE];
+	int taken = 0;
+
+	// Backpressure: with no free descriptor, leave the frames in the kernel
+	// buffer rather than overrunning the ring. Overruns used to clear RXON via
+	// RX_OFLO and cascade into a stall; letting the buffer hold the burst is
+	// the same zero-window flow control that made eth1 work.
+	if (!rings_rx_has_space()) return;
+
+	// Internal loopback disconnects the LANCE from the wire on real hardware.
+	// gotfunc skips its destination filter in that mode, so live segment
+	// traffic would otherwise flood the ring and turn RXON off, failing the
+	// internal-loopback diagnostic.
+	int loop = (registers_mode() & MODE_LOOP) != 0;
+
+	rx_batching = 1;
+	while (taken < RX_BATCH_MAX && (loop || rings_rx_has_space()))
+	{
+		int len = ethernet_recv_nb(rxbuf, sizeof rxbuf);
+		if (len <= 0) break;          // socket empty (0) or error (-1)
+		if (!loop) gotfunc(rxbuf, len);
+		taken++;
+	}
+	rx_batching = 0;
+
+	if (taken)
+	{
+		push_csr_shadow();
+		update_int_state();
+	}
+}
+
+static void write_mbx_mac(const uint8_t *fakemac)
+{
+	uint64_t val = 1;
+	val |= ((uint64_t)fakemac[2]) << 32;
+	val |= ((uint64_t)fakemac[3]) << 40;
+	val |= ((uint64_t)fakemac[4]) << 48;
+	val |= ((uint64_t)fakemac[5]) << 56;
+	wr64(DDR3_MAC_OFF, val);
+}
+
+static int mac_low_is_zero(const uint8_t *m) { return (m[3] | m[4] | m[5]) == 0; }
+
+// Last-resort unique low half when no NIC MAC is available. Seeds from the
+// hostname plus pid/time so two boards never collide and never emit an
+// all-zero MAC.
+static void derive_unique_low(uint8_t *m)
+{
+	char host[64] = {};
+	gethostname(host, sizeof host - 1);
+	uint32_t h = 2166136261u;                       // FNV-1a
+	for (const char *p = host; *p; ++p) h = (h ^ (uint8_t)*p) * 16777619u;
+	h ^= (uint32_t)getpid();
+	h ^= (uint32_t)time(NULL);
+	m[3] = (h >> 16) & 0xff;
+	m[4] = (h >> 8)  & 0xff;
+	m[5] =  h        & 0xff;
+	if (mac_low_is_zero(m)) m[5] = 0x01;            // never all-zero
+}
+
+// Resolve the wire-side MAC low bytes robustly so two cards on one LAN never
+// collide. Order: selected iface MAC -> onboard eth0 (unique per board,
+// stable) -> hostname/pid/time hash. The on-wire source is realmac (the
+// fakemac->realmac munge in mungepacket), so a unique non-zero low half here
+// is what stops the Amiga emitting 00:80:10:00:00:00. The OUI is always
+// forced to Commodore 00:80:10.
+static void a2065_set_default_mac(const char *iface)
+{
+	uint8_t realmac[6] = {}, fakemac[6];
+	const char *src = iface;
+
+	ethernet_get_mac(realmac);
+
+	if (mac_low_is_zero(realmac))
+	{
+		// Selected iface had no usable MAC (e.g. USB NIC late or down). Try
+		// the onboard eth0 — present and unique per DE10-Nano even when eth1
+		// isn't.
+		uint8_t fb[6];
+		if (ethernet_read_iface_mac("eth0", fb))
+		{
+			memcpy(realmac, fb, 6);
+			src = "eth0";
+		}
+		else
+		{
+			derive_unique_low(realmac);
+			src = "hostname-hash";
+		}
+	}
+
+	fakemac[0] = COMMODORE_OUI0; fakemac[1] = COMMODORE_OUI1; fakemac[2] = COMMODORE_OUI2;
+	fakemac[3] = realmac[3]; fakemac[4] = realmac[4]; fakemac[5] = realmac[5];
+
+	realmac[0] = COMMODORE_OUI0; realmac[1] = COMMODORE_OUI1; realmac[2] = COMMODORE_OUI2;
+
+	mac_set_addresses(fakemac, realmac);
+	registers_set_fakemac(fakemac);
+
+	printf("A2065: MAC low bytes from %s -> wire %02X:%02X:%02X:%02X:%02X:%02X\n",
+		src, realmac[0], realmac[1], realmac[2], realmac[3], realmac[4], realmac[5]);
+}
+
+// Build the Amiga's wire MAC from a NIC's low three bytes, under the
+// Commodore OUI, so two boards on one LAN never collide.
+static void amiga_mac_from(const uint8_t *src, uint8_t *out)
+{
+	out[0] = COMMODORE_OUI0; out[1] = COMMODORE_OUI1; out[2] = COMMODORE_OUI2;
+	out[3] = src[3]; out[4] = src[4]; out[5] = src[5];
+}
+
+// Put the chosen interface into a known-good state for its delivery mode.
+// Offload is forced either way rather than trusting whatever it was left at:
+// on a dedicated NIC (direct) offload OFF measurably raises doorbell
+// round-trip time, while on a shared NIC (bpf/macvlan) offload ON produces GRO
+// super-frames far larger than the Amiga LANCE can accept.
+//
+// Returns 1 if a macvlan child was created here and must be torn down on stop.
+static int a2065_setup_iface(const char *iface, const char *parent, int mode)
+{
+	if (mode == MODE_TAP) return 0;        // tap is created by ethernet_open()
+
+	if (mode == MODE_DIRECT)
+	{
+		ethernet_offload_on(parent);
+
+		// Reassign the dedicated NIC's MAC to the Amiga wire MAC so a
+		// non-promiscuous socket receives the Amiga's frames.
+		uint8_t orig[6], amac[6];
+		if (ethernet_read_iface_mac(iface, orig))
+		{
+			amiga_mac_from(orig, amac);
+			ethernet_set_iface_mac(iface, amac);
+		}
+		return 0;
+	}
+
+	ethernet_offload_off(parent);
+
+	if (mode == MODE_MACVLAN)
+	{
+		// Give the Amiga its own address on the LAN without a second NIC, and
+		// without disturbing the parent's. Deny dhcpcd first so it can't lease
+		// the Amiga's MAC out from under us.
+		uint8_t pmac[6], amac[6];
+		if (!ethernet_read_iface_mac(parent, pmac)) return 0;
+		amiga_mac_from(pmac, amac);
+		ethernet_dhcpcd_deny(iface);
+		if (ethernet_macvlan_create(parent, iface, amac)) return 1;
+		printf("A2065: macvlan create failed for %s\n", iface);
+	}
+
+	return 0;
+}
+
+// Bring the card up: map the mailbox, configure the interface, open the socket.
+// Runs to completion in the caller's context — there is no thread here. Main is
+// single-threaded by design, and a background thread would compete with it for
+// the one CPU it has, adding input lag or making it miss core requests.
+static int a2065_open(void)
+{
+	int sel = a2065_get_iface();
+
+	switch (sel)
+	{
+	case A2065_ETH1:    iface_name = "eth1";       parent_name = "eth1"; mode = MODE_DIRECT;  break;
+	case A2065_MACVLAN: iface_name = MACVLAN_NAME; parent_name = "eth0"; mode = MODE_MACVLAN; break;
+	case A2065_TAP:     iface_name = "tap0";       parent_name = "tap0"; mode = MODE_TAP;     break;
+	default:            iface_name = "eth0";       parent_name = "eth0"; mode = MODE_BPF;     break;
+	}
+
+	map = (volatile uint8_t *)shmem_map(DDR3_FLAT_BASE, DDR3_FLAT_WINDOW_SIZE);
+	if (!map)
+	{
+		printf("A2065: cannot map DDR3 mailbox\n");
+		return 0;
+	}
+
+	boardram = map + DDR3_BRAM_OFF;
+
+	wr64(DDR3_CMD_OFF, 0);
+	wr64(DDR3_CSR_OFF, 0);
+	wr64(DDR3_INT_OFF, 0);
+
+	registers_reset();
+	registers_set_boardram(boardram);
+	registers_set_on_interrupt(on_interrupt_cb);
+	registers_set_on_transmit(on_transmit_cb);
+
+	// Interface setup happens before the socket is opened so the NIC already
+	// carries the Amiga's MAC when a2065_set_default_mac() reads it back.
+	created_macvlan = a2065_setup_iface(iface_name, parent_name, mode);
+
+	int promiscuous = (mode == MODE_BPF);   // others own the Amiga MAC outright
+	if (!ethernet_open(iface_name, promiscuous))
+		printf("A2065: failed to open %s, continuing without network\n", iface_name);
+
+	a2065_set_default_mac(iface_name);
+
+	if (mode == MODE_BPF)
+	{
+		uint8_t realmac[6];
+		mac_get_real(realmac);
+		ethernet_set_mac_filter(realmac);
+		prom_active = 0;
+	}
+
+	{
+		uint8_t fakemac[6];
+		registers_get_fakemac(fakemac);
+		write_mbx_mac(fakemac);
+	}
+
+	push_csr_shadow();
+	update_int_state();
+
+	printf("A2065: running on %s (%s)\n", iface_name, a2065_iface_msg(sel));
+	return 1;
+}
+
+// One pass of the card's work, called from Main's poll loop.
+//
+// Two jobs: drain any register write the Amiga has posted through the doorbell,
+// and move received frames into its ring. Both are bounded and non-blocking, so
+// the cost per call stays small and predictable.
+//
+// A register write is DTACK-stretched by the FPGA until the doorbell is
+// drained, so the Amiga is held off for as long as it takes to get back here.
+// That is the reason this must not sit behind anything slow.
+void a2065_poll(void)
+{
+	if (!card_up) return;
+
+	uint64_t cmd = rd64(DDR3_CMD_OFF);
+	if (cmd & DDR3_CMD_PENDING_BIT)
+	{
+		uint8_t  rap_v = (cmd >> DDR3_CMD_RAP_SHIFT) & DDR3_CMD_RAP_MASK;
+		uint16_t data  = (cmd >> DDR3_CMD_DATA_SHIFT) & DDR3_CMD_DATA_MASK;
+
+		chip_wput(A2065_RAP_OFF, rap_v);
+		chip_wput(A2065_RDP_OFF, data);
+
+		wr64(DDR3_CMD_OFF, 0);
+		__sync_synchronize();
+
+		push_csr_shadow();
+		update_int_state();
+
+		// When the Amiga puts the LANCE into promiscuous mode (a sniffer), drop
+		// the kernel filter so it sees every frame, and re-attach on clear.
+		// SO_ATTACH_FILTER replaces atomically. Only meaningful in BPF mode —
+		// the others have no filter.
+		if (mode == MODE_BPF)
+		{
+			int want_prom = (registers_mode() & MODE_PROM) != 0;
+			if (want_prom != prom_active)
+			{
+				if (want_prom)
+				{
+					ethernet_clear_filter();
+				}
+				else
+				{
+					uint8_t realmac[6];
+					mac_get_real(realmac);
+					ethernet_set_mac_filter(realmac);
+				}
+				prom_active = want_prom;
+			}
+		}
+	}
+
+	a2065_drain_rx();
+}
+
+void a2065_stop(void)
+{
+	if (!card_up) return;
+
+	card_up = 0;
+	wr64(DDR3_INT_OFF, 0);
+	ethernet_close();
+
+	// Tear down only what we created. Offload settings and a direct-mode MAC
+	// reassignment are deliberately left in place.
+	if (created_macvlan) ethernet_macvlan_delete(iface_name);
+	created_macvlan = 0;
+
+	if (map)
+	{
+		shmem_unmap((void *)map, DDR3_FLAT_WINDOW_SIZE);
+		map = NULL;
+	}
+
+	printf("A2065: stopped\n");
+}
+
+void a2065_start(void)
+{
+	// Already up: this is a Minimig reset, so put the LANCE back to its
+	// power-on state rather than tearing the interface down and back up.
+	if (card_up)
+	{
+		registers_reset();
+		push_csr_shadow();
+		update_int_state();
+		return;
+	}
+
+	if (a2065_get_iface() == A2065_OFF) return;
+
+	if (a2065_open()) card_up = 1;
+	else a2065_stop();
+}
+
+void a2065_set_iface(int mode_sel)
+{
+	if (mode_sel < A2065_OFF || mode_sel >= A2065_MODES) mode_sel = A2065_OFF;
+	// Clamp an unsupported mode (the OSD skips these, so this is a safety net
+	// for a stale saved value or a scripted status write).
+	if (!a2065_mode_available(mode_sel)) mode_sel = A2065_OFF;
+
+	a2065_stop();
+	user_io_status_set(A2065_STATUS_OPT, mode_sel);
+	a2065_start();
+}

--- a/support/minimig/minimig_a2065.h
+++ b/support/minimig/minimig_a2065.h
@@ -1,0 +1,68 @@
+#ifndef MINIMIG_A2065_H
+#define MINIMIG_A2065_H
+
+// A2065 ZorroII Ethernet card support for the Minimig core.
+//
+// The FPGA side implements ZorroII autoconfig, the boardram window and the
+// LANCE CSR register file; this module is the host half — the AMD Am7990
+// LANCE controller state machine, the TX/RX descriptor ring walker and the
+// bridge to a host network interface. It runs in Main's single thread, driven
+// by a2065_poll() from the poll loop, and is started when the Minimig core
+// boots and stopped when it unloads.
+//
+// FPGA <-> host communication is a DDR3 shared-memory mailbox: register
+// writes raise a doorbell in a DDR3 CMD slot that a2065_poll() drains, and CSR
+// reads are served from a DDR3 shadow it keeps up to date.
+
+// Interface selection, shown on the Minimig "System" OSD page.
+//
+//   OFF      card idle, nothing polled
+//   eth0     onboard NIC, shared with MiSTer itself (promiscuous + cBPF filter)
+//   eth1     dedicated second NIC (carries the Amiga MAC, no filter)
+//   macvlan  macvlan child of eth0, so the Amiga gets its own MAC on the LAN
+//            without a second NIC and without disturbing MiSTer's own address
+//   tap0     tap device on a private subnet, reached by host-side routing or
+//            NAT. Needs tun/tap in the kernel (CONFIG_TUN), and covers the two
+//            cases the others cannot: local-only access between the Amiga and
+//            the MiSTer, and getting out over WiFi — a WiFi station cannot emit
+//            frames bearing a second source MAC, so the Amiga cannot hold its
+//            own address on the wireless network the way macvlan gives it one
+//            on wired eth0.
+#define A2065_OFF     0
+#define A2065_ETH0    1
+#define A2065_ETH1    2
+#define A2065_MACVLAN 3
+#define A2065_TAP     4
+#define A2065_MODES   5
+
+// The live selection lives in core status bits so it travels the same path as
+// every other core option. Minimig is excluded from the generic status-word
+// config load (user_io.cpp), so a2065_cfg_save()/a2065_cfg_load() persist just
+// this field alongside the numbered Minimig config slots.
+#define A2065_STATUS_OPT "[54:52]"
+
+int  a2065_get_iface(void);
+void a2065_set_iface(int mode);
+const char *a2065_iface_msg(int mode);
+int  a2065_eth1_present(void);
+
+// Whether this box can actually support a mode: a second NIC for eth1, a tun
+// driver for tap0, macvlan support for macvlan. Probed once and cached, so the
+// OSD can skip modes that cannot work here. OFF and eth0 are always available.
+int  a2065_mode_available(int mode);
+
+// Persistence, called from minimig_cfg_save()/minimig_cfg_load().
+void a2065_cfg_save(int num);
+void a2065_cfg_load(int num);
+
+// Lifecycle. Both are idempotent: a2065_start() on an already-running card
+// just resets the LANCE state, and a2065_stop() on a stopped card is a nop.
+void a2065_start(void);
+void a2065_stop(void);
+
+// One pass of the card's work — drain the register doorbell and move any
+// received frames into the Amiga's ring. Bounded and non-blocking; call it
+// from the poll loop. Does nothing when the card is off.
+void a2065_poll(void);
+
+#endif

--- a/support/minimig/minimig_a2065_boardram.h
+++ b/support/minimig/minimig_a2065_boardram.h
@@ -1,0 +1,28 @@
+#ifndef MINIMIG_A2065_BOARDRAM_H
+#define MINIMIG_A2065_BOARDRAM_H
+
+#include "minimig_a2065_types.h"
+#include <stdint.h>
+
+#define RAM_MASK 0x7FFF
+
+extern volatile uint8_t *boardram;
+
+/* The 68k (big-endian) writes the flat DDR3 window; the FPGA stores each 68k
+ * 16-bit word in its DDR3 lane little-endian (byte[off]=D[7:0],
+ * byte[off+1]=D[15:8]).  So a byte the 68k placed at boardram offset `off`
+ * lives at host offset `off ^ 1`.  XOR every byte index with 1 so this side
+ * sees boardram in 68k byte order (init block, descriptors, frames). */
+static inline uint8_t  get_ram_byte(uint32_t off) { return boardram[(off ^ 1) & RAM_MASK]; }
+static inline uint16_t get_ram_word(uint32_t off) { return ((uint16_t)get_ram_byte(off) << 8) | get_ram_byte(off + 1); }
+static inline void     put_ram_byte(uint32_t off, uint8_t v) { boardram[(off ^ 1) & RAM_MASK] = v; }
+static inline void     put_ram_word(uint32_t off, uint16_t v) { put_ram_byte(off, v >> 8); put_ram_byte(off + 1, (uint8_t)v); }
+
+static inline void ram_read_block(uint32_t off, uint8_t *dst, int len) {
+    for (int i = 0; i < len; i++) dst[i] = boardram[((off + i) ^ 1) & RAM_MASK];
+}
+static inline void ram_write_block(uint32_t off, const uint8_t *src, int len) {
+    for (int i = 0; i < len; i++) boardram[((off + i) ^ 1) & RAM_MASK] = src[i];
+}
+
+#endif

--- a/support/minimig/minimig_a2065_crc32.cpp
+++ b/support/minimig/minimig_a2065_crc32.cpp
@@ -1,0 +1,32 @@
+/*
+ * crc32.cpp — CRC-32 for Ethernet FCS
+ *
+ * Standard Ethernet CRC32 (polynomial 0xEDB88320, reflected).
+ * Used to append FCS bytes to received frames before writing to RX ring,
+ * since AF_PACKET does not include FCS.
+ */
+
+#include <stdint.h>
+
+static uint32_t crc32_table[256];
+static int table_built = 0;
+
+static void build_table(void)
+{
+    for (int i = 0; i < 256; i++) {
+        uint32_t c = (uint32_t)i;
+        for (int j = 0; j < 8; j++)
+            c = (c & 1) ? (0xEDB88320 ^ (c >> 1)) : (c >> 1);
+        crc32_table[i] = c;
+    }
+    table_built = 1;
+}
+
+uint32_t crc32_compute(const uint8_t *data, int len)
+{
+    if (!table_built) build_table();
+    uint32_t crc = 0xFFFFFFFF;
+    for (int i = 0; i < len; i++)
+        crc = crc32_table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+    return ~crc;
+}

--- a/support/minimig/minimig_a2065_ddr3.h
+++ b/support/minimig/minimig_a2065_ddr3.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <stdint.h>
+
+/*
+ * DDR3 shared-memory layout for flat boardram + CSR doorbell architecture.
+ *
+ * DDR3 physical base (ARM):  0x1FF00000
+ * Avalon (f2sdram2) base:    0x03FE0000  (= ARM physical >> 3, 64-bit words)
+ *
+ * Region +0x0000..+0x7FFF is the 32KB boardram — both 68k (via FPGA DDR3
+ * window) and ARM (via /dev/mem mmap) access the same bytes.
+ *
+ * Control slots start at +0x8000 (one 64-bit DDR3 word each).
+ * Avalon address = ARM_byte_offset >> 3.
+ */
+
+#define DDR3_FLAT_BASE          0x1FF00000UL
+#define DDR3_FLAT_WINDOW_SIZE   0x10000UL
+
+/* ── Boardram (shared 68k + ARM, 32 KB) ──────────────────────────── */
+#define DDR3_BRAM_OFF           0x0000UL
+#define DDR3_BRAM_SIZE          0x8000UL
+
+/* ── CMD: FPGA→ARM doorbell (Avalon 0x1000) ──────────────────────── */
+#define DDR3_CMD_OFF            0x8000UL
+#define DDR3_CMD_PENDING_BIT    (1ULL << 0)
+#define DDR3_CMD_RAP_SHIFT      1
+#define DDR3_CMD_RAP_MASK       0x7FULL
+#define DDR3_CMD_DATA_SHIFT     8
+#define DDR3_CMD_DATA_MASK      0xFFFFULL
+
+/* ── CMD_ACK: ARM→FPGA (write 0 to release, Avalon 0x1001) ──────── */
+#define DDR3_CMD_ACK_OFF        0x8008UL
+
+/* ── CSR_SHADOW: ARM→FPGA packed CSR0..CSR3 (Avalon 0x1002) ─────── */
+#define DDR3_CSR_OFF            0x8010UL
+#define DDR3_CSR_SHIFT(n)       ((n) * 16)
+#define DDR3_CSR_MASK           0xFFFFULL
+
+/* ── INT_STATE: ARM→FPGA interrupt line (Avalon 0x1003) ─────────── */
+#define DDR3_INT_OFF            0x8018UL
+#define DDR3_INT_ASSERT_BIT     (1ULL << 0)
+
+/* ── RAP_MIRROR: FPGA→ARM current RAP (Avalon 0x1004) ───────────── */
+#define DDR3_RAP_MIRROR_OFF     0x8020UL
+
+/* ── MAC: ARM→FPGA dynamic MAC address (Avalon 0x1005) ──────────── */
+#define DDR3_MAC_OFF            0x8028UL
+#define DDR3_MAC_VALID_BIT      (1ULL << 0)
+#define DDR3_MAC_DATA_SHIFT     16
+
+/* ── Avalon equivalents ─────────────────────────────────────────── */
+#define AV_CMD          0x1000
+#define AV_CMD_ACK      0x1001
+#define AV_CSR          0x1002
+#define AV_INT          0x1003
+#define AV_RAP_MIRROR   0x1004
+#define AV_MAC          0x1005

--- a/support/minimig/minimig_a2065_debug.h
+++ b/support/minimig/minimig_a2065_debug.h
@@ -1,0 +1,21 @@
+#ifndef MINIMIG_A2065_DEBUG_H
+#define MINIMIG_A2065_DEBUG_H
+
+#include <stdio.h>
+
+/* Runtime debug switch, defined in minimig_a2065_registers.cpp. Off by
+ * default; set it to 1 while tracing the LANCE register/ring paths. DBG(...)
+ * is a drop-in for fprintf(stderr, ...) that only emits when enabled, so the
+ * hot paths stay quiet. */
+extern int a2065_debug;
+
+/* Writes a "yyyymmdd-hhmmss.xxx " timestamp prefix to stderr (local time,
+ * milliseconds). Defined in minimig_a2065_registers.cpp. */
+void a2065_log_prefix(void);
+
+/* LOG: always emitted (lifecycle/errors). DBG: only when a2065_debug is set.
+ * Both prefix every line with a timestamp. */
+#define LOG(...) do { a2065_log_prefix(); fprintf(stderr, __VA_ARGS__); } while (0)
+#define DBG(...) do { if (a2065_debug) { a2065_log_prefix(); fprintf(stderr, __VA_ARGS__); } } while (0)
+
+#endif

--- a/support/minimig/minimig_a2065_ethernet.cpp
+++ b/support/minimig/minimig_a2065_ethernet.cpp
@@ -1,0 +1,540 @@
+/*
+ * ethernet.cpp — AF_PACKET raw socket for A2065 daemon
+ *
+ * Replaces Amiberry's WinPcap/libpcap layer.
+ * Sends and receives raw Ethernet frames via Linux AF_PACKET socket.
+ *
+ * Stub implementation for non-Linux builds (macOS native testing).
+ */
+
+#include "minimig_a2065_types.h"
+#include "minimig_a2065_debug.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+#include <linux/if_tun.h>
+#include <linux/filter.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+
+static int sock_fd = -1;
+static int is_tap = 0;
+static uint8_t host_mac[6];
+
+void ethernet_iface_up(const char *iface);  /* forward decl for open_tap */
+
+int ethernet_is_tap(void) { return is_tap; }
+
+static int open_tap(const char *iface)
+{
+    int fd = open("/dev/net/tun", O_RDWR | O_CLOEXEC);
+    if (fd < 0) { perror("[a2065] open /dev/net/tun"); return 0; }
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof ifr);
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+    strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    if (ioctl(fd, TUNSETIFF, &ifr) < 0) {
+        perror("[a2065] TUNSETIFF");
+        close(fd);
+        return 0;
+    }
+
+    sock_fd = fd;
+    is_tap = 1;
+
+    /* Read the tap interface's MAC via a temporary socket. */
+    memset(host_mac, 0, 6);
+    int s = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (s >= 0) {
+        struct ifreq m;
+        memset(&m, 0, sizeof m);
+        strncpy(m.ifr_name, ifr.ifr_name, IFNAMSIZ - 1);
+        if (ioctl(s, SIOCGIFHWADDR, &m) == 0)
+            memcpy(host_mac, m.ifr_hwaddr.sa_data, 6);
+        close(s);
+    }
+
+    ethernet_iface_up(ifr.ifr_name);
+
+    LOG("[a2065] Opened tap %s MAC=%02X:%02X:%02X:%02X:%02X:%02X\n",
+            ifr.ifr_name,
+            host_mac[0], host_mac[1], host_mac[2],
+            host_mac[3], host_mac[4], host_mac[5]);
+    return 1;
+}
+
+int ethernet_open(const char *iface, int promiscuous)
+{
+    if (!strncmp(iface, "tap", 3)) return open_tap(iface);
+
+    struct ifreq ifr;
+    struct sockaddr_ll addr;
+
+    is_tap = 0;
+    /* SOCK_CLOEXEC matters here: Main spawns helper processes, and without it
+     * every one of them inherits this raw socket. The socket then outlives the
+     * card being switched off — it keeps its promiscuous-mode membership and
+     * keeps queueing every frame on the interface, with nobody to read it. */
+    sock_fd = socket(AF_PACKET, SOCK_RAW | SOCK_CLOEXEC, htons(ETH_P_ALL));
+    if (sock_fd < 0) {
+        perror("[a2065] socket");
+        return 0;
+    }
+
+    strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+    if (ioctl(sock_fd, SIOCGIFINDEX, &ifr) < 0) {
+        perror("[a2065] SIOCGIFINDEX");
+        close(sock_fd); sock_fd = -1;
+        return 0;
+    }
+    int ifindex = ifr.ifr_ifindex;
+
+    memset(host_mac, 0, 6);
+    if (ioctl(sock_fd, SIOCGIFHWADDR, &ifr) == 0)
+        memcpy(host_mac, ifr.ifr_hwaddr.sa_data, 6);
+    else
+        perror("[a2065] SIOCGIFHWADDR");
+
+    /* Bring the interface up. The A2065's wire side (eth1) is often admin-down
+     * after boot; raw send/recv fail with "Network is down" until IFF_UP is set. */
+    if (ioctl(sock_fd, SIOCGIFFLAGS, &ifr) == 0) {
+        if (!(ifr.ifr_flags & IFF_UP)) {
+            ifr.ifr_flags |= IFF_UP;
+            if (ioctl(sock_fd, SIOCSIFFLAGS, &ifr) < 0)
+                perror("[a2065] SIOCSIFFLAGS (up)");
+            else
+                LOG("[a2065] Brought %s up\n", iface);
+        }
+    }
+
+    memset(&addr, 0, sizeof addr);
+    addr.sll_family   = AF_PACKET;
+    addr.sll_protocol = htons(ETH_P_ALL);
+    addr.sll_ifindex  = ifindex;
+    if (bind(sock_fd, (struct sockaddr *)&addr, sizeof addr) < 0) {
+        perror("[a2065] bind");
+        close(sock_fd); sock_fd = -1;
+        return 0;
+    }
+
+    if (promiscuous) {
+        struct packet_mreq mreq = {};
+        mreq.mr_ifindex = ifindex;
+        mreq.mr_type    = PACKET_MR_PROMISC;
+        setsockopt(sock_fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mreq, sizeof mreq);
+    }
+
+    /* Enlarge the kernel socket receive buffer. The default (rmem_max ~180KB on
+     * MiSTer) overflows when the rx_thread can't drain a line-rate TCP burst
+     * fast enough, dropping segments → retransmit spiral → collapsed throughput.
+     * SO_RCVBUFFORCE bypasses rmem_max (we run as root). */
+    int rcvbuf = 4 * 1024 * 1024;
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUFFORCE, &rcvbuf, sizeof rcvbuf) < 0) {
+        /* fall back to the capped, non-privileged setter */
+        if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof rcvbuf) < 0)
+            perror("[a2065] SO_RCVBUF");
+    }
+    int got = 0; socklen_t glen = sizeof got;
+    if (getsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF, &got, &glen) == 0)
+        LOG("[a2065] socket rcvbuf = %d bytes\n", got);
+
+    LOG("[a2065] Opened %s idx=%d MAC=%02X:%02X:%02X:%02X:%02X:%02X\n",
+            iface, ifindex,
+            host_mac[0], host_mac[1], host_mac[2],
+            host_mac[3], host_mac[4], host_mac[5]);
+    return 1;
+}
+
+/* Read and reset the kernel AF_PACKET stats (tp_packets seen, tp_drops dropped
+ * for lack of socket buffer). PACKET_STATISTICS clears the counters on read.
+ * Not available on tap devices (no SOL_PACKET). */
+void ethernet_packet_stats(unsigned long *packets, unsigned long *drops)
+{
+    *packets = *drops = 0;
+    if (sock_fd < 0 || is_tap) return;
+    struct tpacket_stats st = {};
+    socklen_t len = sizeof st;
+    if (getsockopt(sock_fd, SOL_PACKET, PACKET_STATISTICS, &st, &len) == 0) {
+        *packets = st.tp_packets;
+        *drops   = st.tp_drops;
+    }
+}
+
+void ethernet_close(void)
+{
+    if (sock_fd >= 0) { close(sock_fd); sock_fd = -1; }
+}
+
+void ethernet_send(const uint8_t *frame, int len)
+{
+    if (sock_fd < 0 || len <= 0) return;
+    ssize_t sent = is_tap ? write(sock_fd, frame, (size_t)len)
+                          : send(sock_fd, frame, (size_t)len, 0);
+    if (sent < 0) perror("[a2065] send");
+}
+
+int ethernet_recv(uint8_t *buf, int maxlen)
+{
+    if (sock_fd < 0) return -1;
+    ssize_t n = is_tap ? read(sock_fd, buf, (size_t)maxlen)
+                       : recv(sock_fd, buf, (size_t)maxlen, 0);
+    if (n < 0) {
+        if (errno != EINTR) perror("[a2065] recv");
+        return -1;
+    }
+    return (int)n;
+}
+
+/* Non-blocking receive for batch draining. Returns the frame length (>0),
+ * 0 when the socket queue is empty (EAGAIN — drain complete), or -1 on error.
+ * Lets the rx_thread pull every queued frame into the RX ring in one pass so
+ * a TSO pair lands together and the Amiga issues an immediate (2-segment) ACK. */
+int ethernet_recv_nb(uint8_t *buf, int maxlen)
+{
+    if (sock_fd < 0) return -1;
+    if (is_tap) {
+        struct pollfd pfd = { sock_fd, POLLIN, 0 };
+        int pr = poll(&pfd, 1, 0);
+        if (pr <= 0) return 0;
+        ssize_t n = read(sock_fd, buf, (size_t)maxlen);
+        if (n < 0) { if (errno != EINTR) perror("[a2065] tap recv_nb"); return -1; }
+        return (int)n;
+    }
+    ssize_t n = recv(sock_fd, buf, (size_t)maxlen, MSG_DONTWAIT);
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+        if (errno != EINTR) perror("[a2065] recv_nb");
+        return -1;
+    }
+    return (int)n;
+}
+
+void ethernet_get_mac(uint8_t *mac_out)
+{
+    memcpy(mac_out, host_mac, 6);
+}
+
+/* Read any interface's hardware MAC without disturbing the open socket.
+ * Returns 1 if a non-zero low half (bytes 3..5) was obtained, else 0. */
+int ethernet_read_iface_mac(const char *iface, uint8_t *out)
+{
+    memset(out, 0, 6);
+    int fd = socket(AF_PACKET, SOCK_DGRAM | SOCK_CLOEXEC, htons(ETH_P_ALL));
+    if (fd < 0) return 0;
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof ifr);
+    strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    int ok = 0;
+    if (ioctl(fd, SIOCGIFHWADDR, &ifr) == 0) {
+        memcpy(out, ifr.ifr_hwaddr.sa_data, 6);
+        ok = (out[3] | out[4] | out[5]) != 0;
+    }
+    close(fd);
+    return ok;
+}
+
+/*
+ * Attach a classic-BPF filter that runs in the kernel before the copy to
+ * userspace, so the daemon only wakes for frames the Amiga cares about.
+ * Required for the BPF eth0-sharing mode: eth0 is promiscuous (so frames for
+ * the Amiga's distinct MAC reach the kernel), and this filter does the same
+ * selection gotfunc() does in software — accept dst == mac or broadcast; drop
+ * our own outgoing frames AND non-broadcast multicast. gotfunc() re-filters,
+ * so the bind()/attach startup race is harmless.
+ *
+ * Why drop multicast in the kernel: on a shared host segment multicast is the
+ * dominant noise (mDNS/PTP/IPv6-ND were ~75% of frames in measurement).
+ * gotfunc() already rejects it via the LADRF hash (LADRF=0 → all multicast
+ * dropped), but only after a userspace copy, an rx-thread wakeup and a
+ * registers_lock hold per frame — which starves the doorbell CMD loop and
+ * collapses TCP throughput. Filtering it here removes that load entirely.
+ * Trade-off: if the Amiga ever joins a multicast group it won't be delivered
+ * under BPF mode — acceptable for v1 (AmigaOS/Roadshow rarely joins groups);
+ * MODE_PROM detaches the filter for sniffers.
+ *
+ * 11-instruction program (interpreted; CONFIG_BPF_JIT off on stock MiSTer):
+ */
+int ethernet_set_mac_filter(const uint8_t *mac)
+{
+    if (sock_fd < 0 || is_tap) return 0;
+
+    /* cBPF BPF_ABS loads are big-endian, so pack the MAC the same way. */
+    uint32_t macword = ((uint32_t)mac[0] << 24) | ((uint32_t)mac[1] << 16)
+                     | ((uint32_t)mac[2] << 8)  |  (uint32_t)mac[3];
+    uint32_t machalf = ((uint32_t)mac[4] << 8)  |  (uint32_t)mac[5];
+
+    struct sock_filter code[] = {
+        /* 0: drop frames the host itself transmitted (loopback echo) */
+        BPF_STMT(BPF_LD  | BPF_B   | BPF_ABS, (uint32_t)(SKF_AD_OFF + SKF_AD_PKTTYPE)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,   PACKET_OUTGOING, 8, 0),
+        /* 2: load dst[0..3]; branch broadcast vs realmac */
+        BPF_STMT(BPF_LD  | BPF_W   | BPF_ABS, 0),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,   0xFFFFFFFFu, 0, 2),
+        /* 4: dst[0..3]==FFFFFFFF → accept iff dst[4..5]==FFFF (broadcast) */
+        BPF_STMT(BPF_LD  | BPF_H   | BPF_ABS, 4),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,   0xFFFFu, 3, 4),
+        /* 6: dst[0..3]==macword (A still holds dst[0..3]); else drop */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,   macword, 0, 3),
+        /* 7: dst[4..5]==machalf → accept; else drop */
+        BPF_STMT(BPF_LD  | BPF_H   | BPF_ABS, 4),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,   machalf, 0, 1),
+        /* 9: accept (whole frame) */
+        BPF_STMT(BPF_RET | BPF_K,             0xFFFFFFFFu),
+        /* 10: drop */
+        BPF_STMT(BPF_RET | BPF_K,             0),
+    };
+
+    struct sock_fprog prog;
+    prog.len    = sizeof code / sizeof code[0];
+    prog.filter = code;
+
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof prog) < 0) {
+        perror("[a2065] SO_ATTACH_FILTER");
+        return 0;
+    }
+
+    LOG("[a2065] BPF filter attached: dst=%02X:%02X:%02X:%02X:%02X:%02X + bcast/mcast\n",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return 1;
+}
+
+void ethernet_clear_filter(void)
+{
+    if (sock_fd < 0 || is_tap) return;
+    int dummy = 0;  /* SO_DETACH_FILTER ignores optval but needs a valid ptr */
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_DETACH_FILTER, &dummy, sizeof dummy) < 0)
+        perror("[a2065] SO_DETACH_FILTER");
+    else
+        LOG("[a2065] BPF filter detached\n");
+}
+
+/* ── Network-management helpers (combined daemon auto-setup) ───────────────
+ * These mutate host network state (interface flags, MAC, macvlan, dhcpcd) and
+ * are gated by the caller's --no-net-setup. Shell-out (v1) for readability and
+ * parity with the manually validated commands. */
+
+static int run_cmd(const char *cmd)
+{
+    LOG("[a2065] exec: %s\n", cmd);
+    int rc = system(cmd);
+    if (rc != 0) LOG("[a2065] exec rc=%d: %s\n", rc, cmd);
+    return rc;
+}
+
+int ethernet_iface_present(const char *iface)
+{
+    return if_nametoindex(iface) != 0;
+}
+
+void ethernet_iface_up(const char *iface)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) return;
+    struct ifreq ifr; memset(&ifr, 0, sizeof ifr);
+    strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) == 0 && !(ifr.ifr_flags & IFF_UP)) {
+        ifr.ifr_flags |= IFF_UP;
+        ioctl(fd, SIOCSIFFLAGS, &ifr);
+    }
+    close(fd);
+}
+
+/* 1 iff the interface exists and reports carrier (link up). Brings it up first
+ * so /carrier is meaningful. */
+int ethernet_iface_carrier(const char *iface)
+{
+    if (!ethernet_iface_present(iface)) return 0;
+    ethernet_iface_up(iface);
+    char path[128];
+    snprintf(path, sizeof path, "/sys/class/net/%s/carrier", iface);
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    int c = 0;
+    if (fscanf(f, "%d", &c) != 1) c = 0;
+    fclose(f);
+    return c == 1;
+}
+
+void ethernet_offload_off(const char *iface)
+{
+    char cmd[160];
+    snprintf(cmd, sizeof cmd,
+             "ethtool -K %s gro off lro off gso off tso off 2>/dev/null", iface);
+    run_cmd(cmd);
+}
+
+void ethernet_offload_on(const char *iface)
+{
+    char cmd[160];
+    snprintf(cmd, sizeof cmd,
+             "ethtool -K %s gro on lro on gso on tso on 2>/dev/null", iface);
+    run_cmd(cmd);
+}
+
+/* Set an interface's hardware MAC (direct mode). Bounces the link down/up. */
+int ethernet_set_iface_mac(const char *iface, const uint8_t *mac)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) return 0;
+    struct ifreq ifr;
+
+    memset(&ifr, 0, sizeof ifr); strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) == 0) {       /* down */
+        ifr.ifr_flags &= ~IFF_UP;
+        ioctl(fd, SIOCSIFFLAGS, &ifr);
+    }
+    memset(&ifr, 0, sizeof ifr); strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    ifr.ifr_hwaddr.sa_family = ARPHRD_ETHER;
+    memcpy(ifr.ifr_hwaddr.sa_data, mac, 6);
+    int ok = ioctl(fd, SIOCSIFHWADDR, &ifr) == 0;
+    if (!ok) perror("[a2065] SIOCSIFHWADDR");
+
+    memset(&ifr, 0, sizeof ifr); strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) == 0) {       /* up */
+        ifr.ifr_flags |= IFF_UP;
+        ioctl(fd, SIOCSIFFLAGS, &ifr);
+    }
+    close(fd);
+    if (ok)
+        LOG("[a2065] set %s MAC %02X:%02X:%02X:%02X:%02X:%02X\n", iface,
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return ok;
+}
+
+/* Probe whether macvlan is usable by creating + deleting a throwaway child. */
+int ethernet_macvlan_available(const char *parent)
+{
+    char cmd[160];
+    snprintf(cmd, sizeof cmd,
+             "ip link add a2065probe link %s type macvlan mode bridge 2>/dev/null", parent);
+    if (run_cmd(cmd) != 0) return 0;
+    run_cmd("ip link del a2065probe 2>/dev/null");
+    return 1;
+}
+
+int ethernet_macvlan_create(const char *parent, const char *name, const uint8_t *mac)
+{
+    char cmd[200], m[18];
+    snprintf(m, sizeof m, "%02x:%02x:%02x:%02x:%02x:%02x",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    snprintf(cmd, sizeof cmd, "ip link del %s 2>/dev/null", name); run_cmd(cmd);
+    snprintf(cmd, sizeof cmd,
+             "ip link add %s link %s address %s type macvlan mode bridge",
+             name, parent, m);
+    if (run_cmd(cmd) != 0) return 0;
+    snprintf(cmd, sizeof cmd, "ip link set %s up", name); run_cmd(cmd);
+    snprintf(cmd, sizeof cmd, "ip addr flush dev %s", name); run_cmd(cmd);
+    return 1;
+}
+
+void ethernet_macvlan_delete(const char *name)
+{
+    char cmd[80];
+    snprintf(cmd, sizeof cmd, "ip link del %s 2>/dev/null", name);
+    run_cmd(cmd);
+}
+
+/* Stop dhcpcd contending for the Amiga's MAC on <iface>: add denyinterfaces to
+ * the global section of /etc/dhcpcd.conf (idempotent), restart dhcpcd
+ * (persistent keeps eth0's lease), and flush any address already on <iface>. */
+void ethernet_dhcpcd_deny(const char *iface)
+{
+    const char *cfg = "/etc/dhcpcd.conf";
+    char cmd[512];
+
+    snprintf(cmd, sizeof cmd,
+             "grep '^denyinterfaces' %s 2>/dev/null | grep -qw %s", cfg, iface);
+    if (run_cmd(cmd) == 0) {
+        LOG("[a2065] dhcpcd already denies %s\n", iface);
+    } else {
+        snprintf(cmd, sizeof cmd,
+            "if grep -q '^denyinterfaces ' %s 2>/dev/null; then "
+            "sed -i '0,/^denyinterfaces /s//denyinterfaces %s /' %s; "
+            "else printf 'denyinterfaces %s\\n' >> %s; fi",
+            cfg, iface, cfg, iface, cfg);
+        run_cmd(cmd);
+        LOG("[a2065] added denyinterfaces %s to %s; restarting dhcpcd\n", iface, cfg);
+        run_cmd("killall dhcpcd 2>/dev/null; dhcpcd 2>/dev/null &");
+        usleep(300000);
+    }
+    snprintf(cmd, sizeof cmd, "ip addr flush dev %s 2>/dev/null", iface);
+    run_cmd(cmd);
+}
+
+#else
+
+int ethernet_is_tap(void) { return 0; }
+
+int ethernet_open(const char *iface, int promiscuous)
+{
+    (void)iface; (void)promiscuous;
+    LOG("[a2065] ethernet: stub (non-Linux build)\n");
+    return 1;
+}
+
+void ethernet_close(void) {}
+
+void ethernet_send(const uint8_t *frame, int len)
+{
+    (void)frame; (void)len;
+}
+
+int ethernet_recv(uint8_t *buf, int maxlen)
+{
+    (void)buf; (void)maxlen;
+    return -1;
+}
+
+int ethernet_recv_nb(uint8_t *buf, int maxlen)
+{
+    (void)buf; (void)maxlen;
+    return 0;
+}
+
+void ethernet_get_mac(uint8_t *mac_out)
+{
+    memset(mac_out, 0, 6);
+}
+
+int ethernet_read_iface_mac(const char *iface, uint8_t *out)
+{
+    (void)iface;
+    memset(out, 0, 6);
+    return 0;
+}
+
+int ethernet_set_mac_filter(const uint8_t *mac) { (void)mac; return 1; }
+
+void ethernet_clear_filter(void) {}
+
+void ethernet_packet_stats(unsigned long *packets, unsigned long *drops)
+{
+    *packets = *drops = 0;
+}
+
+int  ethernet_iface_present(const char *iface) { (void)iface; return 0; }
+void ethernet_iface_up(const char *iface) { (void)iface; }
+int  ethernet_iface_carrier(const char *iface) { (void)iface; return 0; }
+void ethernet_offload_off(const char *iface) { (void)iface; }
+void ethernet_offload_on(const char *iface) { (void)iface; }
+int  ethernet_set_iface_mac(const char *iface, const uint8_t *mac) { (void)iface; (void)mac; return 0; }
+int  ethernet_macvlan_available(const char *parent) { (void)parent; return 0; }
+int  ethernet_macvlan_create(const char *parent, const char *name, const uint8_t *mac)
+{ (void)parent; (void)name; (void)mac; return 0; }
+void ethernet_macvlan_delete(const char *name) { (void)name; }
+void ethernet_dhcpcd_deny(const char *iface) { (void)iface; }
+
+#endif

--- a/support/minimig/minimig_a2065_mac.cpp
+++ b/support/minimig/minimig_a2065_mac.cpp
@@ -1,0 +1,125 @@
+/*
+ * MAC address translation — ported from Amiberry a2065.cpp
+ *
+ * Translates between:
+ *   fakemac: 00:80:10:XX:XX:XX  (Commodore OUI, presented to Amiga driver)
+ *   realmac: host NIC MAC with OUI forced to 00:80:10
+ *
+ * Applied to every packet in both directions (TX and RX).
+ * Also fixes ARP sender/target and DHCP CHADDR fields.
+ * Recalculates UDP checksum if DHCP CHADDR was modified.
+ */
+
+#include "minimig_a2065_types.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+static uint8_t fakemac[6];
+static uint8_t realmac[6];
+
+void mac_set_addresses(const uint8_t *fake, const uint8_t *real)
+{
+    memcpy(fakemac, fake, 6);
+    memcpy(realmac, real, 6);
+}
+
+/* Update only the fakemac (the Amiga-side address munge matches against),
+ * leaving realmac untouched. Called from chip_init once the LANCE init block
+ * reveals the station address the Amiga actually programmed (from autoconfig
+ * er_SerialNumber). Without this the startup fakemac never matches the real
+ * Amiga frames and the fakemac<->realmac swap is a no-op. */
+void mac_set_fakemac(const uint8_t *fake) { memcpy(fakemac, fake, 6); }
+
+void mac_get_fake(uint8_t *out) { memcpy(out, fakemac, 6); }
+void mac_get_real(uint8_t *out) { memcpy(out, realmac, 6); }
+
+/* Swap MAC at packet[0..5] if it matches either known MAC. */
+static int dofakemac(uint8_t *packet)
+{
+    if (!memcmp(fakemac, realmac, 6))
+        return 1;
+    if (!memcmp(packet, fakemac, 6)) {
+        memcpy(packet, realmac, 6);
+        return 1;
+    }
+    if (!memcmp(packet, realmac, 6)) {
+        memcpy(packet, fakemac, 6);
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * Translate MACs in a complete Ethernet frame.
+ * Handles: dst MAC, src MAC, ARP sender/target, DHCP CHADDR.
+ * Returns frame length (unchanged), or 0 if packet too short.
+ */
+int mungepacket(uint8_t *packet, int len)
+{
+    if (len < 20)
+        return 0;
+    if (!memcmp(fakemac, realmac, 6))
+        return len;
+
+    uint8_t *data = packet + 14;
+    uint16_t type = ((uint16_t)packet[12] << 8) | packet[13];
+    int ret = 0;
+
+    /* dst and src MACs */
+    ret |= dofakemac(packet);
+    ret |= dofakemac(packet + 6);
+
+    if (type == 0x0806) {
+        /* ARP: hardware type must be Ethernet (1) and hw addr len = 6 */
+        if (((data[0] << 8) | data[1]) == 1 && data[4] == 6) {
+            ret |= dofakemac(data + 8);          /* sender hardware addr */
+            ret |= dofakemac(data + 8 + 6 + 4); /* target hardware addr */
+        }
+    } else if (type == 0x0800) {
+        /* IPv4 */
+        int proto = data[9];
+        int ihl   = data[0] & 0x0f;
+        uint8_t *ipv4 = data;
+
+        data += ihl * 4;
+
+        if (proto == 17) {
+            /* UDP */
+            int sp   = ((int)data[0] << 8) | data[1];
+            int dp   = ((int)data[2] << 8) | data[3];
+            int len2 = ((int)data[4] << 8) | data[5];
+            int udpcrc = 0;
+
+            /* DHCP ports 67/68: fix CHADDR field at UDP payload + 36 */
+            if (sp == 67 || sp == 68 || dp == 67 || dp == 68)
+                udpcrc |= dofakemac(data + 8 + 28);
+
+            if (udpcrc && (data[6] || data[7])) {
+                /* Recalculate UDP checksum */
+                uint32_t sum = 0;
+                int i;
+                data[6] = data[7] = 0;
+                data[len2] = 0; /* pad to even if needed */
+                for (i = 0; i < ((len2 + 1) & ~1); i += 2)
+                    sum += ((uint32_t)data[i] << 8) | data[i + 1];
+                /* IPv4 pseudo-header: src IP, dst IP, proto, UDP len */
+                sum += ((uint32_t)ipv4[12] << 8) | ipv4[13];
+                sum += ((uint32_t)ipv4[14] << 8) | ipv4[15];
+                sum += ((uint32_t)ipv4[16] << 8) | ipv4[17];
+                sum += ((uint32_t)ipv4[18] << 8) | ipv4[19];
+                sum += 17;
+                sum += len2;
+                while (sum >> 16)
+                    sum = (sum & 0xFFFF) + (sum >> 16);
+                sum = ~sum;
+                if (sum == 0) sum = 0xffff;
+                data[6] = (uint8_t)(sum >> 8);
+                data[7] = (uint8_t)(sum);
+                ret |= 1;
+            }
+        }
+    }
+
+    return ret ? len : len;
+}

--- a/support/minimig/minimig_a2065_registers.cpp
+++ b/support/minimig/minimig_a2065_registers.cpp
@@ -1,0 +1,284 @@
+/*
+ * AMD Am7990 CSR register emulation — ported from Amiberry a2065.cpp
+ *
+ * chip_wput(): called when 68k writes to RAP or RDP
+ * chip_wget(): called when 68k reads from RAP or RDP
+ *
+ * All state is module-internal. rings.cpp and main.cpp access it
+ * via the accessor functions below.
+ */
+
+#include "minimig_a2065_types.h"
+#include "minimig_a2065_debug.h"
+#include "minimig_a2065_boardram.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <time.h>
+#include <sys/time.h>
+
+/* Runtime debug switch (see a2065_debug.h). Shared by all daemon builds. */
+int a2065_debug = 0;
+
+/* "yyyymmdd-hhmmss.xxx " timestamp prefix (local time, milliseconds). */
+void a2065_log_prefix(void)
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    struct tm tmv;
+    localtime_r(&tv.tv_sec, &tmv);
+    fprintf(stderr, "%04d%02d%02d-%02d%02d%02d.%03d ",
+            tmv.tm_year + 1900, tmv.tm_mon + 1, tmv.tm_mday,
+            tmv.tm_hour, tmv.tm_min, tmv.tm_sec, (int)(tv.tv_usec / 1000));
+}
+
+/* ── Internal state ────────────────────────────────────────────────── */
+static volatile uint16_t csr[RAP_SIZE];
+static uint8_t rap = 0;
+static int  am_initialized = 0;
+
+static pthread_mutex_t reg_lock;
+static int reg_lock_init_done = 0;
+
+void registers_lock_init(void)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&reg_lock, &attr);
+    pthread_mutexattr_destroy(&attr);
+    reg_lock_init_done = 1;
+}
+
+void registers_lock(void)   { if (reg_lock_init_done) pthread_mutex_lock(&reg_lock); }
+void registers_unlock(void) { if (reg_lock_init_done) pthread_mutex_unlock(&reg_lock); }
+
+/* Ring configuration — written by chip_init(), read by rings.cpp */
+static uint16_t am_mode;
+static uint64_t am_ladrf;
+static uint32_t am_rdr_rlen, am_rdr_rdra;
+static uint32_t am_tdr_tlen, am_tdr_tdra;
+static int       tdr_offset = 0, rdr_offset = 0;
+
+/* MAC addresses — set by mac.cpp via registers_set_mac() */
+static uint8_t  fakemac[6];
+
+/* boardram pointer — the flat DDR3 window, set by registers_set_boardram() */
+volatile uint8_t *boardram = NULL;
+
+/* Callbacks into main.cpp */
+static void (*on_interrupt)(void) = NULL;
+static int (*on_transmit)(void)  = NULL;
+
+void registers_set_boardram(volatile uint8_t *ram)  { boardram = ram; }
+void registers_set_fakemac(const uint8_t *mac)       { memcpy(fakemac, mac, 6); }
+void registers_set_on_interrupt(void (*fn)(void))    { on_interrupt = fn; }
+void registers_set_on_transmit(int (*fn)(void))     { on_transmit = fn; }
+
+int  registers_am_initialized(void)  { return am_initialized; }
+uint32_t registers_rdr_rdra(void)    { return am_rdr_rdra; }
+uint32_t registers_rdr_rlen(void)    { return am_rdr_rlen; }
+uint32_t registers_tdr_tdra(void)    { return am_tdr_tdra; }
+uint32_t registers_tdr_tlen(void)    { return am_tdr_tlen; }
+int *    registers_tdr_offset(void)  { return &tdr_offset; }
+int *    registers_rdr_offset(void)  { return &rdr_offset; }
+uint16_t registers_csr0(void)        { return csr[0]; }
+uint16_t registers_csr(int n)        { return (n >= 0 && n < RAP_SIZE) ? csr[n] : 0; }
+void     registers_csr0_set(uint16_t v) { csr[0] |= v; }
+void     registers_csr0_clr(uint16_t v) { csr[0] &= ~v; }
+uint16_t registers_mode(void)        { return am_mode; }
+uint64_t registers_ladrf(void)       { return am_ladrf; }
+int      registers_prom(void)        { return (am_mode & MODE_PROM) ? 1 : 0; }
+void     registers_get_fakemac(uint8_t *out) { memcpy(out, fakemac, 6); }
+
+/* ── Boardram helpers (see boardram_access.h) ─ */
+
+/* ── Initialization ─────────────────────────────────────────────────── */
+static void chip_init_mask(void)
+{
+    am_rdr_rdra &= RAM_MASK;
+    am_tdr_tdra &= RAM_MASK;
+    tdr_offset = rdr_offset = 0;
+}
+
+extern void rings_reset_loopback_count(void);
+extern void mac_set_fakemac(const uint8_t *fake);
+static void chip_init(void)
+{
+    rings_reset_loopback_count();
+    uint32_t iaddr = ((csr[2] & 0xff) << 16) | csr[1];
+    int off = iaddr & RAM_MASK;
+
+    DBG("[a2065] chip_init: iaddr=%06X off=%04X csr1=%04X csr2=%04X\n",
+            iaddr, off, csr[1], csr[2]);
+    DBG("[a2065] chip_init: raw[0]=%04X raw[2]=%04X raw[4]=%04X raw[6]=%04X raw[8]=%04X\n",
+            get_ram_word(off + 0), get_ram_word(off + 2), get_ram_word(off + 4),
+            get_ram_word(off + 6), get_ram_word(off + 8));
+
+    am_mode  = get_ram_word(off + 0);
+    am_ladrf = ((uint64_t)get_ram_word(off + 14) << 48) |
+               ((uint64_t)get_ram_word(off + 12) << 32) |
+               ((uint64_t)get_ram_word(off + 10) << 16) |
+               get_ram_word(off + 8);
+
+    uint32_t rdr = ((uint32_t)get_ram_word(off + 18) << 16) | get_ram_word(off + 16);
+    uint32_t tdr = ((uint32_t)get_ram_word(off + 22) << 16) | get_ram_word(off + 20);
+
+    am_rdr_rlen = 1u << ((rdr >> 29) & 7);
+    am_tdr_tlen = 1u << ((tdr >> 29) & 7);
+    am_rdr_rdra = rdr & 0x00fffff8;
+    am_tdr_tdra = tdr & 0x00fffff8;
+
+    /* MAC from init block (byte-swapped pairs) */
+    fakemac[0] = get_ram_byte(off + 3);
+    fakemac[1] = get_ram_byte(off + 2);
+    fakemac[2] = get_ram_byte(off + 5);
+    fakemac[3] = get_ram_byte(off + 4);
+    fakemac[4] = get_ram_byte(off + 7);
+    fakemac[5] = get_ram_byte(off + 6);
+
+    /* Tell the munge unit the address the Amiga actually uses on the wire, so
+     * mungepacket() can swap it for the unique NIC-derived realmac. Otherwise
+     * the wire src stays the Amiga's station MAC (00:80:10:00:00:00). */
+    mac_set_fakemac(fakemac);
+
+    chip_init_mask();
+    DBG("[a2065] chip_init: mode=%04X rdr_rlen=%u tdr_tlen=%u "
+            "rdra=%06X tdra=%06X MAC=%02X:%02X:%02X:%02X:%02X:%02X\n",
+            am_mode, am_rdr_rlen, am_tdr_tlen, am_rdr_rdra, am_tdr_tdra,
+            fakemac[0], fakemac[1], fakemac[2], fakemac[3], fakemac[4], fakemac[5]);
+}
+
+void rethink(void)
+{
+    csr[0] &= ~CSR0_INTR;
+    if (csr[0] & (CSR0_BABL | CSR0_MISS | CSR0_MERR | CSR0_RINT | CSR0_TINT | CSR0_IDON))
+        csr[0] |= CSR0_INTR;
+    if ((csr[0] & (CSR0_INTR | CSR0_INEA)) == (CSR0_INTR | CSR0_INEA))
+        if (on_interrupt) on_interrupt();
+}
+
+/* ── chip_wget — called when 68k reads from RDP ─────────────────────── */
+uint16_t chip_wget(uint8_t reg_offset)
+{
+    if (reg_offset == A2065_RAP_OFF)
+        return (uint16_t)rap;
+
+    /* RDP */
+    if (rap >= RAP_SIZE) return 0;
+    uint16_t v = csr[rap];
+    if (rap == 0 && (v & (CSR0_BABL | CSR0_CERR | CSR0_MISS | CSR0_MERR)))
+        v |= CSR0_ERR;
+    if (rap == 88) v = 1 << (28 - 16);     /* chip ID */
+    if (rap == 89) v = 0x3003;
+    return v;
+}
+
+/* ── chip_wput — called when 68k writes to RAP or RDP ──────────────── */
+void chip_wput(uint8_t reg_offset, uint16_t v)
+{
+    if (reg_offset == A2065_RAP_OFF) {
+        rap = v & 0x7f; /* mask to 7 bits (128 CSRs) */
+        return;
+    }
+
+    /* RDP */
+    if (rap >= RAP_SIZE) return;
+    uint16_t oreg = csr[rap];
+
+    switch (rap) {
+    case 0: {
+        csr[0] &= ~CSR0_INEA; csr[0] |= v & CSR0_INEA;
+        csr[0] |= v & (CSR0_INIT | CSR0_STRT | CSR0_STOP | CSR0_TDMD);
+        csr[0] &= ~(v & (CSR0_IDON | CSR0_TINT | CSR0_RINT |
+                         CSR0_MERR | CSR0_MISS | CSR0_CERR | CSR0_BABL));
+        csr[0] &= ~CSR0_ERR;
+
+        if ((csr[0] & CSR0_STOP) && !(oreg & CSR0_STOP)) {
+            csr[0] = CSR0_STOP;
+            csr[3] = 0;
+            DBG("[a2065] STOP\n");
+        } else if ((csr[0] & CSR0_STRT) && !(oreg & CSR0_STRT) &&
+                   (oreg & (CSR0_STOP | CSR0_INIT))) {
+            csr[0] &= ~CSR0_STOP;
+            if (!(am_mode & MODE_DTX)) csr[0] |= CSR0_TXON;
+            if (!(am_mode & MODE_DRX)) csr[0] |= CSR0_RXON;
+            if ((csr[0] & CSR0_INIT) && !(oreg & CSR0_INIT)) {
+                chip_init();
+                csr[0] |= CSR0_IDON;
+                am_initialized = 1;
+            }
+            DBG("[a2065] START csr0=%04X\n", csr[0]);
+        } else if ((csr[0] & CSR0_INIT) && !(oreg & CSR0_INIT) &&
+                   (oreg & CSR0_STOP)) {
+            chip_init();
+            csr[0] |= CSR0_IDON;
+            csr[0] &= ~(CSR0_RXON | CSR0_TXON | CSR0_STOP);
+            am_initialized = 1;
+            csr[3] = 0;
+            DBG("[a2065] INIT csr0=%04X\n", csr[0]);
+        }
+
+        if (csr[0] & CSR0_TDMD) {
+            if (am_initialized) {
+                if (!(csr[0] & CSR0_TXON)) {
+                    csr[0] &= ~CSR0_STOP;
+                    if (!(am_mode & MODE_DTX)) csr[0] |= CSR0_TXON;
+                    if (!(am_mode & MODE_DRX)) csr[0] |= CSR0_RXON;
+                    DBG("[a2065] implicit STRT from TDMD csr0=%04X\n", csr[0]);
+                }
+                if (on_transmit) {
+                    on_transmit();
+                }
+            }
+            csr[0] &= ~CSR0_TDMD;
+        }
+        rethink();
+        break;
+    }
+    case 1:
+        if (csr[0] & CSR0_STOP) { csr[1] = v & ~1; }
+        break;
+    case 2:
+        if (csr[0] & CSR0_STOP) { csr[2] = v & 0x00ff; }
+        break;
+    case 3:
+        if (csr[0] & CSR0_STOP) { csr[3] = v & 7; }
+        break;
+    /* CSR8–11: logical address filter */
+    case 8:  am_ladrf = (am_ladrf & 0x0000ffffffffffffULL) | ((uint64_t)v << 48); break;
+    case 9:  am_ladrf = (am_ladrf & 0xffff0000ffffffffULL) | ((uint64_t)v << 32); break;
+    case 10: am_ladrf = (am_ladrf & 0xffffffff0000ffffULL) | ((uint64_t)v << 16); break;
+    case 11: am_ladrf = (am_ladrf & 0xffffffffffff0000ULL) | v; break;
+    /* CSR12–14: physical address */
+    case 12: fakemac[1] = v >> 8; fakemac[0] = v & 0xff; break;
+    case 13: fakemac[3] = v >> 8; fakemac[2] = v & 0xff; break;
+    case 14: fakemac[5] = v >> 8; fakemac[4] = v & 0xff; break;
+    /* CSR15: mode */
+    case 15: am_mode = v; break;
+    /* CSR24/25: RX ring pointer */
+    case 24: am_rdr_rdra = (am_rdr_rdra & 0xffff0000) | v;        chip_init_mask(); break;
+    case 25: am_rdr_rdra = (am_rdr_rdra & 0x0000ffff) | (v << 16); chip_init_mask(); break;
+    /* CSR30/31: TX ring pointer */
+    case 30: am_tdr_tdra = (am_tdr_tdra & 0xffff0000) | v;        chip_init_mask(); break;
+    case 31: am_tdr_tdra = (am_tdr_tdra & 0x0000ffff) | (v << 16); chip_init_mask(); break;
+    /* CSR76/78: ring lengths */
+    case 76: am_rdr_rlen = (uint32_t)(-(int16_t)v) & 0xffff; break;
+    case 78: am_tdr_tlen = (uint32_t)(-(int16_t)v) & 0xffff; break;
+    default:
+        if (rap >= 4) csr[rap] = v;
+        break;
+    }
+}
+
+void registers_reset(void)
+{
+    memset((void*)csr, 0, sizeof csr);
+    csr[0] = CSR0_STOP;
+    csr[4] = 0x0115;
+    rap = 0;
+    am_initialized = 0;
+    tdr_offset = rdr_offset = 0;
+}

--- a/support/minimig/minimig_a2065_rings.cpp
+++ b/support/minimig/minimig_a2065_rings.cpp
@@ -1,0 +1,368 @@
+/*
+ * TX/RX descriptor ring walker — ported from Amiberry a2065.cpp
+ *
+ * do_transmit(): walk TX ring, build frame, hand to ethernet layer
+ * gotfunc():     receive frame from ethernet layer, write into RX ring
+ */
+
+#include "minimig_a2065_types.h"
+#include "minimig_a2065_debug.h"
+#include "minimig_a2065_boardram.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+/* External references — resolved at link time */
+extern volatile uint8_t *boardram;
+extern int mungepacket(uint8_t *packet, int len);
+extern uint32_t crc32_compute(const uint8_t *data, int len);
+extern void ethernet_send(const uint8_t *frame, int len);
+
+/* Register accessors from registers.cpp */
+extern uint16_t registers_csr0(void);
+extern void     registers_csr0_set(uint16_t v);
+extern void     registers_csr0_clr(uint16_t v);
+extern uint32_t registers_rdr_rdra(void);
+extern uint32_t registers_rdr_rlen(void);
+extern uint32_t registers_tdr_tdra(void);
+extern uint32_t registers_tdr_tlen(void);
+extern int *    registers_tdr_offset(void);
+extern int *    registers_rdr_offset(void);
+extern uint16_t registers_mode(void);
+extern int      registers_prom(void);
+extern uint64_t registers_ladrf(void);
+extern void     registers_get_fakemac(uint8_t *out);
+extern void     rethink(void);
+
+static uint8_t transmitbuffer[MAX_PACKET_SIZE];
+static int     transmitlen = 0;
+
+/* ── Boardram accessors (see boardram_access.h) ─ */
+
+/* ── Forward declaration (gotfunc defined after do_transmit) ──── */
+void gotfunc(const uint8_t *databuf, int len);
+
+/* ── do_transmit ────────────────────────────────────────────────────── */
+int do_transmit(void)
+{
+    int err = 0, outsize = 0, add_fcs;
+    uint32_t addr, off;
+    uint16_t tmd0, tmd1, tmd2, tmd3;
+
+    uint16_t csr0 = registers_csr0();
+    if (!(csr0 & CSR0_TXON)) return 0;
+
+    uint32_t tdr_tdra = registers_tdr_tdra();
+    uint32_t tdr_tlen = registers_tdr_tlen();
+    int *tdr_offset   = registers_tdr_offset();
+
+    if (!tdr_tlen || tdr_tlen > 512) return 0;
+    if (tdr_tdra + (tdr_tlen - 1) * 8 > RAM_MASK) return 0;
+
+    *tdr_offset %= tdr_tlen;
+    off = tdr_tdra + (uint32_t)(*tdr_offset) * 8;
+    tmd1 = get_ram_word(off + 2);
+    if (!(tmd1 & TX_OWN) || !(tmd1 & TX_STP)) {
+        int start = *tdr_offset;
+        for (uint32_t i = 0; i < tdr_tlen; i++) {
+            (*tdr_offset) = (start + i) % tdr_tlen;
+            off = tdr_tdra + (uint32_t)(*tdr_offset) * 8;
+            tmd1 = get_ram_word(off + 2);
+            if ((tmd1 & TX_OWN) && (tmd1 & TX_STP)) break;
+        }
+        if (!(tmd1 & TX_OWN) || !(tmd1 & TX_STP)) {
+            if (a2065_debug && (registers_mode() & MODE_LOOP)) {
+                fprintf(stderr, "[a2065] TX scan fail: tdr_tdra=%04X tlen=%d off=%d",
+                        tdr_tdra, tdr_tlen, start);
+                for (uint32_t i = 0; i < tdr_tlen; i++) {
+                    uint32_t d = tdr_tdra + i * 8;
+                    fprintf(stderr, " [%u]=%04X", i, get_ram_word(d + 2));
+                }
+                fprintf(stderr, "\n");
+            }
+            (*tdr_offset) = start;
+            return 0;
+        }
+    }
+
+    add_fcs = tmd1 & TX_ADD_FCS;
+
+    for (;;) {
+        *tdr_offset %= tdr_tlen;
+        off  = tdr_tdra + (uint32_t)(*tdr_offset) * 8;
+        tmd0 = get_ram_word(off + 0);
+        tmd1 = get_ram_word(off + 2);
+        tmd2 = get_ram_word(off + 4);
+        tmd3 = get_ram_word(off + 6);
+        addr = (uint32_t)tmd0 | ((uint32_t)(tmd1 & 0xff) << 16);
+        addr &= RAM_MASK;
+
+        if (!(tmd1 & TX_OWN)) {
+            tmd3 |= TX_BUFF | TX_UFLO;
+            tmd1 |= TX_ERR;
+            registers_csr0_clr(CSR0_TXON);
+            DBG("[a2065] TX OWN not set\n");
+            err = 1;
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            break;
+        }
+
+        tmd1 &= ~TX_OWN;
+        int size = (int)(65536 - tmd2);
+        if (size > MAX_PACKET_SIZE) size = MAX_PACKET_SIZE;
+        if (outsize + size > MAX_PACKET_SIZE) {
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            break;
+        }
+        ram_read_block(addr, (uint8_t *)&transmitbuffer[outsize], size);
+        outsize += size;
+        if ((tmd1 & TX_ENP) && outsize < 60 && !(registers_mode() & MODE_LOOP)) {
+            while (outsize < 60) transmitbuffer[outsize++] = 0;
+        }
+        (*tdr_offset)++;
+
+        if (tmd1 & TX_ENP)
+            break;
+
+        put_ram_word(off + 2, tmd1);
+        put_ram_word(off + 6, tmd3);
+    }
+
+    if (err) {
+        registers_csr0_set(CSR0_TINT);
+        rethink();
+        return 1;
+    }
+
+    if (outsize < 60 && !(registers_mode() & MODE_LOOP)) {
+        tmd3 |= TX_BUFF | TX_UFLO;
+        tmd1 |= TX_ERR;
+        registers_csr0_clr(CSR0_TXON);
+        DBG("[a2065] TX underflow: %d bytes\n", outsize);
+        put_ram_word(off + 6, tmd3);
+        put_ram_word(off + 2, tmd1);
+        registers_csr0_set(CSR0_TINT);
+        rethink();
+        return 1;
+    }
+
+    uint16_t mode = registers_mode();
+
+    if (mode & MODE_LOOP) {
+        if (mode & MODE_COLL) {
+            tmd1 |= TX_ERR;
+            tmd3 |= TX_RTRY;
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            DBG("[a2065] TX LOOP+COLL tmd1=%04X tmd3=%04X\n", tmd1, tmd3);
+        } else {
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            DBG("[a2065] TX LOOP %d bytes\n", outsize);
+            gotfunc(transmitbuffer, outsize);
+        }
+    } else {
+        int coll = (mode & MODE_COLL) != 0;
+        if (!coll && outsize >= 6) {
+            uint8_t fakemac_buf[6];
+            registers_get_fakemac(fakemac_buf);
+            if (memcmp(transmitbuffer, fakemac_buf, 6) == 0) {
+                coll = 1;
+                DBG("[a2065] TX self-loopback collision\n");
+            }
+        }
+        if (coll) {
+            tmd1 |= TX_ERR;
+            tmd3 |= TX_RTRY;
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            DBG("[a2065] TX COLL tmd1=%04X tmd3=%04X\n", tmd1, tmd3);
+        } else {
+            put_ram_word(off + 2, tmd1);
+            put_ram_word(off + 6, tmd3);
+            if ((mode & MODE_DTCR) && !add_fcs)
+                outsize -= 4;
+            transmitlen = outsize;
+            mungepacket(transmitbuffer, transmitlen);
+            ethernet_send(transmitbuffer, transmitlen);
+            DBG("[a2065] TX %d bytes DST=%02X:%02X:%02X:%02X:%02X:%02X\n",
+                    transmitlen,
+                    transmitbuffer[0], transmitbuffer[1], transmitbuffer[2],
+                    transmitbuffer[3], transmitbuffer[4], transmitbuffer[5]);
+        }
+    }
+
+    registers_csr0_set(CSR0_TINT);
+    rethink();
+    return 1;
+}
+
+/* ── gotfunc (RX) ───────────────────────────────────────────────────── */
+static int loopback_iter = 0;
+void rings_reset_loopback_count(void) { loopback_iter = 0; }
+
+/* RX drop accounting — where frames die between the daemon and Amiga TCP. */
+static unsigned long rx_drop_rxoff = 0;   /* RXON off (incl. after an OFLO) */
+static unsigned long rx_drop_ringfull = 0;/* no OWN descriptor */
+static unsigned long rx_delivered = 0;    /* written into the ring */
+void rings_get_rx_stats(unsigned long *deliv, unsigned long *rxoff, unsigned long *ringfull)
+{ *deliv = rx_delivered; *rxoff = rx_drop_rxoff; *ringfull = rx_drop_ringfull; }
+
+/* ── rings_rx_has_space ──────────────────────────────────────────────────
+ * Peek (non-destructive) whether the RX ring can accept another frame: RXON is
+ * on and the descriptor at the current rdr_offset is still owned by the LANCE
+ * (RX_OWN set). Used by the rx_thread for socket backpressure — when this is
+ * false it stops draining the socket, so the kernel's large receive buffer
+ * holds the burst losslessly instead of the daemon overflowing the tiny ring
+ * (which would clear RXON via RX_OFLO and cascade into a stall). The Amiga only
+ * ever frees descriptors (gives RX_OWN back) as it drains, so a positive answer
+ * here cannot be invalidated by the Amiga before we deliver. */
+int rings_rx_has_space(void)
+{
+    if (!(registers_csr0() & CSR0_RXON)) return 0;          /* RX disabled — hold */
+    uint32_t rdr_rlen = registers_rdr_rlen();
+    if (!rdr_rlen || rdr_rlen > 512) return 1;              /* unconfigured — don't block */
+    uint32_t rdr_rdra = registers_rdr_rdra();
+    if (rdr_rdra + (rdr_rlen - 1) * 8 > RAM_MASK) return 1;
+    int *rdr_offset = registers_rdr_offset();
+    uint32_t off = rdr_rdra + (uint32_t)((*rdr_offset) % rdr_rlen) * 8;
+    uint16_t rmd1 = get_ram_word(off + 2);
+    return (rmd1 & RX_OWN) ? 1 : 0;
+}
+
+void gotfunc(const uint8_t *databuf, int len)
+{
+    if (registers_mode() & MODE_LOOP)
+        DBG("[a2065] gotfunc entry len=%d csr0=%04X\n", len, registers_csr0());
+    int insize = 0, first = 1, size;
+    uint32_t addr, off;
+    uint16_t rmd0, rmd1, rmd2, rmd3;
+    uint8_t tmp[MAX_PACKET_SIZE];
+    uint8_t fakemac_buf[6];
+
+    if (!(registers_csr0() & CSR0_RXON)) {
+        if (registers_mode() & MODE_LOOP)
+            DBG("[a2065] RX LOOP skip: RXON off csr0=%04X\n", registers_csr0());
+        rx_drop_rxoff++;
+        return;
+    }
+    if (len < 20) { DBG("[a2065] RX LOOP skip: len=%d < 20\n", len); return; }
+    uint32_t rdr_rlen = registers_rdr_rlen();
+    if (!rdr_rlen || rdr_rlen > 512) { DBG("[a2065] RX skip: bad rdr_rlen=%u\n", rdr_rlen); return; }
+    if (registers_rdr_rdra() + (rdr_rlen - 1) * 8 > RAM_MASK) { DBG("[a2065] RX skip: rdr overflow\n"); return; }
+
+    registers_get_fakemac(fakemac_buf);
+
+    /* Munge BEFORE filtering: on the wire we use the unique realmac, so an
+     * incoming reply is addressed to realmac. mungepacket() swaps realmac->
+     * fakemac (the Amiga's station MAC), after which every filter below can
+     * compare against fakemac as before. Filtering the raw frame would drop
+     * unicast replies (dst=realmac != fakemac). */
+    memcpy(tmp, databuf, len);
+    uint8_t *d = tmp;
+    if (!(registers_mode() & MODE_LOOP))
+        mungepacket(d, len);
+
+    const uint8_t *dstmac = d;
+    const uint8_t *srcmac = d + 6;
+
+    if (!(registers_mode() & MODE_LOOP)) {
+        if (dstmac[0] & 0x01) {
+            /* Multicast (group bit set). Broadcast is always accepted.
+             * For other multicast the Am7990 hashes the destination address
+             * into the 64-bit logical address filter (LADRF): the top 6 bits
+             * of the (non-inverted) CRC-32 of the 6 address bytes select a bit;
+             * the frame is accepted only if that LADRF bit is set. With LADRF=0
+             * (no groups joined) all multicast is rejected — matching hardware,
+             * and stopping the daemon from flooding the RX ring with IPv6
+             * ND/MLD traffic the Amiga never asked for. PROM mode bypasses. */
+            if (!registers_prom() &&
+                memcmp(dstmac, BROADCAST_MAC, 6) != 0) {
+                uint32_t hash = (~crc32_compute(dstmac, 6)) >> 26;
+                if (!(registers_ladrf() & (1ULL << hash)))
+                    return;
+            }
+        } else {
+            if (!registers_prom() &&
+                memcmp(dstmac, fakemac_buf, 6) != 0 &&
+                memcmp(dstmac, BROADCAST_MAC, 6) != 0) {
+                return;
+            }
+        }
+    }
+
+    /* Drop loopback: src == dst == us (skip in internal loopback mode) */
+    if (!(registers_mode() & MODE_LOOP) &&
+        memcmp(dstmac, fakemac_buf, 6) == 0 &&
+        memcmp(srcmac, fakemac_buf, 6) == 0) return;
+
+    if (!(registers_mode() & MODE_LOOP)) {
+        if (memcmp(dstmac, BROADCAST_MAC, 6) == 0 &&
+            memcmp(srcmac, fakemac_buf, 6) == 0) return;
+    }
+
+    uint32_t crc = crc32_compute(d, len);
+    d[len++] = (uint8_t)(crc >> 24);
+    d[len++] = (uint8_t)(crc >> 16);
+    d[len++] = (uint8_t)(crc >>  8);
+    d[len++] = (uint8_t)(crc);
+
+    uint32_t rdr_rdra = registers_rdr_rdra();
+    int *rdr_offset   = registers_rdr_offset();
+
+    for (;;) {
+        *rdr_offset %= rdr_rlen;
+        off  = rdr_rdra + (uint32_t)(*rdr_offset) * 8;
+        rmd0 = get_ram_word(off + 0);
+        rmd1 = get_ram_word(off + 2);
+        rmd2 = get_ram_word(off + 4);
+        rmd3 = get_ram_word(off + 6);
+        addr = (uint32_t)rmd0 | ((uint32_t)(rmd1 & 0xff) << 16);
+        addr &= RAM_MASK;
+
+        if (!(rmd1 & RX_OWN)) {
+            DBG("[a2065] RX buffer error\n");
+            rx_drop_ringfull++;
+            if (!first) {
+                rmd1 |= RX_BUFF | RX_OFLO;
+                registers_csr0_clr(CSR0_RXON);
+            } else {
+                registers_csr0_set(CSR0_MISS);
+            }
+            put_ram_word(off + 2, rmd1);
+            rethink();
+            return;
+        }
+
+        rmd1 &= ~RX_OWN;
+        (*rdr_offset)++;
+
+        if (first) { rmd1 |= RX_STP; first = 0; }
+
+        size = (int)(65536 - rmd2);
+        ram_write_block(addr, &d[insize], size);
+        insize += size;
+
+        if (insize >= len) {
+            rmd1 |= RX_ENP;
+            rmd3 = (uint16_t)len;
+        }
+
+        put_ram_word(off + 2, rmd1);
+        put_ram_word(off + 6, rmd3);
+
+        if (insize >= len) break;
+    }
+
+    registers_csr0_set(CSR0_RINT);
+    rethink();
+    rx_delivered++;
+    if (registers_mode() & MODE_LOOP) {
+        loopback_iter++;
+        DBG("[a2065] RX LOOP OK #%d %d bytes\n", loopback_iter, len - 4);
+    } else {
+        DBG("[a2065] RX %d bytes\n", len - 4);
+    }
+}

--- a/support/minimig/minimig_a2065_types.h
+++ b/support/minimig/minimig_a2065_types.h
@@ -1,0 +1,82 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+/* ── CSR0 bits ─────────────────────────────────────────────────────── */
+#define CSR0_ERR    0x8000
+#define CSR0_BABL   0x4000
+#define CSR0_CERR   0x2000
+#define CSR0_MISS   0x1000
+#define CSR0_MERR   0x0800
+#define CSR0_RINT   0x0400
+#define CSR0_TINT   0x0200
+#define CSR0_IDON   0x0100
+#define CSR0_INTR   0x0080
+#define CSR0_INEA   0x0040
+#define CSR0_RXON   0x0020
+#define CSR0_TXON   0x0010
+#define CSR0_TDMD   0x0008
+#define CSR0_STOP   0x0004
+#define CSR0_STRT   0x0002
+#define CSR0_INIT   0x0001
+
+/* ── CSR3 bits ─────────────────────────────────────────────────────── */
+#define CSR3_BSWP   0x0004
+#define CSR3_ACON   0x0002
+#define CSR3_BCON   0x0001
+
+/* ── Mode register bits ─────────────────────────────────────────────── */
+#define MODE_PROM   0x8000
+#define MODE_EMBA   0x0080
+#define MODE_INTL   0x0040
+#define MODE_DRTY   0x0020
+#define MODE_COLL   0x0010
+#define MODE_DTCR   0x0008
+#define MODE_LOOP   0x0004
+#define MODE_DTX    0x0002
+#define MODE_DRX    0x0001
+
+/* ── TX descriptor bits ─────────────────────────────────────────────── */
+#define TX_OWN      0x8000
+#define TX_ERR      0x4000
+#define TX_ADD_FCS  0x2000
+#define TX_MORE     0x1000
+#define TX_ONE      0x0800
+#define TX_DEF      0x0400
+#define TX_STP      0x0200
+#define TX_ENP      0x0100
+#define TX_BUFF     0x8000
+#define TX_UFLO     0x4000
+#define TX_LCOL     0x1000
+#define TX_LCAR     0x0800
+#define TX_RTRY     0x0400
+
+/* ── RX descriptor bits ─────────────────────────────────────────────── */
+#define RX_OWN      0x8000
+#define RX_ERR      0x4000
+#define RX_FRAM     0x2000
+#define RX_OFLO     0x1000
+#define RX_CRC      0x0800
+#define RX_BUFF     0x0400
+#define RX_STP      0x0200
+#define RX_ENP      0x0100
+
+/* ── Sizes ──────────────────────────────────────────────────────────── */
+#define RAP_SIZE        128
+#define MAX_PACKET_SIZE 4096
+#define RAM_OFFSET      0x8000
+#define RAM_SIZE        0x8000
+
+/* ── A2065 card identity ────────────────────────────────────────────── */
+#define A2065_MFR_ID    0x0202          /* Commodore-Amiga */
+#define A2065_PROD_ID   0x70            /* 112 */
+#define COMMODORE_OUI0  0x00
+#define COMMODORE_OUI1  0x80
+#define COMMODORE_OUI2  0x10
+
+/* ── Chip register offsets within card (for bridge addr field) ──────── */
+#define A2065_RDP_OFF   0x00            /* Register Data Port offset */
+#define A2065_RAP_OFF   0x02            /* Register Address Pointer offset */
+
+static const uint8_t BROADCAST_MAC[6] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -17,6 +17,7 @@
 #include "minimig_fdd.h"
 #include "minimig_config.h"
 #include "minimig_share.h"
+#include "minimig_a2065.h"
 
 const char *config_memory_chip_msg[] = { "512K", "1M",   "1.5M", "2M" };
 const char *config_memory_slow_msg[] = { "none", "512K", "1M",   "1.5M" };
@@ -285,6 +286,10 @@ static char* GetConfigurationName(int num, int chk)
 
 int minimig_cfg_save(int num)
 {
+	// The A2065 interface selection rides in core status bits, which Minimig
+	// excludes from the generic status-word config load, so it is stored
+	// beside the config slot rather than inside the size-checked blob.
+	a2065_cfg_save(num);
 	return FileSaveConfig(GetConfigurationName(num, 0), &minimig_config, sizeof(minimig_config));
 }
 
@@ -487,6 +492,10 @@ int minimig_cfg_load(int num)
 		BootPrintEx(">>> No config found. Using defaults. <<<");
 	}
 
+	// Restore the A2065 interface selection for this slot (kept in core status
+	// bits, saved beside the config blob by minimig_cfg_save()).
+	a2065_cfg_load(num);
+
 	for (int i = 0; i < 4; i++)
 	{
 		df[i].status = 0;
@@ -524,6 +533,7 @@ void minimig_reset()
 	ApplyConfiguration(0);
 	user_io_rtc_reset();
 	minimig_share_reset();
+	a2065_start();
 }
 
 void minimig_set_kickstart(char *name)

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1389,6 +1389,10 @@ void user_io_init(const char *path, const char *xml)
 	// Clean up old game ID when loading a new core
 	unlink("/tmp/GAMEID");
 
+	// Stop the A2065 threads left over from a previous core. The Minimig boot
+	// path below restarts them if the card is enabled.
+	a2065_stop();
+
 	// we need to set the directory to where the XML file (MRA) is
 	// not the RBF. The RBF will be in arcade, which the user shouldn't
 	// browse
@@ -1553,6 +1557,7 @@ void user_io_init(const char *path, const char *xml)
 				{
 					printf("Identified Minimig V2 core");
 					BootInit();
+					a2065_start();
 				}
 				else if (is_x86() || is_pcxt())
 				{
@@ -3167,6 +3172,7 @@ void user_io_poll()
 		}
 
 		minimig_share_poll();
+		a2065_poll();
 	}
 
 	if (core_type == CORE_TYPE_8BIT && !is_menu())


### PR DESCRIPTION
# minimig: A2065 Ethernet card support

Host half of the emulated Commodore **A2065** ZorroII Ethernet card for the
Minimig core. Works with the standard AmigaOS A2065 drivers — no custom
Amiga-side software.

Companion to MiSTer-devel/Minimig-AGA_MiSTer#215, which adds the FPGA side.
Neither half does anything without the other.

## What this adds

The FPGA implements ZorroII autoconfig, the boardram window and the LANCE CSR
register file. This side implements the AMD **Am7990 LANCE** controller state
machine, the TX/RX descriptor ring walker, the station-MAC munge, and the
bridge to a host network interface.

## No threads

It creates none. Main is single-threaded with one CPU to itself, so a helper
thread here would compete with the code servicing the core. The card does its
work from `a2065_poll()`, called from the poll loop alongside
`minimig_share_poll()`.

Both halves of that call are bounded and non-blocking: the doorbell drain takes
whatever the FPGA has posted, and the receive path takes at most one batch from
the socket, leaving the rest in the kernel buffer for the next pass.

Nothing makes the Amiga wait on this code either. The FPGA posts register writes
into a DDR3 ring and releases the bus immediately, rather than holding it until
the host has read the entry — which matters because Main busy-waits on the Amiga
inside its IDE handler, and with the Amiga waiting back the two would deadlock.

## OSD

The Minimig **System** page gains an `Ethernet` option, held in core status bits
`[54:52]`:

| | |
|---|---|
| `OFF` | default — the card is strictly opt-in |
| `eth0` | onboard NIC shared with MiSTer: promiscuous + a cBPF filter |
| `eth1` | dedicated second NIC, carrying the Amiga's MAC |
| `macvlan` | macvlan child of eth0: the Amiga gets its own LAN address without a second NIC and without disturbing MiSTer's own |
| `tap0` | tap device for host-side routing — the only route out over WiFi, since an 802.11 station cannot emit a second source MAC |

Modes the running kernel cannot support are skipped in the OSD cycle.
Availability is settled by asking the kernel to do the thing once and caching
the answer — opening `/dev/net/tun`, and a macvlan create-then-delete — because
both features are routinely compiled in (`CONFIG_TUN=y`, `CONFIG_MACVLAN=y`),
where there is deliberately no module to find.

Minimig is excluded from the generic status-word config load, and
`mm_configTYPE` cannot grow (its loader does an exact `sizeof()` check), so the
selection is persisted beside each numbered config slot and follows the slot
like every other System-page option.

## Verification

On hardware (DE10-Nano), through the Amiga's own TCP/IP stack (Roadshow):

| Mode | DHCP | Ping | 100 MB download | AmiSpeedTest down/up |
|---|---|---|---|---|
| eth0 (bpf) | 192.168.1.73 | 10/10, 0% loss | 478.73 KB/s | 5179 / 4397 kb/s |
| eth1 (direct) | 192.168.1.90 | 10/10, 0% loss | 559.33 KB/s | 5572 / 4385 kb/s |
| eth0 (macvlan) | 192.168.1.73 | 10/10, 0% loss | 493.92 KB/s | 5185 / 4384 kb/s |
| tap0 | 192.168.10.2 | 10/10, 0% loss | 571.43 KB/s | — |

All four transfers byte-exact. The ceiling there is the 68000 itself — the
Amiga's stack hits zero-window flow control on a sustained transfer — not any
particular delivery mode.

Also: lance-test controller diagnostics 5/5, and config save/load verified
across slots, including that existing `.cfg` files are unchanged in size so the
loader's exact `sizeof()` check still passes.

## Notes

- `$(wildcard ./support/*/*.cpp)` picks the new sources up; no Makefile change.
- Sources are named `minimig_a2065*` and sit flat in `support/minimig/`,
  matching `minimig_boot` / `minimig_fdd` / `minimig_share`.
- All descriptors are opened `CLOEXEC`, so spawned helpers do not inherit the
  raw socket.
- Verified on TG68 (68020); fx68k (68000) not exercised.
