### PR TITLE
IDE: complete common no-data ATA commands

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -946,7 +946,24 @@ static int handle_hdd(ide_config *ide)
 
 	case 0x40: // READ VERIFY
 		dbg_printf("Received read verify command. Not implemented but returning OK.\n");
-		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_IRQ;
+		ide->regs.error = 0;
+		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_DSC | ATA_STATUS_IRQ;
+		ide_set_regs(ide);
+		break;
+
+	case 0x70: // seek
+	case 0xE3: // standby immediate
+		// These no-data commands complete immediately for image-backed disks.
+		ide->regs.error = 0;
+		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_DSC | ATA_STATUS_IRQ;
+		ide_set_regs(ide);
+		break;
+
+	case 0x90: // execute device diagnostic
+		// Return the ATA drive-0-passed diagnostic code. Some system BIOSes
+		// require this command to succeed before registering the disk.
+		ide->regs.error = 0x01;
+		ide->regs.status = ATA_STATUS_RDY | ATA_STATUS_DSC | ATA_STATUS_IRQ;
 		ide_set_regs(ide);
 		break;
 


### PR DESCRIPTION
Completes several standard no-data ATA commands for image-backed hard disks:

- READ VERIFY (`0x40`)
- SEEK (`0x70`)
- EXECUTE DEVICE DIAGNOSTIC (`0x90`)
- STANDBY IMMEDIATE (`0xE3`)

The former PC110 profile and explicit geometry changes have been removed. The PC110 core now advertises the existing `AO486` service identity. The current PR does not replace or override CHS geometry.

The tested PersonaWare image retains the geometry with which it was partitioned: its MBR encodes `C0/H1/S1` through `C127/H1/S32`, and its FAT BPB records 32 sectors/track, 2 heads, and 32 hidden sectors. Its same-basename VHD metadata merely declares those existing values to Main (`HEADS = 2`, `SECTORS = 32`, `CYLINDERS = 128`). The core README now explicitly warns never to apply those values to an image formatted with different CHS.

For image-backed drives the commands in this PR complete synchronously with ready/seek-complete status. The diagnostic command reports the ATA drive-0-passed code (`error=0x01`).