### PR TITLE
minimig: native CD32 (Akiko) and CDTV CD-ROM host support

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -21,6 +21,9 @@
 #include "file_io.h"
 #include "hardware.h"
 #include "ide.h"
+#include "ide_cdrom.h"
+#include "support/minimig/akiko_cd32.h"
+#include "support/minimig/cdtv_cd.h"
 
 #if 0
 	#define dbg_printf     printf
@@ -1116,7 +1119,11 @@ int ide_open(uint8_t unit, const char* filename)
 	static fileTYPE hdd_file[4] = {};
 	chs_t chs = {};
 
-	if (!is_minimig() || ((minimig_config.ide_cfg & 1) && minimig_config.hardfile[unit].cfg))
+	bool cdtv_cd_slot = (minimig_config.chipset & CONFIG_CDTV)
+	                 && minimig_config.hardfile[unit].cfg == 2;
+	if (!is_minimig()
+	    || ((minimig_config.ide_cfg & 1) && minimig_config.hardfile[unit].cfg)
+	    || cdtv_cd_slot)
 	{
 		printf("\nChecking HDD %d\n", unit);
 		if (filename[0] && FileOpenEx(&hdd_file[unit], filename, FileCanWrite(filename) ? O_RDWR : O_RDONLY))
@@ -1152,6 +1159,13 @@ int ide_open(uint8_t unit, const char* filename)
 	}
 
 	// close if opened earlier.
+	{
+		int port = (unit >> 1) & 1;
+		int drv  = unit & 1;
+		cdrom_close_chd(&ide_inst[port].drive[drv]);
+		if (unit == 0) akiko_cd32_set_cd_path("");
+		if (unit == 0) cdtv_cd_set_cd_path("");
+	}
 	ide_img_set(unit, 0, 0);
 	FileClose(&hdd_file[unit]);
 	return 0;

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1102,7 +1102,104 @@ void cdrom_read(ide_config *ide)
 	pkt_send(ide, ide_buf, cnt * 2048);
 }
 
-static int disc_info(drive_t *drv, uint16_t maxlen) 
+int cdrom_read_raw_sector(drive_t *drive, uint32_t lba, uint8_t *buf)
+{
+	if (!drive || !buf) return -1;
+
+	bool is_index0 = false;
+	track_t *track = get_track_from_lba(drive, lba, is_index0);
+	if (!track) return -1;
+
+	if (drive->chd_f)
+	{
+		uint32_t chd_lba = lba + track->chd_offset;
+		uint16_t sz = track->sectorSize;
+
+		if (sz == BYTES_PER_RAW_REDBOOK_FRAME)
+		{
+			if (mister_chd_read_sector(drive->chd_f, chd_lba, 0, 0,
+			                           BYTES_PER_RAW_REDBOOK_FRAME, buf,
+			                           drive->chd_hunkbuf, &drive->chd_hunknum)
+			    != CHDERR_NONE) return -1;
+			return 0;
+		}
+
+		if (sz == 2336)
+		{
+			memset(buf, 0, BYTES_PER_RAW_REDBOOK_FRAME);
+			if (mister_chd_read_sector(drive->chd_f, chd_lba, 16, 0,
+			                           2336, buf,
+			                           drive->chd_hunkbuf, &drive->chd_hunknum)
+			    != CHDERR_NONE) return -1;
+			return 0;
+		}
+
+		if (sz == BYTES_PER_COOKED_REDBOOK_FRAME)
+		{
+			memset(buf, 0, BYTES_PER_RAW_REDBOOK_FRAME);
+			buf[0] = 0x00;
+			memset(buf + 1, 0xff, 10);
+			buf[11] = 0x00;
+			uint32_t f_lba = lba + REDBOOK_FRAME_PADDING;
+			uint8_t mm = (uint8_t)(f_lba / (REDBOOK_FRAMES_PER_SECOND * 60));
+			uint8_t ss = (uint8_t)((f_lba / REDBOOK_FRAMES_PER_SECOND) % 60);
+			uint8_t ff = (uint8_t)(f_lba % REDBOOK_FRAMES_PER_SECOND);
+			buf[12] = (uint8_t)(((mm / 10) << 4) | (mm % 10));
+			buf[13] = (uint8_t)(((ss / 10) << 4) | (ss % 10));
+			buf[14] = (uint8_t)(((ff / 10) << 4) | (ff % 10));
+			buf[15] = 0x01;
+			if (mister_chd_read_sector(drive->chd_f, chd_lba, 16, 0,
+			                           BYTES_PER_COOKED_REDBOOK_FRAME, buf,
+			                           drive->chd_hunkbuf, &drive->chd_hunknum)
+			    != CHDERR_NONE) return -1;
+			return 0;
+		}
+
+		return -1;
+	}
+
+	if (!track->f.opened()) return -1;
+
+	uint16_t sz = track->sectorSize;
+	uint32_t pos = track->skip + (lba - track->start) * sz;
+	if (FileSeek(&track->f, pos, SEEK_SET) < 0) return -1;
+
+	if (sz == BYTES_PER_RAW_REDBOOK_FRAME)
+	{
+		if (FileReadAdv(&track->f, buf, BYTES_PER_RAW_REDBOOK_FRAME, -1) <= 0)
+			return -1;
+		return 0;
+	}
+
+	if (sz == 2336)
+	{
+		memset(buf, 0, 16);
+		if (FileReadAdv(&track->f, buf + 16, 2336, -1) <= 0) return -1;
+		return 0;
+	}
+
+	if (sz == BYTES_PER_COOKED_REDBOOK_FRAME)
+	{
+		memset(buf, 0, BYTES_PER_RAW_REDBOOK_FRAME);
+		buf[0] = 0x00;
+		memset(buf + 1, 0xff, 10);
+		buf[11] = 0x00;
+		uint32_t f_lba = lba + REDBOOK_FRAME_PADDING;
+		uint8_t mm = (uint8_t)(f_lba / (REDBOOK_FRAMES_PER_SECOND * 60));
+		uint8_t ss = (uint8_t)((f_lba / REDBOOK_FRAMES_PER_SECOND) % 60);
+		uint8_t ff = (uint8_t)(f_lba % REDBOOK_FRAMES_PER_SECOND);
+		buf[12] = (uint8_t)(((mm / 10) << 4) | (mm % 10));
+		buf[13] = (uint8_t)(((ss / 10) << 4) | (ss % 10));
+		buf[14] = (uint8_t)(((ff / 10) << 4) | (ff % 10));
+		buf[15] = 0x01;
+		if (FileReadAdv(&track->f, buf + 16, 2048, -1) <= 0) return -1;
+		return 0;
+	}
+
+	return -1;
+}
+
+static int disc_info(drive_t *drv, uint16_t maxlen)
 {
 	if (!maxlen) return 0;
 	if (maxlen > 34) maxlen = 34;
@@ -1684,6 +1781,22 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 	int drv = num & 1;
 	num >>= 1;
 
+	static char last_path[2][2][1024] = {};
+	const char *cmp_filename = filename ? filename : "";
+	bool same_path = filename && filename[0]
+	                 && !strcmp(last_path[num][drv], cmp_filename)
+	                 && ide_inst[num].drive[drv].chd_f != NULL;
+
+	if (same_path) {
+		const char *full = getFullPath(filename);
+		ide_inst[num].drive[drv].mcr_flag = true;
+		ide_inst[num].drive[drv].playing = 0;
+		ide_inst[num].drive[drv].paused = 0;
+		ide_inst[num].drive[drv].play_start_lba = 0;
+		ide_inst[num].drive[drv].play_end_lba = 0;
+		return full;
+	}
+
 	//always close files and reset state. empty filename == unmounted cd from OSD
 	cdrom_close_chd(&ide_inst[num].drive[drv]);
 	for (uint8_t i = 0; i < sizeof(ide_inst[num].drive[drv].track) / sizeof(track_t); i++)
@@ -1698,13 +1811,22 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 	ide_inst[num].drive[drv].paused = 0;
 	ide_inst[num].drive[drv].play_start_lba = 0;
 	ide_inst[num].drive[drv].play_end_lba = 0;
+	const char *path = NULL;
 	if (strlen(filename))
 	{
-		const char *path = getFullPath(filename);
+		path = getFullPath(filename);
 		res = load_chd_file(&ide_inst[num].drive[drv], path);
 		if (!res) res = load_cue_file(&ide_inst[num].drive[drv], path);
 		if (!res) res = load_iso_file(&ide_inst[num].drive[drv], path);
 	}
+
+	if (filename && filename[0] && res) {
+		strncpy(last_path[num][drv], cmp_filename, sizeof(last_path[0][0]) - 1);
+		last_path[num][drv][sizeof(last_path[0][0]) - 1] = '\0';
+	} else {
+		last_path[num][drv][0] = '\0';
+	}
+
 	return res;
 }
 

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -348,6 +348,7 @@ static const char* load_chd_file(drive_t *drv, const char *chdfile)
 		if (drv->track[i].attr == 0x40)
 		{
 			drv->data_num = i;
+			break;
 		}
 	}
 

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1738,7 +1738,7 @@ void ide_cdda_send_sector()
 	{
 		if (drv->chd_f)
 		{
-			mister_chd_read_sector(drv->chd_f, drv->play_start_lba + drv->track[drv->data_num].chd_offset, 0, 0, BYTES_PER_RAW_REDBOOK_FRAME, cdda_buf, drv->chd_hunkbuf, &drv->chd_hunknum);
+			mister_chd_read_sector(drv->chd_f, drv->play_start_lba + track->chd_offset, 0, 0, BYTES_PER_RAW_REDBOOK_FRAME, cdda_buf, drv->chd_hunkbuf, &drv->chd_hunknum);
 			needs_swap = true;
 		}
 		else

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -20,6 +20,7 @@
 #include "hardware.h"
 #include "cd.h"
 #include "ide.h"
+#include "support/minimig/akiko_cd32.h"
 
 #if 0
 #define dbg_printf     printf
@@ -1794,6 +1795,7 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 		ide_inst[num].drive[drv].paused = 0;
 		ide_inst[num].drive[drv].play_start_lba = 0;
 		ide_inst[num].drive[drv].play_end_lba = 0;
+		akiko_cd32_set_cd_path(full);
 		return full;
 	}
 
@@ -1819,6 +1821,8 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 		if (!res) res = load_cue_file(&ide_inst[num].drive[drv], path);
 		if (!res) res = load_iso_file(&ide_inst[num].drive[drv], path);
 	}
+
+	akiko_cd32_set_cd_path((path && res) ? path : "");
 
 	if (filename && filename[0] && res) {
 		strncpy(last_path[num][drv], cmp_filename, sizeof(last_path[0][0]) - 1);

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -21,6 +21,7 @@
 #include "cd.h"
 #include "ide.h"
 #include "support/minimig/akiko_cd32.h"
+#include "support/minimig/cdtv_cd.h"
 
 #if 0
 #define dbg_printf     printf
@@ -1796,6 +1797,7 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 		ide_inst[num].drive[drv].play_start_lba = 0;
 		ide_inst[num].drive[drv].play_end_lba = 0;
 		akiko_cd32_set_cd_path(full);
+		cdtv_cd_set_cd_path(full);
 		return full;
 	}
 
@@ -1823,6 +1825,7 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 	}
 
 	akiko_cd32_set_cd_path((path && res) ? path : "");
