### PR TITLE
Fix error detection in file writes

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -339,8 +339,19 @@ static int isPathRegularFile(const char *path, int use_zip = 1)
 	return 0;
 }
 
-void FileClose(fileTYPE *file)
+static int file_write_failed = 0;
+
+int FileWriteFailed()
 {
+	int r = file_write_failed;
+	file_write_failed = 0;
+	return r;
+}
+
+int FileClose(fileTYPE *file)
+{
+	int err = 0;
+
 	if (file->zip)
 	{
 		if (file->zip->iter)
@@ -355,7 +366,12 @@ void FileClose(fileTYPE *file)
 	if (file->filp)
 	{
 		//printf("closing %p\n", file->filp);
-		fclose(file->filp);
+		if (fclose(file->filp))
+		{
+			err = -1;
+			file_write_failed = 1;
+			printf("FileClose error on %s (%s).\n", file->name, strerror(errno));
+		}
 		if (file->type == 1)
 		{
 			if (file->name[0] == '/')
@@ -369,6 +385,8 @@ void FileClose(fileTYPE *file)
 	file->zip = nullptr;
 	file->filp = nullptr;
 	file->size = 0;
+
+	return err;
 }
 
 static int zip_search_by_crc(mz_zip_archive *zipArchive, uint32_t crc32)
@@ -729,11 +747,11 @@ int FileWriteAdv(fileTYPE *file, void *pBuffer, int length, int failres)
 	if (file->filp)
 	{
 		ret = fwrite(pBuffer, 1, length, file->filp);
-		fflush(file->filp);
 
-		if (ret < 0)
+		if (ret != length || fflush(file->filp))
 		{
-			printf("FileWriteAdv error(%d).\n", ret);
+			printf("FileWriteAdv error: wrote %d of %d bytes (%s).\n", ret, length, strerror(errno));
+			file_write_failed = 1;
 			return failres;
 		}
 

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -339,15 +339,6 @@ static int isPathRegularFile(const char *path, int use_zip = 1)
 	return 0;
 }
 
-static int file_write_failed = 0;
-
-int FileWriteFailed()
-{
-	int r = file_write_failed;
-	file_write_failed = 0;
-	return r;
-}
-
 int FileClose(fileTYPE *file)
 {
 	int err = 0;
@@ -369,7 +360,6 @@ int FileClose(fileTYPE *file)
 		if (fclose(file->filp))
 		{
 			err = -1;
-			file_write_failed = 1;
 			printf("FileClose error on %s (%s).\n", file->name, strerror(errno));
 		}
 		if (file->type == 1)
@@ -751,7 +741,6 @@ int FileWriteAdv(fileTYPE *file, void *pBuffer, int length, int failres)
 		if (ret != length || fflush(file->filp))
 		{
 			printf("FileWriteAdv error: wrote %d of %d bytes (%s).\n", ret, length, strerror(errno));
-			file_write_failed = 1;
 			return failres;
 		}
 

--- a/file_io.h
+++ b/file_io.h
@@ -86,7 +86,6 @@ int  FileOpenZip(fileTYPE *file, const char *name, uint32_t crc32);
 int  FileOpenEx(fileTYPE *file, const char *name, int mode, char mute = 0, int use_zip = 1);
 int  FileOpen(fileTYPE *file, const char *name, char mute = 0);
 int FileClose(fileTYPE *file);
-int FileWriteFailed();
 
 __off64_t FileGetSize(fileTYPE *file);
 

--- a/file_io.h
+++ b/file_io.h
@@ -85,7 +85,8 @@ int  isUSBMounted();
 int  FileOpenZip(fileTYPE *file, const char *name, uint32_t crc32);
 int  FileOpenEx(fileTYPE *file, const char *name, int mode, char mute = 0, int use_zip = 1);
 int  FileOpen(fileTYPE *file, const char *name, char mute = 0);
-void FileClose(fileTYPE *file);
+int FileClose(fileTYPE *file);
+int FileWriteFailed();
 
 __off64_t FileGetSize(fileTYPE *file);
 

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3137,7 +3137,7 @@ void user_io_poll()
 		PROFILE_FUNCTION();
 	#endif
 
-	if (FileWriteFailed()) Info("ERROR: File write failed!\nCheck storage", 6000);
+	if (!menu_present() && FileWriteFailed()) Info("ERROR: File write failed!\nCheck storage", 6000);
 
 	// every frame, check if a screenshot has been requested.
 	// this is reduce risk of screenshot occurring while the scaler

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3137,8 +3137,6 @@ void user_io_poll()
 		PROFILE_FUNCTION();
 	#endif
 
-	if (!menu_present() && FileWriteFailed()) Info("ERROR: File write failed!\nCheck storage", 6000);
-
 	// every frame, check if a screenshot has been requested.
 	// this is reduce risk of screenshot occurring while the scaler
 	// is being updated and getting a corrupted image.

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3137,6 +3137,8 @@ void user_io_poll()
 		PROFILE_FUNCTION();
 	#endif
 
+	if (FileWriteFailed()) Info("ERROR: File write failed!\nCheck storage", 6000);
+
 	// every frame, check if a screenshot has been requested.
 	// this is reduce risk of screenshot occurring while the scaler
 	// is being updated and getting a corrupted image.


### PR DESCRIPTION
I was triggered by many seeking help in what seems to be storage issues. Looking into how main handles this, the check in `FileWriteAdv` has bugs and doesn't work, and error checking on closing a file was missing. Even in debug console there is very little to diagnose storage issues. File write errors are also serious enough to notify the user immediately, I don't think a debug message is sufficient.

This PR fixes the bug in error checks in `FileWriteAdv`, adds error checking in `FileClose`, exposes the flag `FileWriteFailed` that gets polled at the same time as the check for screenshots (seems appropriate) to also display an osd error if that flag was set.

I hope that this error will help the community in root causing their storage issues.