### PR TITLE
Detect PCXT-EGA variant in is_pcxt

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -302,7 +302,8 @@ char is_pcxt()
 	{
 		if (!strcasecmp(orig_name, "PCXT") ||
 		    !strcasecmp(orig_name, "Tandy1000") ||
-			!strcasecmp(orig_name, "PCjr")
+			!strcasecmp(orig_name, "PCjr") ||
+			!strcasecmp(orig_name, "PCXT-EGA")
 		   )
 			is_pcxt_type = 1;
 		else


### PR DESCRIPTION
Expand is_pcxt() to also recognize PCXT-EGA as a PCXT-class system, same as the existing Tandy1000 and PCjr variants.

I will soon release a new version of the PCXT core focused on EGA and partially on VGA 13h. This is necessary for resource reasons, just as was done with the Tandy 1000 and PCjr.

https://github.com/spark2k06/PCXT_MiSTer/tree/ega-test

Without this change, access to the floppy drive would not work.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3cfe4318-5e96-4513-94c1-1df4b57b698b" />