+	cdtv_cd_set_cd_path((path && res) ? path : "");
 
 	if (filename && filename[0] && res) {
 		strncpy(last_path[num][drv], cmp_filename, sizeof(last_path[0][0]) - 1);

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1005,8 +1005,7 @@ static void pkt_send(ide_config *ide, void *data, uint16_t size)
 
 static void read_cd_sectors(ide_config *ide, track_t *track, int cnt)
 {
-	drive_t *drv = &ide->drive[ide->regs.drv];
-	uint32_t sz = drv->track[drv->data_num].sectorSize;
+	uint32_t sz = track->sectorSize;
 
 	if (sz == 2048)
 	{
@@ -1015,7 +1014,7 @@ static void read_cd_sectors(ide_config *ide, track_t *track, int cnt)
 		return;
 	}
 
-	uint32_t pre = drv->track[drv->data_num].mode2 ? 24 : 16;
+	uint32_t pre = track->mode2 ? 24 : 16;
 	uint32_t post = sz - pre - 2048;
 	uint32_t off = 0;
 
@@ -1061,8 +1060,8 @@ void cdrom_read(ide_config *ide)
 
 	if (drive->chd_f) {
 
-		uint32_t hdr = drive->track[drive->data_num].mode2 ? 24 : 16;
-		if (drive->track[drive->data_num].sectorSize == 2048)
+		uint32_t hdr = track->mode2 ? 24 : 16;
+		if (track->sectorSize == 2048)
 		{
 			hdr = 0;
 		}
@@ -1076,7 +1075,7 @@ void cdrom_read(ide_config *ide)
 		for (uint32_t i = 0; i < cnt; i++)
 		{
 
-			if (mister_chd_read_sector(drive->chd_f, drive->chd_last_partial_lba + drive->track[drive->data_num].chd_offset, d_offset, hdr, 2048, ide_buf, drive->chd_hunkbuf, &drive->chd_hunknum) != CHDERR_NONE)
+			if (mister_chd_read_sector(drive->chd_f, drive->chd_last_partial_lba + track->chd_offset, d_offset, hdr, 2048, ide_buf, drive->chd_hunkbuf, &drive->chd_hunknum) != CHDERR_NONE)
 			{
 				//I don't think anything else uses this, but set it just in case.
 				ide->null = 1;

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -465,7 +465,17 @@ static const char* load_cue_file(drive_t *drv, const char *cuefile)
 			canAddTrack = 0;
 
 			std::string filename;
-			std::getline(std::getline(line, filename, '"'), filename, '"');
+			std::string leading;
+			std::getline(line, leading, '"');
+			if (line.good())
+			{
+				std::getline(line, filename, '"');
+			}
+			else
+			{
+				std::istringstream toks(leading);
+				toks >> filename;
+			}
 
 			strcpy(track.filename, pathname.c_str());
 			strcat(track.filename, filename.c_str());

--- a/ide_cdrom.h
+++ b/ide_cdrom.h
@@ -8,6 +8,9 @@ void cdrom_read(ide_config *ide);
 void cdrom_mode_select(ide_config *ide);
 void ide_cdda_send_sector();
 
+int cdrom_read_raw_sector(struct drive_t *drive, uint32_t lba, uint8_t *buf);
+
 const char* cdrom_parse(uint32_t num, const char *filename);
+void cdrom_close_chd(drive_t *drv);
 
 #endif

--- a/menu.cpp
+++ b/menu.cpp
@@ -180,6 +180,7 @@ enum MENU
 	MENU_MINIMIG_HDFFILE_SELECTED,
 	MENU_MINIMIG_ADFFILE_SELECTED,
 	MENU_MINIMIG_ROMFILE_SELECTED,
+	MENU_MINIMIG_EXTROMFILE_SELECTED,
 	MENU_MINIMIG_LOADCONFIG1,
 	MENU_MINIMIG_LOADCONFIG2,
 	MENU_MINIMIG_SAVECONFIG1,
@@ -6013,7 +6014,10 @@ void HandleUI(void)
 	case MENU_MINIMIG_ADFFILE_SELECTED:
 		if (!mgl->done)
 		{
-			snprintf(selPath, sizeof(selPath), "%s/%s", HomeDir(), mgl->item[mgl->current].path);
+			const char *p = mgl->item[mgl->current].path;
+			if (p[0] == '/') snprintf(selPath, sizeof(selPath), "%s", p);
+			else if (p[0] == '.' && p[1] == '.') snprintf(selPath, sizeof(selPath), "%s/%s", getRootDir(), p);
+			else snprintf(selPath, sizeof(selPath), "%s/%s", HomeDir(), p);
 			// Update /tmp/ files to reflect the actual file being loaded by MGL
 			if (cfg.log_file_entry)
 			{
@@ -6192,34 +6196,34 @@ void HandleUI(void)
 
 	case MENU_MINIMIG_CHIPSET1:
 		helptext_idx = HELPTEXT_CHIPSET;
-		menumask = 0x7FF;
+		menumask = 0xFFF;
 		OsdSetTitle("System");
 		parentstate = menustate;
 
 		m = 0;
 		OsdWrite(m++, "", 0, 0);
-		strcpy(s, " CPU      : ");
+		strcpy(s, " CPU       : ");
 		strcat(s, config_cpu_msg[minimig_config.cpu & 0x03]);
 		OsdWrite(m++, s, menusub == 0, 0);
-		strcpy(s, " D-Cache  : ");
+		strcpy(s, " D-Cache   : ");
 		strcat(s, (minimig_config.cpu & 16) ? "ON" : "OFF");
 		OsdWrite(m++, s, menusub == 1, !(minimig_config.cpu & 0x2));
 		OsdWrite(m++, "", 0, 0);
-		strcpy(s, " Chipset  : ");
+		strcpy(s, " Chipset   : ");
 		strcat(s, config_chipset_msg[(minimig_config.chipset >> 2) & 7]);
 		OsdWrite(m++, s, menusub == 2, 0);
-		strcpy(s, " ChipRAM  : ");
+		strcpy(s, " ChipRAM   : ");
 		strcat(s, config_memory_chip_msg[minimig_config.memory & 0x03]);
 		OsdWrite(m++, s, menusub == 3, 0);
-		strcpy(s, " FastRAM  : ");
+		strcpy(s, " FastRAM   : ");
 		strcat(s, config_memory_fast_msg[(minimig_config.cpu >> 1) & 1][((minimig_config.memory >> 4) & 0x03) | ((minimig_config.memory & 0x80) >> 5)]);
 		OsdWrite(m++, s, menusub == 4, 0);
-		strcpy(s, " SlowRAM  : ");
+		strcpy(s, " SlowRAM   : ");
 		strcat(s, config_memory_slow_msg[(minimig_config.memory >> 2) & 0x03]);
 		OsdWrite(m++, s, menusub == 5, 0);
 
 		OsdWrite(m++, "", 0, 0);
-		strcpy(s, " Joystick : ");
+		strcpy(s, " Joystick  : ");
 		strcat(s, config_joystick_mode[(minimig_config.autofire & 6) >> 1]);
 		OsdWrite(m++, s, menusub == 6, 0);
 
@@ -6234,17 +6238,30 @@ void HandleUI(void)
 		}
 
 		OsdWrite(m++, s, menusub == 7, 0);
+		strcpy(s, " Ext.ROM: ");
+		{
+			char *path = HomeDir();
+			int len = strlen(path);
+			const char *name = minimig_get_extrom();
+			if (!name[0]) {
+				strcat(s, "<none>");
+			} else {
+				if (!strncasecmp(name, path, len)) name += len + 1;
+				strncat(&s[3], name, 24);
+			}
+		}
+		OsdWrite(m++, s, menusub == 8, 0);
 		strcpy(s, " HRTmon : ");
 		strcat(s, (minimig_config.memory & 0x40) ? "enabled " : "disabled");
-		OsdWrite(m++, s, menusub == 8, 0);
+		OsdWrite(m++, s, menusub == 9, 0);
 
 		OsdWrite(m++, "", 0, 0);
 		strcpy(s, " Ethernet : ");
 		strcat(s, a2065_iface_msg(a2065_get_iface()));
-		OsdWrite(m++, s, menusub == 9, 0);
+		OsdWrite(m++, s, menusub == 10, 0);
 
 		for (int i = m; i < OsdGetSize() - 1; i++) OsdWrite(i, "", 0, 0);
-		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 10, 0);
+		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 11, 0);
 
 		menustate = MENU_MINIMIG_CHIPSET2;
 		break;
@@ -6371,10 +6388,23 @@ void HandleUI(void)
 			}
 			else if (menusub == 8)
 			{
+				if (minus)
+				{
+					minimig_set_extrom((char *)"");
+					menustate = MENU_MINIMIG_CHIPSET1;
+				}
+				else if (select)
+				{
+					ioctl_index = 1;
+					SelectFile(Selected_F[5], "ROM", SCANO_DIR | SCANO_UMOUNT, MENU_MINIMIG_EXTROMFILE_SELECTED, MENU_MINIMIG_CHIPSET1);
+				}
+			}
+			else if (menusub == 9)
+			{
 				minimig_config.memory ^= 0x40;
 				menustate = MENU_MINIMIG_CHIPSET1;
 			}
-			else if (menusub == 9)
+			else if (menusub == 10)
 			{
 				// A2065 ethernet: OFF -> eth0 -> eth1 -> macvlan -> tap0,
 				// skipping anything this box cannot support (no second NIC,
@@ -6390,7 +6420,7 @@ void HandleUI(void)
 				a2065_set_iface(m2);
 				menustate = MENU_MINIMIG_CHIPSET1;
 			}
-			else if (menusub == 10)
+			else if (menusub == 11)
 			{
 				menustate = MENU_MINIMIG_MAIN1;
 				menusub = 6;
@@ -6414,32 +6444,60 @@ void HandleUI(void)
 		menustate = MENU_MINIMIG_CHIPSET1;
 		break;
 
+	case MENU_MINIMIG_EXTROMFILE_SELECTED:
+		memcpy(Selected_F[5], selPath, sizeof(Selected_F[5]));
+		minimig_set_extrom(selPath);
+		menustate = MENU_MINIMIG_CHIPSET1;
+		break;
+
 	case MENU_MINIMIG_DISK1:
 		helptext_idx = HELPTEXT_HARDFILE;
 		OsdSetTitle("Drives");
 
 		m = 0;
 		parentstate = menustate;
-		menumask = 0xC01;
-		if (minimig_config.ide_cfg & 1) menumask |= 0x156;
-		OsdWrite(m++, "", 0, 0);
-		strcpy(s, " IDE A600/A1200    : ");
-		strcat(s, (minimig_config.ide_cfg & 1) ? "On " : "Off");
-		OsdWrite(m++, s, menusub == 0, 0);
-		strcpy(s, " Fast-IDE (68020)  : ");
-		strcat(s, (minimig_config.ide_cfg & 0x20) ? "Off" : "On");
-		OsdWrite(m++, s, menusub == 1,  !(minimig_config.ide_cfg & 1) || !(minimig_config.cpu & 2));
-		if (!(minimig_config.cpu & 2)) menumask &= ~2;
-		OsdWrite(m++);
-
 		{
+			int cdtv_on = (minimig_config.chipset & CONFIG_CDTV) ? 1 : 0;
+			int ide_on  = (minimig_config.ide_cfg & 1) ? 1 : 0;
+			int io_on   = ide_on || cdtv_on;
+
+			menumask = 0xC01;
+			if (ide_on)  menumask |= 0x002;
+			if (io_on)   menumask |= 0x154;
+			OsdWrite(m++, "", 0, 0);
+
+			const char *iomode = cdtv_on ? "CDTV" : (ide_on ? "IDE " : "OFF ");
+			strcpy(s, " I/O controller    : ");
+			strcat(s, iomode);
+			OsdWrite(m++, s, menusub == 0, 0);
+
+			strcpy(s, " Fast-IDE (68020)  : ");
+			if (cdtv_on) strcat(s, "N/A");
+			else         strcat(s, (minimig_config.ide_cfg & 0x20) ? "Off" : "On ");
+			OsdWrite(m++, s, menusub == 1, cdtv_on || !ide_on || !(minimig_config.cpu & 2));
+			if (!(minimig_config.cpu & 2)) menumask &= ~2;
+			OsdWrite(m++);
+
 			uint n = 2, t = 8;
 			for (uint i = 0; i < 4; i++)
 			{
-				strcpy(s, (i & 2) ? " Sec. " : " Pri. ");
-				strcat(s, (i & 1) ? " Slave: " : "Master: ");
+				if (cdtv_on)
+				{
+					static const char *cdtv_slot_label[4] = {
+						" CD0           : ",
+						" HD0  (SCSI)   : ",
+						" HD1  (SCSI)   : ",
+						" HD2  (SCSI)   : "
+					};
+					strcpy(s, cdtv_slot_label[i]);
+				}
+				else
+				{
+					strcpy(s, (i & 2) ? " Sec. " : " Pri. ");
+					strcat(s, (i & 1) ? " Slave: " : "Master: ");
+				}
 				strcat(s, (minimig_config.hardfile[i].cfg == 2) ? "Removable/CD" : minimig_config.hardfile[i].cfg ? "Fixed/HDD" : "Disabled");
-				OsdWrite(m++, s, (minimig_config.ide_cfg & 1) ? (menusub == n++) : 0, !(minimig_config.ide_cfg & 1));
+				OsdWrite(m++, s, io_on ? (menusub == n++) : 0, !io_on);
 				if (minimig_config.hardfile[i].filename[0])
 				{
 					strcpy(s, "                                ");
@@ -6453,7 +6511,7 @@ void HandleUI(void)
 				{
 					strcpy(s, "   ** not selected **");
 				}
-				enable = (minimig_config.ide_cfg & 1) && minimig_config.hardfile[i].cfg;
+				enable = io_on && minimig_config.hardfile[i].cfg;
 				if (enable) menumask |= t;	// Make hardfile selectable
 				OsdWrite(m++, s, menusub == n++, enable == 0);
 				t <<= 2;
@@ -6477,15 +6535,35 @@ void HandleUI(void)
 		{
 			if (menusub == 0)
 			{
-				if (select)
+				if (select || minus || plus)
 				{
-					minimig_config.ide_cfg ^= 1;
+					int cur;
+					if (minimig_config.chipset & CONFIG_CDTV)   cur = 2;
+					else if (minimig_config.ide_cfg & 1)        cur = 1;
+					else                                        cur = 0;
+					int next = minus ? ((cur + 2) % 3) : ((cur + 1) % 3);
+					if (next == 0)
+					{
+						minimig_config.ide_cfg &= ~1;
+						minimig_config.chipset &= ~CONFIG_CDTV;
+					}
+					else if (next == 1)
+					{
+						minimig_config.ide_cfg |= 1;
+						minimig_config.chipset &= ~CONFIG_CDTV;
+					}
+					else
+					{
+						minimig_config.ide_cfg &= ~1;
+						minimig_config.chipset |= CONFIG_CDTV;
+					}
+					minimig_ConfigChipset(minimig_config.chipset);
 					menustate = MENU_MINIMIG_DISK1;
 				}
 			}
 			else if (menusub == 1)
 			{
-				if (select)
+				if (select && !(minimig_config.chipset & CONFIG_CDTV))
 				{
 					minimig_config.ide_cfg ^= 0x20;
 					menustate = MENU_MINIMIG_DISK1;

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -196,6 +196,13 @@ static inline uint8_t bin_to_bcd(uint8_t v)
 	return (uint8_t)(((v / 10u) << 4) | (v % 10u));
 }
 
+static inline bool cd32_active(void)
+{
+	return (minimig_config.cpu & 0x03) == 3
+	    && ((minimig_config.chipset >> 2) & 7) == 6
+	    && minimig_config.hardfile[0].cfg == 2;
+}
+
 static bool cd_is_mounted(void)
 {
 	for (int p = 0; p < 2; p++) {
@@ -1355,6 +1362,8 @@ static void akiko_diag(const char *fmt, ...)
 
 void akiko_cd32_poll(void)
 {
+	if (!cd32_active()) return;
+
 	usleep(20);
 
 	bool mounted = cd_is_mounted();

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -1,0 +1,1636 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <time.h>
+#include <byteswap.h>
+
+#include "../../spi.h"
+#include "../../fpga_io.h"
+#include "../../user_io.h"
+#include "../../ide.h"
+#include "../../ide_cdrom.h"
+#include "../../hardware.h"
+#include "../../menu.h"
+#include "../chd/mister_chd.h"
+#include "minimig_config.h"
+#include "akiko_cd32.h"
+
+static void akiko_diag(const char *fmt, ...);
+
+#define AKIKO_CD32_DEBUG 0
+#if AKIKO_CD32_DEBUG
+	#define akiko_dbg(fmt, ...) akiko_diag("[akiko] " fmt, ##__VA_ARGS__)
+#else
+	#define akiko_dbg(...) do { } while (0)
+#endif
+
+#define AKIKO_BRIDGE_ADDR  0xF400
+
+#define AKIKO_CDDA_ADDR        0xF200
+#define AKIKO_CDDA_BYTES       2352
+#define AKIKO_STATUS_CDDA_REQ  (1u << 8)
+
+#define AKIKO_STATUS_CMD             0x63
+#define AKIKO_STATUS_REQ             (1u << 11)
+#define AKIKO_STATUS_SEC_REQ         (1u << 10)
+#define AKIKO_STATUS_RX_BUSY (1u << 9)
+
+#define AKIKO_SECTOR_ADDR  0xF500
+
+#define AKIKO_SUBCODE_ADDR 0xF410
+#define AKIKO_SUB_ENTRY    12
+#define AKIKO_SUB_BYTES    96
+
+#define AKIKO_NVRAM_ADDR              0xF440
+#define AKIKO_NVRAM_BYTES             1024
+#define AKIKO_NVRAM_DIR               "/media/fat/saves/Minimig"
+#define AKIKO_NVRAM_FILE_LEGACY       "/media/fat/saves/Minimig/cd32.nvr"
+#define AKIKO_STATUS_NVR_DIRTY        (1u << 7)
+#define AKIKO_NVRAM_POLL_PERIOD_MS    1000
+#define AKIKO_NVRAM_DIRTY_DEBOUNCE_MS 30000
+#define AKIKO_NVRAM_MIN_SAVE_INTERVAL_MS 60000
+
+#define AKIKO_SECTOR_BYTES 2352
+
+static const int command_lengths[16] = {
+	1, 2, 1, 1, 12, 2, 1, 1, 4, 1, 2, -1, -1, -1, -1, -1
+};
+
+#define CH_ERR_OK          0x00
+#define CH_ERR_BADCOMMAND  0x80
+#define CH_ERR_NODISK      0xf8
+#define CH_ERR_CHECKSUM    0x88
+#define CDS_ERROR          0x80
+#define CDS_PLAYING        0x08
+#define CDS_PLAYEND        0x00
+
+#define AKIKO_FIRMWARE     "CHINON  O-658-2 24"
+
+#define AKIKO_CMD_MAX      32
+
+static uint8_t  cd_initialized      = 0;
+static uint8_t  cd_paused           = 0;
+static uint8_t  cd_playing          = 0;
+static uint8_t  cd_led_state        = 0;
+static uint8_t  cd_door             = 1;
+static uint32_t cd_play_start_lba   = 0;
+static uint32_t cd_play_end_lba     = 0;
+
+static int32_t  cd_data_lba_base    = -1;
+
+#define AKIKO_PREFETCH_SECTORS 128
+#define AKIKO_PREFETCH_WINDOWS 4
+
+typedef struct {
+	int32_t  base_lba;
+	uint32_t lru_tick;
+	uint8_t  valid[AKIKO_PREFETCH_SECTORS];
+	uint8_t  buf[AKIKO_PREFETCH_SECTORS * AKIKO_SECTOR_BYTES];
+} prefetch_window_t;
+
+static prefetch_window_t cd_prefetch_windows[AKIKO_PREFETCH_WINDOWS];
+static uint32_t cd_prefetch_lru_counter = 0;
+static uint32_t cd_prefetch_hits = 0;
+static uint32_t cd_prefetch_misses = 0;
+static uint32_t cd_prefetch_failed_sectors = 0;
+
+static inline void akiko_prefetch_invalidate(void)
+{
+	for (int i = 0; i < AKIKO_PREFETCH_WINDOWS; i++) {
+		cd_prefetch_windows[i].base_lba = -1;
+	}
+}
+
+static int akiko_prefetch_find(uint32_t lba)
+{
+	for (int i = 0; i < AKIKO_PREFETCH_WINDOWS; i++) {
+		const prefetch_window_t *w = &cd_prefetch_windows[i];
+		if (w->base_lba >= 0
+		    && lba >= (uint32_t)w->base_lba
+		    && lba <  (uint32_t)w->base_lba + AKIKO_PREFETCH_SECTORS) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+static int akiko_prefetch_pick_evict(void)
+{
+	int pick = 0;
+	for (int i = 0; i < AKIKO_PREFETCH_WINDOWS; i++) {
+		if (cd_prefetch_windows[i].base_lba < 0) return i;
+		if (cd_prefetch_windows[i].lru_tick < cd_prefetch_windows[pick].lru_tick) {
+			pick = i;
+		}
+	}
+	return pick;
+}
+
+static int8_t   cd_audio_timeout    = 0;
+
+static uint32_t cd_audio_play_until_ms = 0;
+
+static int32_t cd_cdda_q_pos    = -1;
+static int32_t cd_cdda_q_end    = -1;
+static int32_t cd_cdda_lba_next = -1;
+static int32_t cd_cdda_lba_end  = -1;
+static drive_t *cd_cdda_drv     = NULL;
+
+static bool     cd_last_mounted     = false;
+
+static bool     g_akiko_pending_minimig_reset = false;
+
+static uint8_t  cd_post_info_media_push_pending = 0;
+
+#define AKIKO_TOC_REPEAT       3
+#define AKIKO_TOC_PUSH_PERIOD_MS 20
+#define AKIKO_TOC_MAX_POINTS   32
+static uint8_t  toc_buffer[AKIKO_TOC_MAX_POINTS * 13];
+static uint8_t  toc_point_count     = 0;
+static int16_t  toc_push_idx        = -1;
+static uint32_t toc_push_last_ms    = 0;
+
+static char cd_save_path_active[256] = {0};
+static bool cd_save_load_pending     = false;
+static bool cd_save_dirty_observed   = false;
+
+static bool cd_save_load_failed      = false;
+
+static uint64_t fnv1a_64(const char *s)
+{
+	uint64_t h = 0xcbf29ce484222325ULL;
+	while (*s) {
+		h ^= (uint64_t)(uint8_t)*s++;
+		h *= 0x100000001b3ULL;
+	}
+	return h;
+}
+
+static void compute_save_path(const char *cd_path, char *out, size_t outsz)
+{
+	const char *base = strrchr(cd_path, '/');
+	base = base ? base + 1 : cd_path;
+	uint64_t h = fnv1a_64(base);
+	snprintf(out, outsz, "%s/cd32-%016" PRIx64 ".nvr", AKIKO_NVRAM_DIR, h);
+}
+
+static inline uint32_t msf_to_lba(uint8_t m, uint8_t s, uint8_t f)
+{
+	return (((uint32_t)m * 60u + s) * 75u + f) - 150u;
+}
+
+static inline uint8_t bcd_to_bin(uint8_t b)
+{
+	return (uint8_t)(((b >> 4) * 10u) + (b & 0x0fu));
+}
+
+static inline uint8_t bin_to_bcd(uint8_t v)
+{
+	return (uint8_t)(((v / 10u) << 4) | (v % 10u));
+}
+
+static bool cd_is_mounted(void)
+{
+	for (int p = 0; p < 2; p++) {
+		for (int d = 0; d < 2; d++) {
+			drive_t *drv = &ide_inst[p].drive[d];
+			if (drv->cd && (drv->chd_f || drv->f)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static drive_t *cd_find_drive(void)
+{
+	for (int p = 0; p < 2; p++) {
+		for (int d = 0; d < 2; d++) {
+			drive_t *drv = &ide_inst[p].drive[d];
+			if (drv->cd && (drv->chd_f || drv->f)) {
+				return drv;
+			}
+		}
+	}
+	return NULL;
+}
+
+static uint16_t akiko_read_status(void)
+{
+	uint16_t res;
+	EnableIO();
+	res = spi_w(AKIKO_STATUS_CMD);
+	if (!res) res = (uint8_t)spi_w(0);
+	DisableIO();
+	return res;
+}
+
+static uint8_t akiko_read_sec_counter(void);
+
+static bool akiko_wait_status_bit(uint16_t mask, bool want_set, int max_iters)
+{
+	for (int i = 0; i < max_iters; i++) {
+		uint16_t s = akiko_read_status();
+		if (((s & mask) != 0) == want_set) return true;
+	}
+	return false;
+}
+
+static int akiko_drain_command(uint8_t *buf)
+{
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(AKIKO_BRIDGE_ADDR);
+
+	buf[0] = (uint8_t)spi_w(0);
+
+	int op = buf[0] & 0x0f;
+	int payload_len = command_lengths[op];
+	int total;
+	if (payload_len < 0) {
+		total = AKIKO_CMD_MAX;
+	} else {
+		total = payload_len + 1;
+	}
+	if (total > AKIKO_CMD_MAX) total = AKIKO_CMD_MAX;
+
+	for (int i = 1; i < total; i++) {
+		buf[i] = (uint8_t)spi_w(0);
+	}
+
+	DisableIO();
+
+	akiko_wait_status_bit(AKIKO_STATUS_REQ, false, 200);
+
+	return total;
+}
+
+static void akiko_send_response(const uint8_t *payload, int len)
+{
+	if (len < 1 || len > AKIKO_CMD_MAX) {
+		akiko_dbg("send_response: bad len %d\n", len);
+		return;
+	}
+
+	uint8_t out[AKIKO_CMD_MAX + 1];
+	memcpy(out, payload, (size_t)len);
+
+	uint32_t sum = 0;
+	for (int i = 0; i < len; i++) sum += out[i];
+	out[len] = (uint8_t)(0xff - (sum & 0xff));
+
+	int total = len + 1;
+
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(AKIKO_BRIDGE_ADDR);
+	for (int i = 0; i < total; i++) {
+		spi_w(out[i]);
+	}
+	DisableIO();
+
+	akiko_wait_status_bit(AKIKO_STATUS_RX_BUSY, true, 200);
+
+#if AKIKO_CD32_DEBUG
+	akiko_dbg("TX %d bytes:", total);
+	for (int i = 0; i < total; i++) printf(" %02x", out[i]);
+	printf("\n");
+#endif
+}
+
+static void toc_pack_entry(int point, uint8_t control, uint32_t msf_or_track)
+{
+	if (toc_point_count >= AKIKO_TOC_MAX_POINTS) return;
+	uint8_t *d = &toc_buffer[toc_point_count * 13];
+	memset(d, 0, 13);
+	d[1] = 1u | ((uint8_t)control << 4);
+	d[3] = (point < 100) ? bin_to_bcd((uint8_t)point) : (uint8_t)point;
+	if (point == 0xA0 || point == 0xA1) {
+		d[8] = bin_to_bcd((uint8_t)msf_or_track);
+	} else {
+		uint32_t lsn = msf_or_track + 150u;
+		uint32_t mins = (lsn / 75u) / 60u;
+		uint32_t secs = (lsn / 75u) % 60u;
+		uint32_t fr   = lsn % 75u;
+		d[8]  = bin_to_bcd((uint8_t)mins);
+		d[9]  = bin_to_bcd((uint8_t)secs);
+		d[10] = bin_to_bcd((uint8_t)fr);
+	}
+	toc_point_count++;
+}
+
+static void akiko_build_toc(void)
+{
+	toc_point_count = 0;
+	toc_push_idx    = -1;
+
+	drive_t *drv = cd_find_drive();
+	if (!drv || drv->track_cnt < 2) {
+		akiko_diag("[akiko] TOC build SKIP (no drive or no tracks)");
+		return;
+	}
+
+	int real_tracks = drv->track_cnt - 1;
+	if (real_tracks < 1 || real_tracks > 99) {
+		akiko_diag("[akiko] TOC build SKIP (real_tracks=%d)", real_tracks);
+		return;
+	}
+
+	for (int i = 0; i <= real_tracks; i++) {
+		akiko_diag("[akiko] TRACK[%d] num=%u attr=0x%02x start=%u length=%u chd_off=%u",
+		           i, drv->track[i].number, drv->track[i].attr,
+		           drv->track[i].start, drv->track[i].length,
+		           drv->track[i].chd_offset);
+	}
+
+	uint8_t first_ctrl = (drv->track[0].attr & 0x40) ? 0x04 : 0x00;
+	toc_pack_entry(0xA0, first_ctrl, 1);
+	toc_pack_entry(0xA1, first_ctrl, real_tracks);
+	toc_pack_entry(0xA2, first_ctrl, drv->track[real_tracks].start);
+
+	for (int i = 0; i < real_tracks; i++) {
+		uint8_t ctrl = (drv->track[i].attr & 0x40) ? 0x04 : 0x00;
+		toc_pack_entry(drv->track[i].number, ctrl, drv->track[i].start);
+	}
+
+	toc_push_last_ms = 0;
+	akiko_diag("[akiko] TOC built: %u points (%d real tracks, lead-out lba=%u)",
+	           toc_point_count, real_tracks, drv->track[real_tracks].start);
+}
+
+static bool akiko_push_toc_entry(void)
+{
+	if (toc_push_idx < 0) return false;
+	int point_idx = toc_push_idx / AKIKO_TOC_REPEAT;
+	if (point_idx >= toc_point_count) {
+		toc_push_idx = -1;
+		akiko_diag("[akiko] TOC drip complete (%u points * %d repeat = %d frames)",
+		           toc_point_count, AKIKO_TOC_REPEAT,
+		           toc_point_count * AKIKO_TOC_REPEAT);
+		return false;
+	}
+	uint8_t r[15];
+	memset(r, 0, sizeof(r));
+	r[0] = 0x06;
+	r[1] = 0x0a;
+	memcpy(r + 2, &toc_buffer[point_idx * 13], 13);
+	int counter = toc_push_idx;
+	r[6] = bin_to_bcd(99);
+	r[7] = bin_to_bcd((uint8_t)(24u + (uint32_t)counter / 75u));
+	r[8] = bin_to_bcd((uint8_t)((uint32_t)counter % 75u));
+	akiko_send_response(r, 15);
+	akiko_diag("[akiko] TOC push idx=%d point_idx=%d point=0x%02x ctrl=0x%02x msf=%02x:%02x:%02x",
+	           toc_push_idx, point_idx, r[5], (r[3] >> 4) & 0x0f, r[10], r[11], r[12]);
+	toc_push_idx++;
+	return true;
+}
+
+static void cmd_info(const uint8_t *cmd)
+{
+	uint8_t r[20];
+	r[0] = cmd[0];
+	r[1] = cd_door;
+	memcpy(&r[2], AKIKO_FIRMWARE, 18);
+	akiko_send_response(r, 20);
+	cd_initialized = 2;
+	akiko_dbg("INFO -> initialized=2\n");
+	akiko_build_toc();
+}
+
+static void emit_playend_notify(int status)
+{
+	uint8_t r[2];
+	r[0] = 0x04;
+	if (status < 0)        r[1] = CDS_ERROR;
+	else if (status == 0)  r[1] = CDS_PLAYING | 0x02;
+	else                   r[1] = CDS_PLAYEND;
+	r[1] |= cd_door;
+	akiko_send_response(r, 2);
+	akiko_dbg("PLAYEND_NOTIFY status=%d -> %02x\n", status, r[1]);
+}
+
+static void cmd_stop(const uint8_t *cmd)
+{
+	uint8_t r[2];
+	r[0] = cmd[0];
+	r[1] = cd_is_mounted() ? 0x00 : (CH_ERR_NODISK | cd_door);
+	cd_playing = 0;
+	cd_paused = 0;
+	cd_data_lba_base = -1;
+	cd_cdda_lba_next = -1;
+	cd_cdda_lba_end  = -1;
+	cd_cdda_drv      = NULL;
+	if (cd_audio_timeout > 0) cd_audio_timeout = 0;
+	cd_audio_play_until_ms = 0;
+	akiko_send_response(r, 2);
+	akiko_dbg("STOP\n");
+}
+
+static void cmd_pause(const uint8_t *cmd)
+{
+	uint8_t r[2];
+	r[0] = cmd[0];
+	if (!cd_is_mounted()) {
+		r[1] = CH_ERR_NODISK | cd_door;
+	} else {
+		r[1] = (cd_playing ? CDS_PLAYING : 0) | cd_door;
+	}
+	toc_push_idx     = -1;
+	toc_push_last_ms = 0;
+	cd_paused = 1;
+	akiko_send_response(r, 2);
+	akiko_dbg("PAUSE (playing=%d, mounted=%d)\n", cd_playing, cd_is_mounted());
+}
+
+static void cmd_unpause(const uint8_t *cmd)
+{
+	uint8_t r[2];
+	r[0] = cmd[0];
+	if (!cd_is_mounted()) {
+		r[1] = CH_ERR_NODISK | cd_door;
+	} else {
+		r[1] = (cd_playing ? CDS_PLAYING : 0) | cd_door;
+	}
+	cd_paused = 0;
+	akiko_send_response(r, 2);
+	akiko_dbg("UNPAUSE (playing=%d, mounted=%d)\n", cd_playing, cd_is_mounted());
+}
+
+static int cdrom_speed = 1;
+
+static void cmd_multi(const uint8_t *cmd)
+{
+	uint8_t r[2];
+	r[0] = cmd[0];
+
+	int new_speed = (cmd[8] & 0x40) ? 2 : 1;
+	if (new_speed != cdrom_speed) {
+		akiko_diag("[akiko] cdrom_speed change %dx -> %dx (cmd8=0x%02x)",
+		           cdrom_speed, new_speed, cmd[8]);
+		cdrom_speed = new_speed;
+	}
+
+	if (!cd_is_mounted()) {
+		r[1] = 0x01;
+		akiko_send_response(r, 2);
+		akiko_dbg("PLAY: no disk\n");
+		return;
+	}
+
+	uint32_t s_msf_total = (((uint32_t)bcd_to_bin(cmd[1]) * 60u
+	                       + bcd_to_bin(cmd[2])) * 75u + bcd_to_bin(cmd[3]));
+	bool seek_negative = (s_msf_total < 150u);
+	uint32_t s_lba = s_msf_total - 150u;
+	uint32_t e_lba = msf_to_lba(bcd_to_bin(cmd[4]), bcd_to_bin(cmd[5]), bcd_to_bin(cmd[6]));
+
+	cd_play_start_lba = s_lba;
+	cd_play_end_lba   = e_lba;
+
+	bool data_read = (cmd[7] & 0x80) != 0;
+	if (data_read) {
+		drive_t *drv2 = cd_find_drive();
+		bool start_is_audio = false;
+		bool start_is_oob   = false;
+		if (!seek_negative && drv2) {
+			int real_tracks2 = drv2->track_cnt > 0 ? drv2->track_cnt - 1 : 0;
+			uint32_t lead_out2 = (real_tracks2 > 0) ? drv2->track[real_tracks2].start : 0;
+			if (lead_out2 && s_lba >= lead_out2) {
+				start_is_oob = true;
+			}
+			for (int i = 0; i < real_tracks2 && !start_is_oob; i++) {
+				uint32_t body_end = drv2->track[i].start + drv2->track[i].length;
+				if (s_lba >= drv2->track[i].start && s_lba < body_end) {
+					start_is_audio = !(drv2->track[i].attr & 0x40);
+					break;
+				}
+				if (i + 1 < real_tracks2 &&
+				    s_lba >= body_end && s_lba < drv2->track[i + 1].start) {
+					start_is_audio = !(drv2->track[i + 1].attr & 0x40);
+					break;
+				}
+			}
+		}
+		if (start_is_audio) {
+			cd_data_lba_base = -1;
+			r[1] = CDS_PLAYEND | cd_door;
+			akiko_diag("[akiko] PLAY DATA REFUSED audio start_lba=%u (cmd7=0x%02x)",
+			           s_lba, cmd[7]);
+		} else if (start_is_oob) {
+			cd_data_lba_base = -1;
+			r[1] = 0x02;
+			akiko_diag("[akiko] PLAY DATA REFUSED oob start_lba=%u (cmd7=0x%02x) — silent (no PBX, no playend)",
+			           s_lba, cmd[7]);
+		} else {
+			cd_data_lba_base = (int32_t)s_lba;
+			cd_paused = 0;
+			r[1] = 0x02;
+			akiko_diag("[akiko] PLAY DATA arm: start_lba=%d (cmd7=0x%02x)", (int32_t)s_lba, cmd[7]);
+		}
+	} else if (seek_negative) {
+		cd_data_lba_base = -1;
+		cd_playing = 0;
+		cd_paused = 0;
+		toc_push_idx = (toc_point_count > 0) ? 0 : -1;
+		toc_push_last_ms = 0;
+		r[1] = 0x00;
+		akiko_diag("[akiko] MULTI scan-TOC trigger (points=%u)", toc_point_count);
+	} else {
+		cd_data_lba_base = -1;
+		cd_playing = 1;
+		cd_paused = 0;
+		r[1] = 0x42;
+		cd_audio_timeout = 2;
+
+		drive_t *drv = cd_find_drive();
+		bool valid = false;
+		if (drv && e_lba > s_lba) {
+			int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+			for (int i = 0; i < real_tracks; i++) {
+				uint32_t end = drv->track[i].start + drv->track[i].length;
+				if (s_lba >= drv->track[i].start && s_lba < end) {
+					if (!(drv->track[i].attr & 0x40)) valid = true;
+					break;
+				}
+			}
+		}
+
+		if (valid) {
+			bool same_range_inflight =
+				(cd_cdda_drv == drv) &&
+				(cd_cdda_lba_end == (int32_t)e_lba) &&
+				(cd_cdda_lba_next >= (int32_t)s_lba) &&
+				(cd_cdda_lba_next <  (int32_t)e_lba);
+			cd_cdda_drv      = drv;
+			if (!same_range_inflight) {
+				cd_cdda_lba_next = (int32_t)s_lba;
+				cd_cdda_lba_end  = (int32_t)e_lba;
+				cd_cdda_q_pos    = (int32_t)s_lba;
+			}
+			cd_cdda_q_end = (int32_t)e_lba;
+			cd_audio_play_until_ms = 0;
+			if (same_range_inflight) {
+				akiko_dbg("CDDA re-PLAY same range s=%u e=%u next=%d kept\n",
+				          s_lba, e_lba, cd_cdda_lba_next);
+				akiko_diag("[akiko] CDDA re-PLAY same range s_lba=%u e_lba=%u next=%d (position kept)",
+				           s_lba, e_lba, cd_cdda_lba_next);
+			} else {
+				akiko_dbg("CDDA arm s=%u e=%u\n", s_lba, e_lba);
+				akiko_diag("[akiko] CDDA arm: s_lba=%u e_lba=%u (drv=%p)",
+				           s_lba, e_lba, (void*)drv);
+			}
+		} else {
+			cd_cdda_drv      = NULL;
+			cd_cdda_lba_next = -1;
+			cd_cdda_lba_end  = -1;
+			cd_audio_timeout = -3;
+			cd_audio_play_until_ms = 0;
+			cd_playing       = 0;
+			akiko_diag("[akiko] CDDA arm INVALID: drv=%p s_lba=%u e_lba=%u",
+			           (void*)drv, s_lba, e_lba);
+		}
+	}
+
+	akiko_send_response(r, 2);
+	akiko_dbg("PLAY %s start=%u(%s) end=%u\n",
+		data_read ? "DATA" : "AUDIO", s_lba, seek_negative ? "neg" : "pos", e_lba);
+}
+
+static void cmd_led(const uint8_t *cmd)
+{
+	uint8_t r[2];
+	r[0] = cmd[0];
+
+	if (cmd[1] & 0x80) {
+		cd_led_state = cmd[1] & 0x01;
+		r[1] = cd_led_state;
+		akiko_send_response(r, 2);
+	} else {
+	}
+	akiko_dbg("LED cmd1=%02x state=%d\n", cmd[1], cd_led_state);
+}
+
+static void cmd_subq(const uint8_t *cmd)
+{
+	uint8_t r[15];
+	memset(r, 0, sizeof(r));
+	r[0] = cmd[0];
+
+	drive_t *drv = cd_find_drive();
+	uint32_t cur_lba = 0;
+	bool valid = false;
+
+	if (drv) {
+		if (cd_data_lba_base >= 0) {
+			cur_lba = (uint32_t)cd_data_lba_base + akiko_read_sec_counter();
+			valid = true;
+		} else if (cd_playing && cd_cdda_q_pos >= 0) {
+			cur_lba = (uint32_t)cd_cdda_q_pos;
+			if (cd_cdda_q_end > 0 && (cd_cdda_q_end - (int32_t)cur_lba) < 10)
+				cur_lba = (uint32_t)cd_cdda_q_end;
+			valid = true;
+		} else if (cd_playing && cd_play_start_lba > 0) {
+			cur_lba = cd_play_start_lba;
+			valid = true;
+		}
+	}
+
+	if (!valid) {
+		r[2 + 2] = 0x80;
+		akiko_send_response(r, 15);
+		return;
+	}
+
+	int trk_idx = 0;
+	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+	for (int i = 0; i < real_tracks; i++) {
+		uint32_t end = (i + 1 < drv->track_cnt) ? drv->track[i + 1].start
+		                                        : drv->track[i].start + drv->track[i].length;
+		if (cur_lba >= drv->track[i].start && cur_lba < end) {
+			trk_idx = i;
+			break;
+		}
+	}
+
+	const track_t &t = drv->track[trk_idx];
+	uint8_t ctl_adr = (uint8_t)((t.attr & 0xf0) | 0x01);
+
+	uint32_t trk_lsn  = (cur_lba >= t.start) ? (cur_lba - t.start) + 150u : 150u;
+	uint32_t disk_lsn = cur_lba + 150u;
+
+	uint32_t tm = (trk_lsn / 75u) / 60u;
+	uint32_t ts = (trk_lsn / 75u) % 60u;
+	uint32_t tf =  trk_lsn % 75u;
+	uint32_t dm = (disk_lsn / 75u) / 60u;
+	uint32_t ds = (disk_lsn / 75u) % 60u;
+	uint32_t df =  disk_lsn % 75u;
+
+	r[2 + 0] = 0;
+	r[2 + 1] = ctl_adr;
+	r[2 + 2] = bin_to_bcd((uint8_t)t.number);
+	r[2 + 3] = bin_to_bcd(1);
+	r[2 + 4] = bin_to_bcd((uint8_t)tm);
+	r[2 + 5] = bin_to_bcd((uint8_t)ts);
+	r[2 + 6] = bin_to_bcd((uint8_t)tf);
+	r[2 + 7] = 0;
+	r[2 + 8] = bin_to_bcd((uint8_t)dm);
+	r[2 + 9] = bin_to_bcd((uint8_t)ds);
+	r[2 + 10] = bin_to_bcd((uint8_t)df);
+
+	akiko_send_response(r, 15);
+	akiko_dbg("SUBQ trk=%u lba=%u tpos=%u:%u:%u dpos=%u:%u:%u\n",
+	          t.number, cur_lba, tm, ts, tf, dm, ds, df);
+}
+
+static void cmd_bad(const uint8_t *cmd, uint8_t err_code)
+{
+	uint8_t r[2];
+	r[0] = (uint8_t)((cmd[0] & 0xf0) | 5);
+	r[1] = err_code | cd_door;
+	akiko_send_response(r, 2);
+	akiko_dbg("BAD cmd=%02x err=%02x\n", cmd[0], err_code);
+}
+
+static uint8_t akiko_read_sec_counter(void)
+{
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(AKIKO_SECTOR_ADDR);
+	uint16_t w = spi_w(0);
+	DisableIO();
+	return (uint8_t)(w & 0xff);
+}
+
+static void akiko_nvram_dump(uint8_t *out_1024)
+{
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(AKIKO_NVRAM_ADDR);
+	for (int i = 0; i < AKIKO_NVRAM_BYTES; i++) {
+		out_1024[i] = (uint8_t)spi_w(0);
+	}
+	DisableIO();
+}
+
+static uint32_t  nvr_verify_due_at_ms = 0;
+static char      nvr_verify_path[1024];
+
+static bool akiko_nvram_load_from_path(const char *path)
+{
+	struct stat st;
+	if (stat(path, &st) != 0) {
+		akiko_diag("[akiko] NVR load skip: no file at %s (errno=%d)",
+		           path, errno);
+		return false;
+	}
+	if (st.st_size != AKIKO_NVRAM_BYTES) {
+		akiko_diag("[akiko] NVR load skip: %s wrong size %lld (want %d)",
+		           path, (long long)st.st_size, AKIKO_NVRAM_BYTES);
+		return false;
+	}
+
+	int rc = user_io_file_mount(path, 0, 0, 0);
+	if (rc != 1) {
+		akiko_diag("[akiko] NVR mount FAIL: user_io_file_mount(%s, slot=0) rc=%d",
+		           path, rc);
+		cd_save_load_failed = true;
+		return false;
+	}
+
+	akiko_diag("[akiko] NVR mounted slot 0 (%d bytes from %s) — verify in 100 ms",
+	           AKIKO_NVRAM_BYTES, path);
+	cd_save_load_failed = false;
+	strncpy(nvr_verify_path, path, sizeof(nvr_verify_path) - 1);
+	nvr_verify_path[sizeof(nvr_verify_path) - 1] = '\0';
+	nvr_verify_due_at_ms = (uint32_t)GetTimer(100);
+	return true;
+}
+
+static void akiko_nvram_verify_load_pending(void)
+{
+	if (!nvr_verify_due_at_ms) return;
+	if (!CheckTimer(nvr_verify_due_at_ms)) return;
+	nvr_verify_due_at_ms = 0;
+
+	uint8_t verify[AKIKO_NVRAM_BYTES];
+	akiko_nvram_dump(verify);
+	uint8_t expected[AKIKO_NVRAM_BYTES];
+	FILE *f = fopen(nvr_verify_path, "rb");
+	if (!f) {
+		akiko_diag("[akiko] NVR verify: fopen(%s) failed errno=%d",
+		           nvr_verify_path, errno);
+		cd_save_load_failed = true;
+		return;
+	}
+	size_t got = fread(expected, 1, AKIKO_NVRAM_BYTES, f);
+	fclose(f);
+	if (got != AKIKO_NVRAM_BYTES) {
+		akiko_diag("[akiko] NVR verify: short read %zu/%d", got, AKIKO_NVRAM_BYTES);
+		cd_save_load_failed = true;
+		return;
+	}
+	if (memcmp(expected, verify, AKIKO_NVRAM_BYTES) == 0) {
+		akiko_diag("[akiko] NVR loaded %d bytes from %s (verify OK)",
+		           AKIKO_NVRAM_BYTES, nvr_verify_path);
+		cd_save_load_failed = false;
+		return;
+	}
+	int first_bad = -1, mismatches = 0;
+	for (int i = 0; i < AKIKO_NVRAM_BYTES; i++) {
+		if (verify[i] != expected[i]) {
+			if (first_bad < 0) first_bad = i;
+			mismatches++;
+		}
+	}
+	akiko_diag("[akiko] NVR LOAD VERIFY FAILED: %d/%d mismatched (first @ 0x%03x)",
+	           mismatches, AKIKO_NVRAM_BYTES, first_bad);
+	int logged = 0;
+	for (int i = 0; i < AKIKO_NVRAM_BYTES && logged < 32; i++) {
+		if (verify[i] != expected[i]) {
+			akiko_diag("[akiko]   @0x%03x: got 0x%02x want 0x%02x",
+			           i, verify[i], expected[i]);
+			logged++;
+		}
+	}
+	cd_save_load_failed = true;
+}
+
+static bool akiko_nvram_save_to_path(const char *path)
+{
+	uint8_t buf[AKIKO_NVRAM_BYTES];
+	akiko_nvram_dump(buf);
+
+	{
+		FILE *cur = fopen(path, "rb");
+		if (cur) {
+			uint8_t disk_buf[AKIKO_NVRAM_BYTES];
+			size_t n = fread(disk_buf, 1, AKIKO_NVRAM_BYTES, cur);
+			fclose(cur);
+			if (n == AKIKO_NVRAM_BYTES) {
+				if (memcmp(disk_buf, buf, AKIKO_NVRAM_BYTES) == 0) {
+					akiko_diag("[akiko] NVR save skipped: identical to %s", path);
+					return true;
+				}
+				int buf_entry_nz  = 0;
+				int disk_entry_nz = 0;
+				for (int i = 25; i < AKIKO_NVRAM_BYTES; i++) {
+					if (buf[i])      buf_entry_nz++;
+					if (disk_buf[i]) disk_entry_nz++;
+				}
+				if (buf_entry_nz == 0 && disk_entry_nz > 0) {
+					akiko_diag("[akiko] NVR save BLOCKED: about to overwrite "
+					           "%s (%d entry bytes) with empty FlashFile bootstrap "
+					           "(0 entry bytes) — destructive cascade detected, "
+					           "refusing.",
+					           path, disk_entry_nz);
+					return false;
+				}
+			}
+		}
+	}
+
+	if (mkdir(AKIKO_NVRAM_DIR, 0755) != 0 && errno != EEXIST) {
+		akiko_diag("[akiko] NVR mkdir(%s) failed: errno=%d", AKIKO_NVRAM_DIR, errno);
+	}
+
+	char tmp_path[300];
+	snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
+
+	FILE *f = fopen(tmp_path, "wb");
+	if (!f) {
+		akiko_diag("[akiko] NVR fopen(%s) failed: errno=%d", tmp_path, errno);
+		return false;
+	}
+	size_t wrote = fwrite(buf, 1, AKIKO_NVRAM_BYTES, f);
+	int    flush = fflush(f);
+	int    fsy   = fsync(fileno(f));
+	int    cls   = fclose(f);
+	if (wrote != AKIKO_NVRAM_BYTES || flush != 0 || fsy != 0 || cls != 0) {
+		akiko_diag("[akiko] NVR write incomplete: wrote=%zu flush=%d fsync=%d close=%d",
+		           wrote, flush, fsy, cls);
+		unlink(tmp_path);
+		return false;
+	}
+
+	if (rename(tmp_path, path) != 0) {
+		akiko_diag("[akiko] NVR rename(%s -> %s) failed: errno=%d",
+		           tmp_path, path, errno);
+		unlink(tmp_path);
+		return false;
+	}
+
+	akiko_diag("[akiko] NVR saved %d bytes to %s", AKIKO_NVRAM_BYTES, path);
+	return true;
+}
+
+static bool akiko_nvram_save_to_disk(void)
+{
+	if (cd_save_load_failed && cd_save_path_active[0]) {
+		static bool warned_once = false;
+		if (!warned_once) {
+			akiko_diag("[akiko] NVR save BLOCKED: load failed for %s — refusing to "
+			           "overwrite real save with BIOS bootstrap. Future blocks silent.",
+			           cd_save_path_active);
+			warned_once = true;
+		}
+		return false;
+	}
+	const char *target = (cd_save_path_active[0])
+		? cd_save_path_active
+		: AKIKO_NVRAM_FILE_LEGACY;
+	return akiko_nvram_save_to_path(target);
+}
+
+#define AKIKO_SEC_SLOT 1
+static const bool g_akiko_fast_push = (getenv("AKIKO_SLOW_PUSH") == nullptr);
+
+static void akiko_push_sector(const uint8_t *buf)
+{
+	if (g_akiko_fast_push) {
+		EnableIO();
+		spi_w(UIO_SECTOR_RD | (AKIKO_SEC_SLOT << 8));
+		fpga_spi_fast_block_write_8(buf, AKIKO_SECTOR_BYTES);
+		DisableIO();
+	} else {
+		EnableIO();
+		spi8(UIO_DMA_WRITE);
+		spi32_w(AKIKO_SECTOR_ADDR);
+		for (int i = 0; i < AKIKO_SECTOR_BYTES; i++) {
+			spi_w(buf[i]);
+		}
+		DisableIO();
+	}
+}
+
+static bool cd_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
+{
+	if (!drv || !drv->chd_f || !buf2352) return false;
+
+	bool index0 = false;
+	track_t *track = NULL;
+	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+	for (int i = 0; i < real_tracks; i++) {
+		uint32_t end = drv->track[i].start + drv->track[i].length;
+		if (lba >= drv->track[i].start && lba < end) {
+			track = &drv->track[i];
+			break;
+		}
+		if (i + 1 < real_tracks && lba < drv->track[i + 1].start &&
+		    lba >= end) {
+			track = &drv->track[i];
+			index0 = true;
+			break;
+		}
+	}
+	(void)index0;
+
+	if (!track) return false;
+	if (track->attr & 0x40) return false;
+	if (track->sectorSize != AKIKO_CDDA_BYTES) return false;
+
+	uint32_t chd_lba = lba + track->chd_offset;
+	if (mister_chd_read_sector(drv->chd_f, chd_lba, 0, 0,
+	                           AKIKO_CDDA_BYTES, buf2352,
+	                           drv->chd_hunkbuf, &drv->chd_hunknum)
+	    != CHDERR_NONE) {
+		return false;
+	}
+	return true;
+}
+
+static bool akiko_audio_fifo_ready(void)
+{
+	return (akiko_read_status() & AKIKO_STATUS_CDDA_REQ) != 0;
+}
+
+static void akiko_push_audio_sector(const uint8_t *buf2352)
+{
+	const uint16_t *src = (const uint16_t *)buf2352;
+	const int nframes = AKIKO_CDDA_BYTES / 4;
+
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(AKIKO_CDDA_ADDR);
+	for (int i = 0; i < nframes; i++) {
+		uint16_t l = bswap_16(src[2 * i + 0]);
+		uint16_t r = bswap_16(src[2 * i + 1]);
+		spi_w(l);
+		spi_w(r);
+	}
+	DisableIO();
+}
+
+static void build_subcode_deint(drive_t *drv, uint32_t lba, uint8_t out[AKIKO_SUB_BYTES])
+{
+	memset(out, 0, AKIKO_SUB_BYTES);
+	if (!drv) return;
+
+	int trk_idx = 0;
+	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+	for (int i = 0; i < real_tracks; i++) {
+		uint32_t end = (i + 1 < drv->track_cnt) ? drv->track[i + 1].start
+		                                        : drv->track[i].start + drv->track[i].length;
+		if (lba >= drv->track[i].start && lba < end) { trk_idx = i; break; }
+	}
+	const track_t &t = drv->track[trk_idx];
+
+	uint8_t *q = out + AKIKO_SUB_ENTRY;
+	q[0] = (uint8_t)((t.attr & 0xf0) | 0x01);
+	q[1] = bin_to_bcd((uint8_t)t.number);
+	q[2] = bin_to_bcd(1);
+
+	uint32_t rel = (lba >= t.start) ? (lba - t.start) : 0u;
+	q[3] = bin_to_bcd((uint8_t)((rel / 75u) / 60u));
+	q[4] = bin_to_bcd((uint8_t)((rel / 75u) % 60u));
+	q[5] = bin_to_bcd((uint8_t)( rel % 75u));
+	q[6] = 0;
+
+	uint32_t ab = lba + 150u;
+	q[7] = bin_to_bcd((uint8_t)((ab / 75u) / 60u));
+	q[8] = bin_to_bcd((uint8_t)((ab / 75u) % 60u));
+	q[9] = bin_to_bcd((uint8_t)( ab % 75u));
+}
+
+static void sub_to_interleaved(const uint8_t *s, uint8_t *d)
+{
+	for (int i = 0; i < AKIKO_SUB_BYTES; i++) {
+		int dmask = 0x80;
+		int smask = 1 << (7 - (i & 7));
+		d[i] = 0;
+		for (int j = 0; j < 8; j++) {
+			if (s[(i / 8) + j * AKIKO_SUB_ENTRY] & smask) d[i] |= dmask;
+			dmask >>= 1;
+		}
+	}
+}
+
+static void akiko_push_subcode(const uint8_t *d96)
+{
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(AKIKO_SUBCODE_ADDR);
+	for (int i = 0; i < AKIKO_SUB_BYTES; i++) spi_w(d96[i]);
+	DisableIO();
+}
+
+static bool akiko_cdda_pump(void)
+{
+	if (cd_cdda_lba_next < 0) return false;
+	if (cd_paused) return false;
+	if (!cd_cdda_drv) {
+		cd_cdda_lba_next = -1;
+		cd_cdda_lba_end  = -1;
+		cd_audio_timeout = -3;
+		akiko_diag("[akiko] CDDA pump abort: drive gone");
+		return false;
+	}
+	if (!akiko_audio_fifo_ready()) return false;
+
+	uint8_t buf[AKIKO_CDDA_BYTES];
+	uint32_t lba = (uint32_t)cd_cdda_lba_next;
+	if (!cd_read_audio_sector(cd_cdda_drv, lba, buf)) {
+		akiko_diag("[akiko] CDDA pump read FAIL at lba=%u, aborting", lba);
+		memset(buf, 0, sizeof(buf));
+		akiko_push_audio_sector(buf);
+		cd_cdda_lba_next = -1;
+		cd_cdda_lba_end  = -1;
+		cd_cdda_drv      = NULL;
+		cd_audio_timeout = -3;
+		return true;
+	}
+
+	akiko_push_audio_sector(buf);
+	cd_cdda_lba_next++;
+	cd_cdda_q_pos = (int32_t)lba;
+
+	{
+		uint8_t sub_deint[AKIKO_SUB_BYTES];
+		uint8_t sub_intlv[AKIKO_SUB_BYTES];
+		build_subcode_deint(cd_cdda_drv, lba, sub_deint);
+		sub_to_interleaved(sub_deint, sub_intlv);
+		akiko_push_subcode(sub_intlv);
+	}
+
+	if ((lba & 0xff) == 0) {
+		int32_t remaining = cd_cdda_lba_end - cd_cdda_lba_next;
+		(void)remaining;
+		akiko_dbg("CDDA pump pushed lba=%u (rem=%d)\n", lba, remaining);
+	}
+
+	if (cd_cdda_lba_next >= cd_cdda_lba_end) {
+		akiko_dbg("CDDA done at lba=%u\n", lba);
+		akiko_diag("[akiko] CDDA pump natural end at lba=%u", lba);
+		cd_cdda_q_pos    = cd_cdda_q_end;
+		cd_cdda_lba_next = -1;
+		cd_cdda_lba_end  = -1;
+		cd_cdda_drv      = NULL;
+		cd_audio_play_until_ms = 0;
+		cd_audio_timeout = -1;
+	}
+	return true;
+}
+
+static int akiko_prefetch_fill(drive_t *drv, int win_idx, uint32_t base_lba)
+{
+	prefetch_window_t *w = &cd_prefetch_windows[win_idx];
+	w->base_lba = (int32_t)base_lba;
+	int filled = 0;
+	for (int i = 0; i < AKIKO_PREFETCH_SECTORS; i++) {
+		uint32_t lba = base_lba + i;
+		uint8_t *slot = &w->buf[i * AKIKO_SECTOR_BYTES];
+		if (cdrom_read_raw_sector(drv, lba, slot) == 0) {
+			w->valid[i] = 1;
+			filled++;
+		} else {
+			w->valid[i] = 0;
+			cd_prefetch_failed_sectors++;
+		}
+	}
+	return filled;
+}
+
+static int akiko_prefetch_get(drive_t *drv, uint32_t lba, uint8_t *out_buf)
+{
+	int win = akiko_prefetch_find(lba);
+	if (win < 0) {
+		cd_prefetch_misses++;
+		win = akiko_prefetch_pick_evict();
+		uint32_t base = (lba / AKIKO_PREFETCH_SECTORS) * AKIKO_PREFETCH_SECTORS;
+		if (akiko_prefetch_fill(drv, win, base) == 0) {
+			akiko_diag("[akiko] prefetch fill TOTAL FAIL win=%d base=%u (req lba=%u)",
+			           win, base, lba);
+			return -1;
+		}
+		akiko_diag("[akiko] prefetch refill win=%d base=%u (req lba=%u hits=%u misses=%u failed=%u)",
+		           win, base, lba, cd_prefetch_hits, cd_prefetch_misses,
+		           cd_prefetch_failed_sectors);
+	} else {
+		cd_prefetch_hits++;
+	}
+	prefetch_window_t *w = &cd_prefetch_windows[win];
+	w->lru_tick = ++cd_prefetch_lru_counter;
+	int idx = (int)(lba - (uint32_t)w->base_lba);
+	if (w->valid[idx] == 0) {
+		uint8_t *slot = &w->buf[idx * AKIKO_SECTOR_BYTES];
+		if (cdrom_read_raw_sector(drv, lba, slot) == 0) {
+			w->valid[idx] = 1;
+		} else {
+			return -2;
+		}
+	}
+	memcpy(out_buf, &w->buf[idx * AKIKO_SECTOR_BYTES], AKIKO_SECTOR_BYTES);
+	return 0;
+}
+
+static void akiko_handle_sec_req(void)
+{
+	struct timespec ts0, ts1, ts2, ts3;
+	static int64_t phase_a_us = 0, phase_b_us = 0, phase_c_us = 0;
+	static uint32_t bucket_count = 0;
+	const uint32_t BUCKET_SIZE = 256;
+
+	static uint32_t last_sec_req_ms = 0;
+	uint32_t now_ms = (uint32_t)GetTimer(0);
+	if (last_sec_req_ms != 0 && (now_ms - last_sec_req_ms) >= 50) {
+		akiko_diag("[akiko] sec_req GAP %ums (lba_base=%d)",
+		           now_ms - last_sec_req_ms, cd_data_lba_base);
+	}
+	last_sec_req_ms = now_ms;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts0);
+	uint8_t counter = akiko_read_sec_counter();
+	clock_gettime(CLOCK_MONOTONIC, &ts1);
+
+	uint8_t buf[AKIKO_SECTOR_BYTES];
+
+	if (cd_data_lba_base == -1) {
+		akiko_dbg("sec_req but no data read armed (counter=%u)\n", counter);
+		memset(buf, 0, sizeof(buf));
+		akiko_push_sector(buf);
+		return;
+	}
+
+	drive_t *drv = cd_find_drive();
+	if (!drv) {
+		akiko_dbg("sec_req but no CD drive (counter=%u)\n", counter);
+		memset(buf, 0, sizeof(buf));
+		akiko_push_sector(buf);
+		return;
+	}
+
+	int32_t signed_lba = cd_data_lba_base + (int32_t)counter;
+	if (signed_lba < 0) {
+		memset(buf, 0, sizeof(buf));
+		akiko_push_sector(buf);
+		return;
+	}
+	uint32_t lba = (uint32_t)signed_lba;
+
+	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+	uint32_t lead_out = (real_tracks > 0) ? drv->track[real_tracks].start : 0;
+	if (!lead_out || lba >= lead_out) {
+		static uint32_t last_oob_lba = 0;
+		if (lba != last_oob_lba) {
+			akiko_diag("[akiko] sec_req lba=%u %s lead_out=%u — push silence, advance",
+			           lba, lead_out ? ">=" : "(no track table)", lead_out);
+			last_oob_lba = lba;
+		}
+		memset(buf, 0, sizeof(buf));
+		akiko_push_sector(buf);
+		return;
+	}
+
+	{
+		track_t *track = NULL;
+		for (int i = 0; i < real_tracks; i++) {
+			uint32_t end = drv->track[i].start + drv->track[i].length;
+			if (lba >= drv->track[i].start && lba < end) {
+				track = &drv->track[i];
+				break;
+			}
+		}
+		if (track && !(track->attr & 0x40)) {
+			static uint32_t held_audio_lba = UINT32_MAX;
+			static uint32_t held_count = 0;
+			const uint32_t HOLD_MAX = 50;
+			if (lba != held_audio_lba) {
+				held_audio_lba = lba;
+				held_count = 0;
+				akiko_diag("[akiko] sec_req lba=%u in audio track (attr=0x%02x) — hold",
+				           lba, track->attr);
+			}
+			held_count++;
+			if (held_count >= HOLD_MAX) {
+				akiko_diag("[akiko] audio-hold cap reached at lba=%u — emit playend_notify, disarm",
+				           lba);
+				cd_data_lba_base = -1;
+				emit_playend_notify(1);
+				held_audio_lba = UINT32_MAX;
+				held_count = 0;
+			}
+			return;
+		}
+	}
+
+	int rc = akiko_prefetch_get(drv, lba, buf);
+	if (rc != 0) {
+		static const unsigned MAX_FAIL_RETRIES = 8;
+		static uint32_t fail_lba = UINT32_MAX;
+		static unsigned fail_count = 0;
+		if (lba != fail_lba) { fail_lba = lba; fail_count = 0; }
+		fail_count++;
+		akiko_diag("[akiko] sec_req lba=%u %s (retry %u/%u)", lba,
+		           (rc == -1) ? "prefetch FAIL" : "cached invalid",
+		           fail_count, MAX_FAIL_RETRIES);
+		if (fail_count < MAX_FAIL_RETRIES) return;
+		akiko_diag("[akiko] sec_req lba=%u retry cap reached — push silence, advance", lba);
+		fail_lba = UINT32_MAX;
+		memset(buf, 0, sizeof(buf));
+		akiko_push_sector(buf);
+		return;
+	}
+	clock_gettime(CLOCK_MONOTONIC, &ts2);
+
+	akiko_push_sector(buf);
+	clock_gettime(CLOCK_MONOTONIC, &ts3);
+
+	#define TS_DELTA_US(a, b) \
+		(((int64_t)(b).tv_sec  - (int64_t)(a).tv_sec ) * 1000000LL + \
+		 ((int64_t)(b).tv_nsec - (int64_t)(a).tv_nsec) / 1000LL)
+	phase_a_us += TS_DELTA_US(ts0, ts1);
+	phase_b_us += TS_DELTA_US(ts1, ts2);
+	phase_c_us += TS_DELTA_US(ts2, ts3);
+	#undef TS_DELTA_US
+	bucket_count++;
+
+	if (bucket_count >= BUCKET_SIZE) {
+		akiko_diag("[akiko] sec_req timing N=%u: ctr_read=%lld chd_read=%lld push=%lld (us total) "
+		           "= %lld/%lld/%lld us avg, last lba=%u",
+		           bucket_count,
+		           (long long)phase_a_us,
+		           (long long)phase_b_us,
+		           (long long)phase_c_us,
+		           (long long)(phase_a_us / bucket_count),
+		           (long long)(phase_b_us / bucket_count),
+		           (long long)(phase_c_us / bucket_count),
+		           lba);
+		phase_a_us = phase_b_us = phase_c_us = 0;
+		bucket_count = 0;
+	}
+}
+
+void akiko_cd32_set_cd_path(const char *path)
+{
+	char new_path[256] = {0};
+	if (path && *path) {
+		compute_save_path(path, new_path, sizeof(new_path));
+	}
+
+	if (strcmp(new_path, cd_save_path_active) == 0) {
+		return;
+	}
+
+	if (path && *path) {
+		int fd = open(path, O_RDONLY | O_CLOEXEC);
+		if (fd >= 0) {
+			posix_fadvise(fd, 0, 16 * 1024 * 1024, POSIX_FADV_WILLNEED);
+			close(fd);
+			akiko_diag("[akiko] set_cd_path: fadvise WILLNEED 16MB on %s", path);
+		}
+	}
+
+	if (cd_save_path_active[0] && cd_save_dirty_observed) {
+		akiko_diag("[akiko] set_cd_path: flushing old save %s before swap",
+		           cd_save_path_active);
+		akiko_nvram_save_to_path(cd_save_path_active);
+	}
+
+	strncpy(cd_save_path_active, new_path, sizeof(cd_save_path_active) - 1);
+	cd_save_path_active[sizeof(cd_save_path_active) - 1] = 0;
+	cd_save_dirty_observed = false;
+	cd_save_load_failed = false;
+
+	if (!cd_save_path_active[0]) {
+		cd_save_load_pending = false;
+		akiko_diag("[akiko] set_cd_path: CD unmounted, no save file active");
+		return;
+	}
+
+	cd_save_load_pending = true;
+	akiko_diag("[akiko] set_cd_path: cd=%s -> save=%s (deferred load armed)",
+	           path, cd_save_path_active);
+}
+
+void akiko_cd32_init(void)
+{
+	cd_initialized   = 0;
+	cd_paused        = 0;
+	cd_playing       = 0;
+	cd_led_state     = 0;
+	cd_door          = 1;
+	cd_play_start_lba = 0;
+	cd_play_end_lba   = 0;
+	cd_data_lba_base = -1;
+	cd_audio_timeout = 0;
+	cd_audio_play_until_ms = 0;
+	cd_cdda_lba_next = -1;
+	cd_cdda_lba_end  = -1;
+	cd_cdda_drv      = NULL;
+	cd_last_mounted  = false;
+	toc_point_count  = 0;
+	toc_push_idx     = -1;
+	toc_push_last_ms = 0;
+
+	akiko_prefetch_invalidate();
+	cd_post_info_media_push_pending = 0;
+
+	cd_save_dirty_observed = false;
+	cd_save_load_failed = false;
+	if (cd_save_path_active[0]) {
+		cd_save_load_pending = true;
+		akiko_diag("[akiko] init: scheduling reload of %s after BRAM wipe",
+		           cd_save_path_active);
+	}
+
+	akiko_dbg("init\n");
+}
+
+static void akiko_diag(const char *fmt, ...)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	printf("[%6lu.%06lu] ", (unsigned long)ts.tv_sec, (unsigned long)(ts.tv_nsec / 1000));
+	va_list ap; va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
+	putchar('\n');
+	fflush(stdout);
+}
+
+void akiko_cd32_poll(void)
+{
+	usleep(20);
+
+	bool mounted = cd_is_mounted();
+
+	if (g_akiko_pending_minimig_reset) {
+		g_akiko_pending_minimig_reset = false;
+		akiko_diag("[akiko] mediachange: BIOS was stuck on no-CD splash, "
+		           "triggering minimig_reset()");
+		minimig_reset();
+		return;
+	}
+
+	static bool first_poll = true;
+	if (first_poll) {
+		first_poll = false;
+		akiko_diag("[akiko] poll alive (first call) mounted=%d", mounted);
+	}
+
+	if (cd_save_load_pending && mounted) {
+		cd_save_load_pending = false;
+		if (cd_save_path_active[0]) {
+			struct stat pst;
+			if (stat(cd_save_path_active, &pst) != 0 &&
+			    stat(AKIKO_NVRAM_FILE_LEGACY, &pst) == 0 &&
+			    pst.st_size == AKIKO_NVRAM_BYTES) {
+				akiko_diag("[akiko] migrating legacy save %s -> %s",
+				           AKIKO_NVRAM_FILE_LEGACY, cd_save_path_active);
+				akiko_nvram_load_from_path(AKIKO_NVRAM_FILE_LEGACY);
+			} else {
+				akiko_nvram_load_from_path(cd_save_path_active);
+			}
+		}
+	}
+
+	akiko_nvram_verify_load_pending();
+
+#if AKIKO_CD32_DEBUG
+	static int unmounted_dump_throttle = 0;
+	if (!mounted && (unmounted_dump_throttle++ % 60) == 0 && unmounted_dump_throttle < 5*60) {
+		akiko_diag(
+			"[akiko] ide_inst dump: "
+			"[0,0]p=%d/c=%d/chd=%p/f=%p  [0,1]p=%d/c=%d/chd=%p/f=%p",
+			ide_inst[0].drive[0].present, ide_inst[0].drive[0].cd,
+			(void*)ide_inst[0].drive[0].chd_f, (void*)ide_inst[0].drive[0].f,
+			ide_inst[0].drive[1].present, ide_inst[0].drive[1].cd,
+			(void*)ide_inst[0].drive[1].chd_f, (void*)ide_inst[0].drive[1].f
+		);
+	}
+#endif
+
+	static bool media_absent_push_pending = false;
+	static bool mediachanged_push_pending = false;
+	static bool had_prior_unmount = false;
+	if (mounted != cd_last_mounted) {
+		cd_data_lba_base = -1;
+		akiko_prefetch_invalidate();
+		cd_cdda_lba_next = -1;
+		cd_cdda_lba_end  = -1;
+		cd_cdda_drv      = NULL;
+		toc_point_count  = 0;
+		toc_push_idx     = -1;
+		if (!mounted) {
+			media_absent_push_pending = true;
+			mediachanged_push_pending = false;
+			had_prior_unmount = true;
+		} else {
+			media_absent_push_pending = false;
+			akiko_build_toc();
+			if (cd_initialized >= 2) {
+				if (had_prior_unmount) {
+					mediachanged_push_pending = true;
+				} else {
+					g_akiko_pending_minimig_reset = true;
+					mediachanged_push_pending = false;
+				}
+			}
+		}
+		cd_last_mounted = mounted;
+		akiko_diag("[akiko] media change -> mounted=%d cd_init=%u (absent=%d, mediachanged=%d)",
+		           mounted, cd_initialized,
+		           media_absent_push_pending, mediachanged_push_pending);
+	}
+
+	uint16_t status = akiko_read_status();
+#if AKIKO_CD32_DEBUG
+	static uint16_t last_status = 0xffff;
+	static int status_log_count = 0;
+	if (status != last_status && status_log_count < 200) {
+		akiko_diag("[akiko] status=0x%04x (was 0x%04x)", status, last_status);
+		last_status = status;
+		status_log_count++;
+	}
+#endif
+	const bool rx_idle = !(status & AKIKO_STATUS_RX_BUSY);
+
+	if (mounted && cd_initialized == 0 && rx_idle) {
+		uint8_t r[2];
+		r[0] = 0x0a;
+		r[1] = 0x01;
+		akiko_send_response(r, 2);
+		cd_initialized = 1;
+		akiko_diag("[akiko] auto-init media-status push: opcode=0x0a status=0x01 (cd_initialized=1)");
+	}
+
+	if (mediachanged_push_pending && mounted && cd_initialized >= 2 && rx_idle) {
+		uint8_t r[2];
+		r[0] = 0x0a;
+		r[1] = 0x01;
+		akiko_send_response(r, 2);
+		mediachanged_push_pending = false;
+		akiko_build_toc();
+		akiko_diag("[akiko] mediachange push: opcode=0x0a status=0x01 (TOC rebuilt 2x)");
+	}
+
+	if (media_absent_push_pending && !mounted && rx_idle) {
+		uint8_t r[2];
+		r[0] = 0x0a;
+		r[1] = 0x00;
+		akiko_send_response(r, 2);
+		media_absent_push_pending = false;
+		akiko_diag("[akiko] eject media-status push: opcode=0x0a status=0x00");
+	}
+
+	(void)cd_post_info_media_push_pending;
+
+	if (cd_initialized == 2 && toc_push_idx >= 0 && rx_idle) {
+		uint32_t now_ms = (uint32_t)GetTimer(0);
+		if ((now_ms - toc_push_last_ms) >= AKIKO_TOC_PUSH_PERIOD_MS) {
+			toc_push_last_ms = now_ms;
+			akiko_push_toc_entry();
+		}
+	}
+
+	{
+		static uint32_t nvr_dirty_seen_at    = 0;
+		static uint32_t nvr_last_save_at     = 0;
+		static int      nvr_menu_was_present = 0;
+		const bool nvr_dirty_now  = (status & AKIKO_STATUS_NVR_DIRTY) != 0;
+		const int  nvr_menu_now   = menu_present();
+		const bool osd_open_edge  = nvr_menu_now && !nvr_menu_was_present;
+		nvr_menu_was_present      = nvr_menu_now;
+
+		if (nvr_dirty_now) {
+			cd_save_dirty_observed = true;
+			uint32_t now_ms = (uint32_t)GetTimer(0);
+			if (!nvr_dirty_seen_at) {
+				nvr_dirty_seen_at = now_ms;
+				akiko_diag("[akiko] NVR dirty observed at t=%u", now_ms);
+			}
+			const bool throttle_expired = rx_idle &&
+				(now_ms - nvr_dirty_seen_at) >= AKIKO_NVRAM_DIRTY_DEBOUNCE_MS;
+			const bool fire = osd_open_edge || throttle_expired;
+			const bool cooldown_clear = !nvr_last_save_at ||
+				(now_ms - nvr_last_save_at) >= AKIKO_NVRAM_MIN_SAVE_INTERVAL_MS;
+			if (fire && cooldown_clear) {
+				if (osd_open_edge) {
+					akiko_diag("[akiko] NVR flush: OSD opened with dirty pending");
+				}
+				akiko_nvram_save_to_disk();
+				nvr_dirty_seen_at = 0;
+				nvr_last_save_at  = now_ms;
+			}
+		} else {
+			nvr_dirty_seen_at = 0;
+		}
+	}
+
+	if (cd_audio_timeout != 0 && rx_idle) {
+		if (cd_audio_timeout > 1) {
+			cd_audio_timeout--;
+		} else if (cd_audio_timeout == 1) {
+			emit_playend_notify(0);
+			cd_audio_timeout = 0;
+		} else if (cd_audio_timeout == -1) {
+			cd_audio_timeout = -2;
+		} else if (cd_audio_timeout == -2) {
+			emit_playend_notify(1);
+			cd_playing = 0;
+			cd_audio_timeout = 0;
+			cd_audio_play_until_ms = 0;
+		} else if (cd_audio_timeout == -3) {
+			emit_playend_notify(-1);
+			cd_playing = 0;
+			cd_audio_timeout = 0;
+			cd_audio_play_until_ms = 0;
+		}
+		return;
+	}
+
+	if (cd_audio_play_until_ms != 0 && cd_playing && rx_idle &&
+	    cd_audio_timeout == 0) {
+		uint32_t now_ms = (uint32_t)GetTimer(0);
+		if ((int32_t)(now_ms - cd_audio_play_until_ms) >= 0) {
+			emit_playend_notify(1);
+			cd_playing = 0;
+			cd_audio_play_until_ms = 0;
+			akiko_diag("[akiko] PLAY AUDIO natural end at t=%u", now_ms);
+			return;
+		}
+	}
+
+	if (akiko_cdda_pump()) {
+		return;
+	}
+
+	if (status & AKIKO_STATUS_SEC_REQ) {
+		akiko_handle_sec_req();
+		return;
+	}
+
+	if (!(status & AKIKO_STATUS_REQ)) return;
+
+	uint8_t cmd[AKIKO_CMD_MAX];
+	int     n = akiko_drain_command(cmd);
+	if (n < 1) {
+		akiko_dbg("drain returned 0 bytes\n");
+		return;
+	}
+
+#if AKIKO_CD32_DEBUG
+	akiko_dbg("RX %d bytes:", n);
+	for (int i = 0; i < n; i++) printf(" %02x", cmd[i]);
+	printf("\n");
+#endif
+
+	int op = cmd[0] & 0x0f;
+	int expected_len = command_lengths[op];
+
+	if (expected_len > 0) {
+		int chk_total = expected_len + 1;
+		if (n < chk_total) {
+			akiko_dbg("short frame: n=%d expected=%d\n", n, chk_total);
+			cmd_bad(cmd, CH_ERR_CHECKSUM);
+			return;
+		}
+		uint32_t sum = 0;
+		for (int i = 0; i < chk_total; i++) sum += cmd[i];
+		if ((sum & 0xff) != 0xff) {
+			akiko_dbg("checksum FAIL sum=%02x\n", sum & 0xff);
+			cmd_bad(cmd, CH_ERR_CHECKSUM);
+			return;
+		}
+	}
+
+	if (op != 0x05) {
+		char hex[3 * AKIKO_CMD_MAX + 1];
+		int  off = 0;
+		for (int i = 0; i < n && i < 16; i++) {
+			off += snprintf(hex + off, sizeof(hex) - off, "%02x ", cmd[i]);
+		}
+		if (off > 0) hex[off - 1] = '\0';
+		akiko_diag("[akiko] CMD op=0x%02x n=%d bytes=%s", op, n, hex);
+	}
+
+	switch (op) {
+		case 0x00: {
+			uint8_t r[1];
+			r[0] = cmd[0];
+			akiko_send_response(r, 1);
+			akiko_dbg("CMD 0x00 echo\n");
+			break;
+		}
+		case 0x01: cmd_stop(cmd);    break;
+		case 0x02: cmd_pause(cmd);   break;
+		case 0x03: cmd_unpause(cmd); break;
+		case 0x04: cmd_multi(cmd);   break;
+		case 0x05: cmd_led(cmd);     break;
+		case 0x06: cmd_subq(cmd);    break;
+		case 0x07: cmd_info(cmd);    break;
+		case 0x08:
+		case 0x09:
+		case 0x0a:
+			akiko_dbg("CMD 0x%02x consumed (no response per WinUAE parity)\n", op);
+			break;
+		default:
+			cmd_bad(cmd, CH_ERR_BADCOMMAND);
+			break;
+	}
+}

--- a/support/minimig/akiko_cd32.h
+++ b/support/minimig/akiko_cd32.h
@@ -1,0 +1,9 @@
+#ifndef AKIKO_CD32_H
+#define AKIKO_CD32_H
+
+void akiko_cd32_init(void);
+void akiko_cd32_poll(void);
+
+void akiko_cd32_set_cd_path(const char *path);
+
+#endif

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -1,0 +1,891 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <byteswap.h>
+
+#include "../../spi.h"
+#include "../../user_io.h"
+#include "../../hardware.h"
+#include "../../ide.h"
+#include "../../ide_cdrom.h"
+#include "../chd/mister_chd.h"
+#include "cdtv_cd.h"
+#include "minimig_config.h"
+
+static void cdtv_diag(const char *fmt, ...)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	printf("[%6lu.%06lu] ", (unsigned long)ts.tv_sec, (unsigned long)(ts.tv_nsec / 1000));
+	va_list ap; va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
+	putchar('\n');
+	fflush(stdout);
+}
+
+#define CDTV_DEBUG 1
+#if CDTV_DEBUG
+	#define cdtv_dbg(fmt, ...) cdtv_diag("[cdtv] " fmt, ##__VA_ARGS__)
+#else
+	#define cdtv_dbg(...) do {} while (0)
+#endif
+
+#define CDTV_BRIDGE_ADDR   0xF800
+#define CDTV_SEC_ADDR      0xF820
+#define CDTV_STCH_ADDR     0xF840
+#define CDTV_CDDA_ADDR     0xF200
+#define CDTV_CDDA_BYTES    2352
+#define CDTV_STATUS_CDDA_REQ (1u << 8)
+#define CDTV_STATUS_CMD    0x63
+#define CDTV_STATUS_REQ    (1u << 6)
+
+static int cr511_command_length(uint8_t op)
+{
+	switch (op) {
+		case 0x00: case 0x80:                      return 2;
+		case 0x81: case 0x85: case 0x86:
+		case 0x88: case 0xA2:                      return 1;
+		case 0x01: case 0x02: case 0x04: case 0x05:
+		case 0x09: case 0x0a: case 0x0b: case 0x82:
+		case 0x83: case 0x84: case 0x87: case 0x89:
+		case 0x8a: case 0x8b: case 0xa3:           return 7;
+		default:                                   return -1;
+	}
+}
+
+#define CDTV_CMD_MAX  16
+static uint8_t  cmd_buf[CDTV_CMD_MAX];
+static int      cmd_idx = 0;
+static int      cmd_need = 0;
+
+static uint8_t  cd_motor       = 0;
+static uint8_t  cd_isready     = 0;
+static uint8_t  cd_media       = 0;
+static uint8_t  cd_playing     = 0;
+static uint8_t  cd_finished    = 0;
+static uint8_t  cd_error       = 0;
+static uint16_t cd_sectorsize  = 2048;
+
+static char     cd_path_active[1024] = {0};
+
+static int32_t  cdtv_play_lba_next = -1;
+static int32_t  cdtv_play_lba_end  = -1;
+static drive_t *cdtv_play_drv      = NULL;
+static uint8_t  cd_paused          = 0;
+
+static uint8_t  cd_audio_status    = 0x15;
+
+static int32_t  cdtv_last_lba      = 0;
+
+static int            stch_retries  = 0;
+static unsigned long  stch_next_ms  = 0;
+#define STCH_RETRY_BUDGET    40
+#define STCH_RETRY_PERIOD_MS 250
+
+static bool           stch_wait_ack = false;
+#define STCH_PLAYEND_BUDGET    400
+#define STCH_PLAYEND_PERIOD_MS 60
+
+static inline bool cdtv_active(void)
+{
+	return (minimig_config.chipset & CONFIG_CDTV) != 0;
+}
+
+static drive_t *cdtv_find_drive(void)
+{
+	for (int p = 0; p < 2; p++) {
+		for (int d = 0; d < 2; d++) {
+			drive_t *drv = &ide_inst[p].drive[d];
+			if (drv->cd && (drv->chd_f || drv->f)) {
+				return drv;
+			}
+		}
+	}
+	return NULL;
+}
+
+static uint16_t cdtv_read_status(void)
+{
+	uint16_t res;
+	EnableIO();
+	res = spi_w(CDTV_STATUS_CMD);
+	if (!res) res = (uint8_t)spi_w(0);
+	DisableIO();
+	return res;
+}
+
+static uint8_t cdtv_drain_byte(void)
+{
+	uint8_t b;
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(CDTV_BRIDGE_ADDR);
+	b = (uint8_t)spi_w(0);
+	DisableIO();
+	return b;
+}
+
+static void cdtv_inject_stch(void)
+{
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(CDTV_STCH_ADDR);
+	spi_w(0);
+	DisableIO();
+	cdtv_dbg("STCH inject");
+}
+
+static bool cdtv_stch_acked(void)
+{
+	uint16_t v;
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(CDTV_STCH_ADDR);
+	v = (uint16_t)spi_w(0);
+	DisableIO();
+	return (v & 1) != 0;
+}
+
+static void cdtv_push_reply(const uint8_t *buf, int len)
+{
+	if (len <= 0) return;
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(CDTV_BRIDGE_ADDR);
+	for (int i = 0; i < len; i++) {
+		spi_w(buf[i]);
+	}
+	DisableIO();
+
+#if CDTV_DEBUG
+	char dump[3 * CDTV_CMD_MAX + 4];
+	int n = 0;
+	int dump_n = (len > CDTV_CMD_MAX) ? CDTV_CMD_MAX : len;
+	for (int i = 0; i < dump_n; i++) n += snprintf(dump + n, sizeof(dump) - n, "%02x ", buf[i]);
+	cdtv_dbg("TX[%d]: %s%s", len, dump, (len > dump_n) ? "..." : "");
+#endif
+}
+
+static void cdtv_push_sector(const uint8_t *buf, int len)
+{
+	if (len <= 0) return;
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(CDTV_SEC_ADDR);
+	for (int i = 0; i < len; i++) {
+		spi_w(buf[i]);
+	}
+	DisableIO();
+}
+
+static bool cdtv_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
+{
+	if (!drv || !drv->chd_f || !buf2352) return false;
+
+	track_t *track = NULL;
+	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
+	for (int i = 0; i < real_tracks; i++) {
+		uint32_t end = drv->track[i].start + drv->track[i].length;
+		if (lba >= drv->track[i].start && lba < end) {
+			track = &drv->track[i];
+			break;
+		}
+	}
+	if (!track) return false;
+	if (track->attr & 0x40) return false;
+	if (track->sectorSize != CDTV_CDDA_BYTES) return false;
+
+	uint32_t chd_lba = lba + track->chd_offset;
+	if (mister_chd_read_sector(drv->chd_f, chd_lba, 0, 0,
+	                           CDTV_CDDA_BYTES, buf2352,
+	                           drv->chd_hunkbuf, &drv->chd_hunknum)
+	    != CHDERR_NONE) {
+		return false;
+	}
+	return true;
+}
+
+static uint16_t cdtv_read_status_full(void)
+{
+	uint16_t hi;
+	EnableIO();
+	hi = spi_w(CDTV_STATUS_CMD);
+	if (!hi) hi = (uint16_t)spi_w(0);
+	DisableIO();
+	return hi;
+}
+
+static bool cdtv_audio_fifo_ready(void)
+{
+	return (cdtv_read_status_full() & CDTV_STATUS_CDDA_REQ) != 0;
+}
+
+static void cdtv_push_audio_sector(const uint8_t *buf2352)
+{
+	const uint16_t *src = (const uint16_t *)buf2352;
+	const int nframes = CDTV_CDDA_BYTES / 4;
+
+	EnableIO();
+	spi8(UIO_DMA_WRITE);
+	spi32_w(CDTV_CDDA_ADDR);
+	for (int i = 0; i < nframes; i++) {
+		uint16_t l = bswap_16(src[2 * i + 0]);
+		uint16_t r = bswap_16(src[2 * i + 1]);
+		spi_w(l);
+		spi_w(r);
+	}
+	DisableIO();
+}
+
+static bool cdtv_cdda_pump(void)
+{
+	if (cdtv_play_lba_next < 0) return false;
+	if (cd_paused) return false;
+	if (!cdtv_play_drv) {
+		cdtv_play_lba_next = -1;
+		cdtv_play_lba_end  = -1;
+		return false;
+	}
+	if (!cdtv_audio_fifo_ready()) return false;
+
+	uint8_t buf[CDTV_CDDA_BYTES];
+	uint32_t lba = (uint32_t)cdtv_play_lba_next;
+	if (!cdtv_read_audio_sector(cdtv_play_drv, lba, buf)) {
+		cdtv_dbg("CDDA pump read FAIL at lba=%u — aborting", lba);
+		memset(buf, 0, sizeof(buf));
+		cdtv_push_audio_sector(buf);
+		cdtv_last_lba      = (int32_t)lba;
+		cdtv_play_lba_next = -1;
+		cdtv_play_lba_end  = -1;
+		cdtv_play_drv      = NULL;
+		cd_playing         = 0;
+		cd_paused          = 0;
+		cd_finished        = 1;
+		cd_audio_status    = 0x14;
+		cdtv_inject_stch();
+		return true;
+	}
+
+	cdtv_push_audio_sector(buf);
+	cdtv_last_lba = (int32_t)lba;
+	cdtv_play_lba_next++;
+
+	if ((lba & 0xff) == 0) {
+		cdtv_dbg("CDDA pump lba=%u (rem=%d)", lba,
+		         cdtv_play_lba_end - cdtv_play_lba_next);
+	}
+
+	if (cdtv_play_lba_next >= cdtv_play_lba_end) {
+		cdtv_dbg("CDDA natural end at lba=%u", lba);
+		cdtv_play_lba_next = -1;
+		cdtv_play_lba_end  = -1;
+		cdtv_play_drv      = NULL;
+		cd_playing         = 0;
+		cd_paused          = 0;
+		cd_finished        = 1;
+		cd_audio_status    = 0x13;
+		cdtv_inject_stch();
+		stch_wait_ack = true;
+		stch_retries  = STCH_PLAYEND_BUDGET;
+		stch_next_ms  = GetTimer(STCH_PLAYEND_PERIOD_MS);
+	}
+	return true;
+}
+
+static uint32_t cdtv_msf_to_lba(uint32_t msf)
+{
+	uint32_t m = (msf >> 16) & 0xff;
+	uint32_t s = (msf >>  8) & 0xff;
+	uint32_t f =  msf        & 0xff;
+	uint32_t lsn = (m * 60u + s) * 75u + f;
+	return (lsn >= 150u) ? (lsn - 150u) : 0u;
+}
+
+static uint32_t cdtv_lba2msf(uint32_t lba)
+{
+	uint32_t m = lba / (60u * 75u);
+	uint32_t s = (lba / 75u) % 60u;
+	uint32_t f =  lba % 75u;
+	return (m << 16) | (s << 8) | f;
+}
+
+static int cmd_subq(const uint8_t *cmd, uint8_t *out)
+{
+	bool msf = (cmd[1] & 0x02) != 0;
+
+	memset(out, 0, 13);
+	out[0] = cd_audio_status;
+	out[1] = 0x10;
+
+	int32_t pump_lba = (cdtv_play_lba_next >= 0) ? cdtv_play_lba_next : cdtv_last_lba;
+	uint32_t disk_lba = (pump_lba > 0) ? (uint32_t)pump_lba : 0;
+
+	drive_t *drv = cdtv_play_drv ? cdtv_play_drv : cdtv_find_drive();
+	int track_idx = 0;
+	uint32_t track_start = 0;
+	if (drv && drv->track_cnt > 1) {
+		int real_tracks = drv->track_cnt - 1;
+		for (int i = 0; i < real_tracks; i++) {
+			uint32_t s_lba = drv->track[i].start;
+			uint32_t e_lba = s_lba + drv->track[i].length;
+			if (disk_lba >= s_lba && disk_lba < e_lba) {
+				track_idx   = i;
+				track_start = s_lba;
+				break;
+			}
+			track_idx   = i;
+			track_start = s_lba;
+		}
+	}
+
+	out[2] = (uint8_t)(track_idx + 1);
+	out[3] = 0x01;
+
+	uint32_t track_lba = (disk_lba > track_start) ? (disk_lba - track_start) : 0;
+	uint32_t disk_pos  = msf ? cdtv_lba2msf(disk_lba + 150) : disk_lba;
+	uint32_t track_pos = msf ? cdtv_lba2msf(track_lba)      : track_lba;
+
+	out[5]  = (disk_pos  >> 16) & 0xff;
+	out[6]  = (disk_pos  >>  8) & 0xff;
+	out[7]  = (disk_pos       ) & 0xff;
+	out[9]  = (track_pos >> 16) & 0xff;
+	out[10] = (track_pos >>  8) & 0xff;
+	out[11] = (track_pos       ) & 0xff;
+
+	return 13;
+}
+
+static int cmd_read_toc(const uint8_t *cmd, uint8_t *out)
+{
+	drive_t *drv = cdtv_find_drive();
+	if (!drv || drv->track_cnt < 1) {
+		cd_error = 1;
+		return -1;
+	}
+
+	uint8_t want = cmd[2];
+	bool msf = (cmd[1] & 0x02) != 0;
+	int real_tracks = drv->track_cnt - 1;
+	if (real_tracks < 1) real_tracks = 1;
+
+	uint32_t lba;
+	uint8_t  control = 0x04;
+	uint8_t  point   = want;
+
+	if (want == 0xa0) {
+		lba = drv->track[0].number;
+		point = 0xa0;
+	} else if (want == 0xa1) {
+		lba = (uint32_t)real_tracks;
+		point = 0xa1;
+	} else if (want == 0xa2) {
+		uint32_t end = 0;
+		for (int i = 0; i < drv->track_cnt; i++) {
+			uint32_t e = drv->track[i].start + drv->track[i].length;
+			if (e > end) end = e;
+		}
+		lba = end;
+		point = 0xa2;
+	} else if (want >= 1 && want <= 99 && want <= real_tracks) {
+		int idx = want - 1;
+		lba = drv->track[idx].start;
+		if (drv->track[idx].attr & 0x01) control = 0x00;
+	} else {
+		return -1;
+	}
+
+	uint32_t addr;
+	if (msf) {
+		uint32_t lsn = lba + 150u;
+		uint32_t mins = (lsn / 75u) / 60u;
+		uint32_t secs = (lsn / 75u) % 60u;
+		uint32_t fr   = lsn % 75u;
+		addr = (mins << 16) | (secs << 8) | fr;
+	} else {
+		addr = lba;
+	}
+
+	out[0] = 0;
+	out[1] = (1u << 4) | control;
+	out[2] = point;
+	out[3] = (uint8_t)real_tracks;
+	out[4] = 0;
+	out[5] = (uint8_t)(addr >> 16);
+	out[6] = (uint8_t)(addr >>  8);
+	out[7] = (uint8_t)(addr      );
+	cd_finished = 1;
+	return 8;
+}
+
+static int cmd_info(uint8_t *out)
+{
+	drive_t *drv = cdtv_find_drive();
+	if (!drv || drv->track_cnt < 1) {
+		cd_error = 1;
+		return -1;
+	}
+
+	int real_tracks = drv->track_cnt - 1;
+	if (real_tracks < 1) real_tracks = 1;
+
+	uint32_t end = 0;
+	for (int i = 0; i < drv->track_cnt; i++) {
+		uint32_t e = drv->track[i].start + drv->track[i].length;
+		if (e > end) end = e;
+	}
+	uint32_t lsn = end + 150u;
+	uint32_t mins = (lsn / 75u) / 60u;
+	uint32_t secs = (lsn / 75u) % 60u;
+	uint32_t fr   = lsn % 75u;
+
+	out[0] = 1;
+	out[1] = (uint8_t)real_tracks;
+	out[2] = (uint8_t)mins;
+	out[3] = (uint8_t)secs;
+	out[4] = (uint8_t)fr;
+	cd_finished = 1;
+	return 5;
+}
+
+static void cmd_mode_set(const uint8_t *cmd)
+{
+	uint16_t sz = (uint16_t)((cmd[2] << 8) | cmd[3]);
+	switch (sz) {
+		case 512: case 1024: case 2048:
+		case 2052: case 2336: case 2340:
+			cd_sectorsize = sz;
+			cd_finished = 1;
+			break;
+		default:
+			cd_error = 1;
+			break;
+	}
+}
+
+static int cmd_play(const uint8_t *cmd, uint8_t *out)
+{
+	drive_t *drv = cdtv_find_drive();
+	if (!drv || drv->track_cnt < 1) {
+		cd_error = 1;
+		out[0] = 0x00;
+		return -1;
+	}
+
+	uint8_t op = cmd[0];
+	uint32_t s_lba = 0, e_lba = 0;
+	int real_tracks = drv->track_cnt - 1;
+	if (real_tracks < 1) real_tracks = 1;
+
+	if (op == 0x0b) {
+		int track_start = cmd[1];
+		int track_end   = cmd[3];
+		if (track_start == 0 && track_end == 0) {
+			cdtv_dbg("PLAY TRACK 0,0 — stop");
+			cdtv_play_lba_next = -1;
+			cdtv_play_lba_end  = -1;
+			cdtv_play_drv      = NULL;
+			cd_playing = 0;
+			cd_paused  = 0;
+			cd_motor   = 0;
+			cd_error   = 1;
+			cd_audio_status = 0x15;
+			out[0] = 0x00;
+			return 1;
+		}
+		bool got_start = false;
+		uint32_t lead_out = drv->track[real_tracks].start;
+		uint32_t s = 0, e = lead_out;
+		for (int i = 0; i < real_tracks; i++) {
+			int trk = i + 1;
+			if (trk == track_start) { s = drv->track[i].start; got_start = true; }
+			if (trk == track_end)   { e = drv->track[i].start; }
+		}
+		if (!got_start) {
+			cdtv_dbg("PLAY TRACK %d-%d: illegal start", track_start, track_end);
+			cd_error = 1;
+			out[0] = 0x00;
+			return 1;
+		}
+		s_lba = s;
+		e_lba = e;
+	} else {
+		uint32_t a = ((uint32_t)cmd[1] << 16) | ((uint32_t)cmd[2] << 8) | cmd[3];
+		uint32_t b = ((uint32_t)cmd[4] << 16) | ((uint32_t)cmd[5] << 8) | cmd[6];
+		if (op == 0x09) {
+			s_lba = a;
+			e_lba = a + b;
+		} else {
+			s_lba = cdtv_msf_to_lba(a);
+			e_lba = (b < 0x00ffffff) ? cdtv_msf_to_lba(b) : 0xffffffffu;
+		}
+		uint32_t lead_out = drv->track[real_tracks].start;
+		if (e_lba > lead_out) e_lba = lead_out;
+	}
+
+	if (s_lba == 0 && e_lba == 0) {
+		cdtv_dbg("PLAY stop (0,0)");
+		cdtv_play_lba_next = -1;
+		cdtv_play_lba_end  = -1;
+		cdtv_play_drv      = NULL;
+		cd_playing = 0;
+		cd_paused  = 0;
+		cd_motor   = 0;
+		cd_error   = 1;
+		cd_audio_status = 0x15;
+		out[0] = 0x00;
+		return 1;
+	}
+
+	bool start_is_audio = false;
+	for (int i = 0; i < real_tracks; i++) {
+		uint32_t end = drv->track[i].start + drv->track[i].length;
+		if (s_lba >= drv->track[i].start && s_lba < end) {
+			start_is_audio = !(drv->track[i].attr & 0x40);
+			break;
+		}
+	}
+
+	if (start_is_audio && e_lba > s_lba) {
+		cdtv_play_drv      = drv;
+		cdtv_play_lba_next = (int32_t)s_lba;
+		cdtv_play_lba_end  = (int32_t)e_lba;
+		cdtv_last_lba      = (int32_t)s_lba;
+		cd_paused = 0;
+		cd_audio_status    = 0x11;
+		cdtv_dbg("PLAY arm op=%02x s_lba=%u e_lba=%u (n=%u)",
+		         op, s_lba, e_lba, e_lba - s_lba);
+	} else {
+		cdtv_play_drv      = NULL;
+		cdtv_play_lba_next = -1;
+		cdtv_play_lba_end  = -1;
+		cd_audio_status    = 0x14;
+		cdtv_dbg("PLAY refuse op=%02x s_lba=%u e_lba=%u (audio=%d)",
+		         op, s_lba, e_lba, start_is_audio);
+	}
+
+	cd_playing = 1;
+	cd_motor   = 1;
+	out[0] = 0x42;
+	return 1;
+}
+
+static void cdtv_dispatch(void)
+{
+	uint8_t op = cmd_buf[0];
+	uint8_t reply[CDTV_CMD_MAX];
+	int rlen = 0;
+
+	if (op != 0x81 && stch_retries > 0) {
+		cdtv_dbg("STCH retry budget cleared (op=%02x)", op);
+		stch_retries = 0;
+		stch_wait_ack = false;
+	}
+
+#if CDTV_DEBUG
+	{
+		char dump[3 * CDTV_CMD_MAX + 4];
+		int n = 0;
+		int dump_n = (cmd_idx > CDTV_CMD_MAX) ? CDTV_CMD_MAX : cmd_idx;
+		for (int i = 0; i < dump_n; i++) n += snprintf(dump + n, sizeof(dump) - n, "%02x ", cmd_buf[i]);
+		cdtv_dbg("RX[%d]: %s", cmd_idx, dump);
+	}
+#endif
+
+	switch (op) {
+		case 0x00:
+		case 0x80:
+			reply[0] = 0xaa;
+			reply[1] = 0x55;
+			rlen = 2;
+			break;
+
+		case 0x01:
+			cd_finished = 1;
+			rlen = 0;
+			break;
+
+		case 0x02: {
+			uint32_t lba   = ((uint32_t)cmd_buf[1] << 16)
+			               | ((uint32_t)cmd_buf[2] <<  8)
+			               | ((uint32_t)cmd_buf[3]      );
+			uint16_t nsec  = ((uint16_t)cmd_buf[4] <<  8) | cmd_buf[5];
+
+			drive_t *drv = cdtv_find_drive();
+			if (!drv || !drv->chd_f) {
+				cdtv_dbg("READ DATA lba=%u nsec=%u — no drive/chd", lba, nsec);
+				cd_error    = 1;
+				cd_finished = 1;
+				rlen        = 0;
+				break;
+			}
+
+			cdtv_dbg("READ DATA lba=%u nsec=%u sec_sz=%u", lba, nsec, cd_sectorsize);
+
+			uint8_t raw[2352];
+			bool    failed = false;
+			for (uint16_t s = 0; s < nsec; s++) {
+				if (cdrom_read_raw_sector(drv, lba + s, raw) != 0) {
+					cdtv_dbg("READ DATA chd_read failed at lba=%u", lba + s);
+					failed = true;
+					break;
+				}
+
+				const uint8_t *src;
+				uint16_t       len;
+				switch (cd_sectorsize) {
+					case 2048: src = raw + 16; len = 2048; break;
+					case 2052: src = raw + 16; len = 2052; break;
+					case 2336: src = raw + 16; len = 2336; break;
+					case 2340: src = raw + 12; len = 2340; break;
+					case 2352: src = raw;      len = 2352; break;
+					default:   src = raw + 16; len = cd_sectorsize; break;
+				}
+
+				cdtv_push_sector(src, len);
+
+				if (s + 1 < nsec) usleep(1000);
+			}
+
+			if (failed) cd_error = 1;
+			cd_finished = 1;
+			rlen = 0;
+			break;
+		}
+
+		case 0x04: cd_motor = 1; cd_finished = 1; rlen = 0; break;
+		case 0x05:
+			cdtv_play_lba_next = -1;
+			cdtv_play_lba_end  = -1;
+			cdtv_play_drv      = NULL;
+			cd_playing = 0;
+			cd_paused  = 0;
+			cd_motor   = 0;
+			cd_finished = 1;
+			cd_audio_status = 0x15;
+			rlen = 0;
+			break;
+
+		case 0x09:
+		case 0x0a:
+		case 0x0b:
+			rlen = cmd_play(cmd_buf, reply);
+			if (rlen < 0) rlen = 0;
+			break;
+
+		case 0x81: {
+			uint8_t flag = 0;
+			if (!cd_isready) flag |= 1 << 0;
+			if (cd_playing)  flag |= 1 << 2;
+			if (cd_finished) flag |= 1 << 3;
+			if (cd_error)    flag |= 1 << 4;
+			if (cd_motor)    flag |= 1 << 5;
+			if (cd_media)    flag |= 1 << 6;
+			reply[0] = flag;
+			rlen = 1;
+			cd_finished = 0;
+			break;
+		}
+
+		case 0x82: {
+			memset(reply, 0, 6);
+			if (cd_error) reply[2] |= 1 << 4;
+			cd_error   = 0;
+			cd_isready = 0;
+			rlen = 6;
+			cd_finished = 1;
+			break;
+		}
+
+		case 0x83: {
+			static const char *MODEL = "MATSHITA0.96";
+			int n = (int)strlen(MODEL);
+			memcpy(reply, MODEL, n);
+			rlen = n;
+			cd_finished = 1;
+			break;
+		}
+
+		case 0x84:
+			cmd_mode_set(cmd_buf);
+			rlen = 0;
+			break;
+
+		case 0x85:
+			reply[0] = (uint8_t)(cd_sectorsize >> 8);
+			reply[1] = (uint8_t)(cd_sectorsize     );
+			rlen = 2;
+			break;
+
+		case 0x86: {
+			drive_t *drv = cdtv_find_drive();
+			if (!drv || drv->track_cnt < 1) {
+				cd_error = 1;
+				rlen = 0;
+				break;
+			}
+			uint32_t end = 0;
+			for (int i = 0; i < drv->track_cnt; i++) {
+				uint32_t e = drv->track[i].start + drv->track[i].length;
+				if (e > end) end = e;
+			}
+			uint32_t size = end - 1;
+			reply[0] = (uint8_t)(size >> 16);
+			reply[1] = (uint8_t)(size >>  8);
+			reply[2] = (uint8_t)(size      );
+			reply[3] = (uint8_t)(cd_sectorsize >> 8);
+			reply[4] = (uint8_t)(cd_sectorsize     );
+			rlen = 5;
+			break;
+		}
+
+		case 0x87: rlen = cmd_subq(cmd_buf, reply); break;
+
+		case 0x88:
+			memset(reply, 0, 14);
+			rlen = 14;
+			break;
+
+		case 0x89: {
+			int n = cmd_info(reply);
+			rlen = (n > 0) ? n : 0;
+			break;
+		}
+
+		case 0x8a: {
+			int n = cmd_read_toc(cmd_buf, reply);
+			rlen = (n > 0) ? n : 0;
+			break;
+		}
+
+		case 0x8b:
+			cd_paused = (cmd_buf[1] == 0x00) ? 1 : 0;
+			if (cdtv_play_lba_next >= 0)
+				cd_audio_status = cd_paused ? 0x12 : 0x11;
+			cdtv_dbg("PAUSE/RESUME cmd1=%02x → paused=%d", cmd_buf[1], cd_paused);
+			cd_finished = 1;
+			rlen = 0;
+			break;
+
+		case 0xa2:
+			memset(reply, 0, 4);
+			rlen = 4;
+			break;
+
+		case 0xa3:
+			cd_finished = 1;
+			rlen = 0;
+			break;
+
+		default:
+			cdtv_dbg("unknown opcode %02x", op);
+			cd_error = 1;
+			rlen = 0;
+			break;
+	}
+
+	if (rlen > 0) cdtv_push_reply(reply, rlen);
+
+	cmd_idx  = 0;
+	cmd_need = 0;
+}
+
+void cdtv_cd_set_cd_path(const char *path)
+{
+	if (!path) path = "";
+	strncpy(cd_path_active, path, sizeof(cd_path_active) - 1);
+	cd_path_active[sizeof(cd_path_active) - 1] = 0;
+
+	bool has_path = (path[0] != 0);
+	cd_media   = has_path ? 1 : 0;
+	cd_isready = 0;
+	cd_motor   = 0;
+	cd_playing = 0;
+	cd_paused  = 0;
+	cd_audio_status = 0x15;
+	cdtv_last_lba   = 0;
+	cdtv_play_lba_next = -1;
+	cdtv_play_lba_end  = -1;
+	cdtv_play_drv      = NULL;
+	cd_finished = has_path ? 1 : 0;
+
+	stch_retries = has_path ? STCH_RETRY_BUDGET : 0;
+	stch_next_ms = GetTimer(0);
+
+	cdtv_dbg("set_cd_path: %s", has_path ? path : "(empty)");
+}
+
+void cdtv_cd_init(void)
+{
+	cmd_idx       = 0;
+	cmd_need      = 0;
+	cd_motor      = 0;
+	cd_media      = (cd_path_active[0] != 0) ? 1 : 0;
+	cd_isready    = 0;
+	cd_playing    = 0;
+	cd_paused     = 0;
+	cd_audio_status = 0x15;
+	cdtv_last_lba   = 0;
+	cdtv_play_lba_next = -1;
+	cdtv_play_lba_end  = -1;
+	cdtv_play_drv      = NULL;
+	cd_finished   = cd_media ? 1 : 0;
+	cd_error      = 0;
+	cd_sectorsize = 2048;
+	if (cd_media) {
+		stch_retries = STCH_RETRY_BUDGET;
+		stch_next_ms = GetTimer(0);
+	}
+	cdtv_dbg("init media=%d isready=%d stch_retries=%d", cd_media, cd_isready, stch_retries);
+}
+
+void cdtv_cd_poll(void)
+{
+	if (!cdtv_active()) return;
+
+	if (stch_retries > 0 && CheckTimer(stch_next_ms)) {
+		cdtv_inject_stch();
+		stch_retries--;
+		stch_next_ms = GetTimer(stch_wait_ack ? STCH_PLAYEND_PERIOD_MS
+		                                      : STCH_RETRY_PERIOD_MS);
+	}
+
+	cdtv_cdda_pump();
+
+	if (stch_wait_ack && cdtv_stch_acked()) {
+		stch_wait_ack = false;
+		stch_retries  = 0;
+		cdtv_dbg("STCH play-end ACKed — retry stopped");
+	}
+
+	for (int guard = 0; guard < 32; guard++) {
+		uint16_t status = cdtv_read_status();
+		if (!(status & CDTV_STATUS_REQ)) break;
+
+		uint8_t b = cdtv_drain_byte();
+
+		if (cmd_idx == 0) {
+			cmd_need = cr511_command_length(b);
+			if (cmd_need < 0) {
+				cdtv_dbg("drop unknown opcode %02x", b);
+				cmd_idx = 0;
+				cmd_need = 0;
+				continue;
+			}
+		}
+
+		if (cmd_idx < CDTV_CMD_MAX) {
+			cmd_buf[cmd_idx++] = b;
+		}
+
+		if (cmd_idx >= cmd_need) {
+			cdtv_dispatch();
+		}
+	}
+}

--- a/support/minimig/cdtv_cd.h
+++ b/support/minimig/cdtv_cd.h
@@ -1,0 +1,9 @@
+#ifndef CDTV_CD_H
+#define CDTV_CD_H
+
+void cdtv_cd_init(void);
+void cdtv_cd_poll(void);
+
+void cdtv_cd_set_cd_path(const char *path);
+
+#endif

--- a/support/minimig/minimig_boot.cpp
+++ b/support/minimig/minimig_boot.cpp
@@ -12,6 +12,8 @@
 #include "../../file_io.h"
 #include "minimig_config.h"
 #include "minimig_fdd.h"
+#include "akiko_cd32.h"
+#include "cdtv_cd.h"
 #include "../../cfg.h"
 
 static uint8_t buffer[1024];
@@ -423,6 +425,9 @@ void BootInit()
 
 	minimig_config.kickstart[0] = 0;
 	minimig_cfg_load(0);
+
+	akiko_cd32_init();
+	cdtv_cd_init();
 }
 
 void BootPrintEx(const char * str)

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -18,6 +18,9 @@
 #include "minimig_config.h"
 #include "minimig_share.h"
 #include "minimig_a2065.h"
+#include "akiko_cd32.h"
+#include "cdtv_cd.h"
+#include <unistd.h>
 
 const char *config_memory_chip_msg[] = { "512K", "1M",   "1.5M", "2M" };
 const char *config_memory_slow_msg[] = { "none", "512K", "1M",   "1.5M" };
@@ -93,6 +96,86 @@ static void SendFileV2(fileTYPE* file, unsigned char* key, int keysize, int addr
 	printf("]\n");
 }
 
+
+const char* minimig_get_extrom()
+{
+	const size_t cap = sizeof(minimig_config.kickstart);
+	size_t kicklen = strnlen(minimig_config.kickstart, cap);
+	if (kicklen + 1 >= cap) return "";
+	return &minimig_config.kickstart[kicklen + 1];
+}
+
+static void SendBufferV2(const uint8_t *buf, int address, int size_bytes)
+{
+	int sectors = size_bytes / 512;
+	printf("Upload %dkB -> 0x%08x [", size_bytes >> 10, address);
+	for (int i = 0; i < sectors; i++)
+	{
+		if (!(i & 31)) printf("*");
+		EnableIO();
+		unsigned int adr = address + i * 512;
+		spi8(UIO_MM2_WR);
+		spi8(adr & 0xff); adr >>= 8;
+		spi8(adr & 0xff); adr >>= 8;
+		spi8(adr & 0xff); adr >>= 8;
+		spi8(adr & 0xff); adr >>= 8;
+		const uint8_t *p = buf + i * 512;
+		for (int j = 0; j < 512; j += 4)
+		{
+			spi8(p[j + 0]);
+			spi8(p[j + 1]);
+			spi8(p[j + 2]);
+			spi8(p[j + 3]);
+		}
+		DisableIO();
+	}
+	printf("]\n");
+}
+
+static bool LoadRomSlot(const char *path, uint8_t *dst512k)
+{
+	fileTYPE file = {};
+	if (!FileOpen(&file, path)) {
+		printf("Ext-ROM open failed: %s\n", path);
+		return false;
+	}
+	int sz = file.size;
+	if (sz == 0x80000) {
+		FileReadAdv(&file, dst512k, 0x80000);
+	} else if (sz == 0x40000) {
+		FileReadAdv(&file, dst512k, 0x40000);
+		memcpy(dst512k + 0x40000, dst512k, 0x40000);
+	} else {
+		printf("Unsupported ROM size %d for slot upload\n", sz);
+		FileClose(&file);
+		return false;
+	}
+	FileClose(&file);
+	return true;
+}
+
+static char UploadKickstartWithExtRom(const char *kick_path, const char *extrom_path)
+{
+	BootPrint("Loading Kickstart + Ext.ROM:");
+	BootPrint(kick_path);
+	BootPrint(extrom_path);
+
+	static uint8_t img[0x100000];
+	memset(img, 0, sizeof(img));
+
+	if (!LoadRomSlot(extrom_path, img)) return 0;
+	if (!LoadRomSlot(kick_path,   img + 0x80000)) return 0;
+
+	EnableIO();
+	spi8(UIO_MM2_WR);
+	for (int i = 0; i < 8; i++) spi8(0);
+	for (int i = 0; i < 4; i++) spi8(1);
+	DisableIO();
+
+	SendBufferV2(img,           0xe00000, 0x80000);
+	SendBufferV2(img + 0x80000, 0xf80000, 0x80000);
+	return 1;
+}
 
 static char UploadKickstart(char *name)
 {
@@ -378,7 +461,13 @@ static void ApplyConfiguration(char reloadkickstart)
 		printf("Reloading kickstart ...\n");
 		rstval |= (SPI_RST_CPU | SPI_CPU_HLT);
 		spi_uio_cmd8(UIO_MM2_RST, rstval);
-		if (!UploadKickstart(minimig_config.kickstart))
+		const char *extrom = minimig_get_extrom();
+		bool uploaded = false;
+		if (extrom[0])
+		{
+			uploaded = UploadKickstartWithExtRom(minimig_config.kickstart, extrom);
+		}
+		if (!uploaded && !UploadKickstart(minimig_config.kickstart))
 		{
 			snprintf(minimig_config.kickstart, sizeof(minimig_config.kickstart) - 1, "%s/%s", HomeDir(), "KICK.ROM");
 			if (!UploadKickstart(minimig_config.kickstart))
@@ -534,6 +623,8 @@ void minimig_reset()
 	user_io_rtc_reset();
 	minimig_share_reset();
 	a2065_start();
+	akiko_cd32_init();
+	cdtv_cd_init();
 }
 
 void minimig_set_kickstart(char *name)
@@ -541,7 +632,21 @@ void minimig_set_kickstart(char *name)
 	uint len = strlen(name);
 	if (len > (sizeof(minimig_config.kickstart) - 1)) len = sizeof(minimig_config.kickstart) - 1;
 	memcpy(minimig_config.kickstart, name, len);
-	minimig_config.kickstart[len] = 0;
+	memset(minimig_config.kickstart + len, 0, sizeof(minimig_config.kickstart) - len);
+	force_reload_kickstart = 1;
+}
+
+void minimig_set_extrom(char *name)
+{
+	const size_t cap = sizeof(minimig_config.kickstart);
+	size_t kicklen = strnlen(minimig_config.kickstart, cap);
+	if (kicklen + 1 >= cap) return;
+	size_t off = kicklen + 1;
+	size_t room = cap - off - 1;
+	size_t nlen = strlen(name);
+	if (nlen > room) nlen = room;
+	memcpy(minimig_config.kickstart + off, name, nlen);
+	memset(minimig_config.kickstart + off + nlen, 0, cap - off - nlen);
 	force_reload_kickstart = 1;
 }
 
@@ -723,7 +828,7 @@ void minimig_ConfigCPU(unsigned char cpu)
 
 void minimig_ConfigChipset(unsigned char chipset)
 {
-	spi_uio_cmd8(UIO_MM2_CHIP, chipset & 0x1f);
+	spi_uio_cmd8(UIO_MM2_CHIP, chipset & 0x3f);
 }
 
 void minimig_ConfigFloppy(unsigned char drives, unsigned char speed)

--- a/support/minimig/minimig_config.h
+++ b/support/minimig/minimig_config.h
@@ -9,6 +9,7 @@
 #define CONFIG_A1000     4
 #define CONFIG_ECS       8
 #define CONFIG_AGA       16
+#define CONFIG_CDTV      32
 
 #define CONFIG_FLOPPY1X  0
 #define CONFIG_FLOPPY2X  1
@@ -67,6 +68,8 @@ const char* minimig_get_cfg_info(int num, int label);
 
 void minimig_reset();
 void minimig_set_kickstart(char *name);
+void minimig_set_extrom(char *name);
+const char* minimig_get_extrom();
 
 void minimig_set_adjust(char n);
 char minimig_get_adjust();

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -34,6 +34,8 @@
 #include "shmem.h"
 #include "ide.h"
 #include "ide_cdrom.h"
+#include "support/minimig/akiko_cd32.h"
+#include "support/minimig/cdtv_cd.h"
 #ifdef PROFILING
 #include "profiling.h"
 #endif
@@ -3163,6 +3165,8 @@ void user_io_poll()
 		ide_io(1, (sd_req >> 3) & 7);
 		if (sd_req & 0x0100) ide_cdda_send_sector();
 		UpdateDriveStatus();
+		akiko_cd32_poll();
+		cdtv_cd_poll();
 
 		kbd_fifo_poll();
 
@@ -3187,7 +3191,7 @@ void user_io_poll()
 	{
 		x86_poll(0);
 	}
-	else if ((core_type == CORE_TYPE_8BIT) && !is_menu() && !is_minimig())
+	else if ((core_type == CORE_TYPE_8BIT) && !is_menu())
 	{
 		if (is_st()) tos_poll();
 		if (is_snes() || is_sgb()) snes_poll();

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -270,7 +270,8 @@ char is_neogeo_cd() {
 static int is_minimig_type = 0;
 char is_minimig()
 {
-	if (!is_minimig_type) is_minimig_type = strcasecmp(orig_name, "minimig") ? 2 : 1;
+	if (!is_minimig_type) is_minimig_type =
+		(!strcasecmp(orig_name, "minimig") || !strcasecmp(orig_name, "minimigcd")) ? 1 : 2;
 	return (is_minimig_type == 1);
 }
 


### PR DESCRIPTION
Userspace support for the CD32's Akiko chip and the CDTV's CR-511/DMAC/TPI
CD-ROM subsystem, driven natively from the standard Minimig core — no
IDE-CD workaround, no launcher shim, no separate core identity. The CD
hardware lives in the core; this PR is the host half that feeds it.

**Depends on #1257.** This PR is stacked on top of that one (generic
`ide_cdrom` CHD/CUE track-geometry and CDDA-offset fixes, needed to mount
CD32/CDTV discs correctly) and is opened against `master` for visibility,
so the diff currently includes #1257's commits too — it'll narrow to just
this PR's changes once #1257 merges. Both are Draft; not requesting review
on either yet.

### Unconditional, not a separate core

Earlier drafts of this shipped as a distinctly-named core ("MinimigCD") with
its own CONF_STR and a stripped-down console-style OSD, gated behind an
`is_minimigcd()` check. That's gone — CD32/CDTV support is now just part of
plain Minimig. `is_minimig()` still also matches the string "minimigcd" (so
an older-CONF_STR bitstream keeps working against this host build), but
there's no separate identity or gate left in the driver code: the CD
controllers, boot init, and reset path are unconditional for any Minimig
session.

To keep a stock floppy-only session from paying for hardware it doesn't
have, the two poll loops self-gate on the actual machine configuration
instead:

| Poll | Gate |
|---|---|
| `akiko_cd32_poll()` (CD32/Akiko) | 68020 CPU + AGA chipset + hardfile[0] set to CD |
| `cdtv_cd_poll()` (CDTV) | `CONFIG_CDTV` chipset bit |

A plain Minimig floppy session satisfies neither, so it does zero extra SPI
traffic to either bridge — the same practical effect `is_minimigcd()` used
to have, just keyed on actual session state instead of a separate identity
flag.

### OSD

The Chipset and Drives pages now carry the CD32/CDTV-relevant rows directly,
in the shared menu everyone already uses — no separate reskinned menu:

- Chipset page: a CDTV entry alongside the existing machine choices, and an
  Ext.ROM row (before HRTmon) for the extended ROM image CD32/CDTV boot
  from.
- Drives page: a 3-state I/O controller toggle (OFF -> IDE -> CDTV -> OFF,
  mutually exclusive since real CDTV has no IDE), with CD0/HD0-2 (SCSI)
  slot labels when CDTV mode is selected.

**Known gap, disclosed for review:** there's no capability handshake yet
between these rows and the RTL. An older core without the native CDTV/Akiko
bridge just ignores the CDTV chipset bit and Ext.ROM upload — the options
are visible but functionally inert on old bitstreams, rather than hidden.
Flagging this for maintainer input on how they'd want it surfaced (e.g. a
version/feature probe at a known UIO address) before merge.

### Notes for review

- **Ext-ROM path storage.** CD32 and CDTV both boot from an extended ROM, so
  the driver uploads a composite 1 MB image (ext at `$e00000`, Kickstart at
  `$f80000`; 256 KB images mirrored). The ext-ROM path is stored inside
  `kickstart[]` past its terminator rather than as a new struct member —
  `kickstart[]` sits at a fixed offset, and a sibling field would shift
  every later field and invalidate existing `.cfg` files.
- **`CONFIG_CDTV` is chipset bit 5**, stored in the existing chipset byte,
  so the on-disk config layout is unchanged.
- MGL `<file path="">` resolution now follows the documented rule: an
  absolute path is used verbatim, `"../"` resolves from the storage root,
  anything else resolves against the home directory. Absolute paths
  previously had the home directory prepended and failed to mount.

### Testing

Verified on hardware (DE10-Nano) against an earlier RTL revision: CD32
discs boot to gameplay, CDTV discs boot to gameplay, CD audio plays and
loops, and the CD32 NVRAM persists.

Since then the RTL line was bisected end-to-end after an apparent boot
regression; the regression turned out not to exist (5/5 cold boots on the
current RTL tip show correct, repeatable video, including reaching the CD32
Language Select screen via live gamepad input), and a defensive watchdog
was added to the A2065 wait-state logic while investigating. This driver
build was freshly rebuilt from current `HEAD` and deployed as the device's
actual default `MiSTer` binary (not a sidecar) against that verified RTL, so
every other core is exercised by it too, not just Minimig — no regressions
observed. A fresh full CD32/CDTV gameplay hardware pass (discs, audio, NVRAM
persistence end-to-end) against this exact build is queued next.

### Known open defects, disclosed up front

- **Jim Power** (CD32) freezes at the intro logo fade-in. CD path verified
  clean; a CPU/chipset issue, not a CD one.
- **Defender of the Crown** (CDTV) hangs moving from the map to character
  select. Traced to a bus/timing race, still open.
- **Universe** with D-Cache OFF shows a black screen.

None of these affect a stock Minimig session.
