### PR TITLE
SNES: Add missing SA1 config to rom detect

### DIFF
--- a/support/snes/snes.cpp
+++ b/support/snes/snes.cpp
@@ -315,7 +315,7 @@ uint8_t* snes_get_header(fileTYPE *f)
 					}
 
 					//SA1 6
-					if (buf[addr + Mapper] == 0x23 && (buf[addr + RomType] == 0x32 || buf[addr + RomType] == 0x34 || buf[addr + RomType] == 0x35))
+					if (buf[addr + Mapper] == 0x23 && (buf[addr + RomType] == 0x32 || buf[addr + RomType] == 0x33 || buf[addr + RomType] == 0x34 || buf[addr + RomType] == 0x35))
 					{
 						hdr[1] |= 0x60;
 					}


### PR DESCRIPTION
This is a valid config for SA1, not used by commercial games but a test rom in this case.

Fixes https://github.com/MiSTer-devel/SNES_MiSTer/issues/500