### PR TITLE
minimig: dedicated CD32/CDTV drive slots, with back-compat for existing configs

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -83,6 +83,28 @@ uint8_t ide_buf[ide_io_max_size * 512];
 
 ide_config ide_inst[2] = {};
 
+drive_t cd32_drive = {};
+drive_t cdtv_drive = {};
+
+int cd_drive_open(int slot, const char *filename)
+{
+	static fileTYPE cd_drive_file[2] = {};
+
+	drive_t *drv = slot ? &cdtv_drive : &cd32_drive;
+	drv->cd = 1;
+
+	const char *res = cd_drive_parse(drv, slot, filename);
+
+	int present = res ? ide_img_mount(&cd_drive_file[slot], res, 0) : 0;
+	drv->f = present ? &cd_drive_file[slot] : NULL;
+
+	const char *full = present ? res : "";
+	if (slot) cdtv_cd_set_cd_path(full);
+	else akiko_cd32_set_cd_path(full);
+
+	return present;
+}
+
 uint16_t ide_check()
 {
 	uint16_t res;
@@ -1119,11 +1141,8 @@ int ide_open(uint8_t unit, const char* filename)
 	static fileTYPE hdd_file[4] = {};
 	chs_t chs = {};
 
-	bool cdtv_cd_slot = (minimig_config.chipset & CONFIG_CDTV)
-	                 && minimig_config.hardfile[unit].cfg == 2;
 	if (!is_minimig()
-	    || ((minimig_config.ide_cfg & 1) && minimig_config.hardfile[unit].cfg)
-	    || cdtv_cd_slot)
+	    || ((minimig_config.ide_cfg & 1) && minimig_config.hardfile[unit].cfg))
 	{
 		printf("\nChecking HDD %d\n", unit);
 		if (filename[0] && FileOpenEx(&hdd_file[unit], filename, FileCanWrite(filename) ? O_RDWR : O_RDONLY))
@@ -1163,8 +1182,6 @@ int ide_open(uint8_t unit, const char* filename)
 		int port = (unit >> 1) & 1;
 		int drv  = unit & 1;
 		cdrom_close_chd(&ide_inst[port].drive[drv]);
-		if (unit == 0) akiko_cd32_set_cd_path("");
-		if (unit == 0) cdtv_cd_set_cd_path("");
 	}
 	ide_img_set(unit, 0, 0);
 	FileClose(&hdd_file[unit]);

--- a/ide.h
+++ b/ide.h
@@ -140,6 +140,12 @@ extern ide_config ide_inst[2];
 extern const uint32_t ide_io_max_size;
 extern uint8_t ide_buf[];
 
+extern drive_t cd32_drive;
+extern drive_t cdtv_drive;
+
+// slot: 0 = cd32_drive, 1 = cdtv_drive
+int cd_drive_open(int slot, const char *filename);
+
 void ide_print_regs(regs_t *regs);
 void ide_get_regs(ide_config *ide);
 void ide_set_regs(ide_config *ide);

--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1796,8 +1796,6 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 		ide_inst[num].drive[drv].paused = 0;
 		ide_inst[num].drive[drv].play_start_lba = 0;
 		ide_inst[num].drive[drv].play_end_lba = 0;
-		akiko_cd32_set_cd_path(full);
-		cdtv_cd_set_cd_path(full);
 		return full;
 	}
 
@@ -1824,14 +1822,64 @@ const char* cdrom_parse(uint32_t num, const char *filename)
 		if (!res) res = load_iso_file(&ide_inst[num].drive[drv], path);
 	}
 
-	akiko_cd32_set_cd_path((path && res) ? path : "");
-	cdtv_cd_set_cd_path((path && res) ? path : "");
-
 	if (filename && filename[0] && res) {
 		strncpy(last_path[num][drv], cmp_filename, sizeof(last_path[0][0]) - 1);
 		last_path[num][drv][sizeof(last_path[0][0]) - 1] = '\0';
 	} else {
 		last_path[num][drv][0] = '\0';
+	}
+
+	return res;
+}
+
+const char* cd_drive_parse(drive_t *drv, int slot, const char *filename)
+{
+	const char *res = 0;
+
+	static char last_path[2][1024] = {};
+	const char *cmp_filename = filename ? filename : "";
+	bool same_path = filename && filename[0]
+	                 && !strcmp(last_path[slot], cmp_filename)
+	                 && drv->chd_f != NULL;
+
+	if (same_path) {
+		const char *full = getFullPath(filename);
+		drv->mcr_flag = true;
+		drv->playing = 0;
+		drv->paused = 0;
+		drv->play_start_lba = 0;
+		drv->play_end_lba = 0;
+		return full;
+	}
+
+	//always close files and reset state. empty filename == unmounted cd from OSD
+	cdrom_close_chd(drv);
+	for (uint8_t i = 0; i < sizeof(drv->track) / sizeof(track_t); i++)
+	{
+		if (drv->track[i].f.opened())
+		{
+			FileClose(&drv->track[i].f);
+		}
+	}
+	drv->mcr_flag = true;
+	drv->playing = 0;
+	drv->paused = 0;
+	drv->play_start_lba = 0;
+	drv->play_end_lba = 0;
+	const char *path = NULL;
+	if (strlen(filename))
+	{
+		path = getFullPath(filename);
+		res = load_chd_file(drv, path);
+		if (!res) res = load_cue_file(drv, path);
+		if (!res) res = load_iso_file(drv, path);
+	}
+
+	if (filename && filename[0] && res) {
+		strncpy(last_path[slot], cmp_filename, sizeof(last_path[0]) - 1);
+		last_path[slot][sizeof(last_path[0]) - 1] = '\0';
+	} else {
+		last_path[slot][0] = '\0';
 	}
 
 	return res;

--- a/ide_cdrom.h
+++ b/ide_cdrom.h
@@ -13,4 +13,7 @@ int cdrom_read_raw_sector(struct drive_t *drive, uint32_t lba, uint8_t *buf);
 const char* cdrom_parse(uint32_t num, const char *filename);
 void cdrom_close_chd(drive_t *drv);
 
+// slot: 0 = cd32_drive, 1 = cdtv_drive
+const char* cd_drive_parse(drive_t *drv, int slot, const char *filename);
+
 #endif

--- a/menu.cpp
+++ b/menu.cpp
@@ -6626,17 +6626,18 @@ void HandleUI(void)
 			strcat(s, cd32_on ? "CD " : "Disabled");
 			OsdWrite(m++, s, menusub == 0, 0);
 
-			strcpy(s, " CD32 CD           : ");
+			OsdWrite(m++, " CD32 CD:", cd32_on ? (menusub == 1) : 0, !cd32_on);
 			if (minimig_config.cd32_drive.filename[0])
 			{
+				strcpy(s, "                                ");
 				char *path = HomeDir();
 				int len = strlen(path);
 				char *name = minimig_config.cd32_drive.filename;
 				if (!strncasecmp(name, path, len)) name += len + 1;
-				strncat(s, name, 25);
+				strncpy(&s[3], name, 25);
 			}
-			else strcat(s, "** not selected **");
-			OsdWrite(m++, s, cd32_on ? (menusub == 1) : 0, !cd32_on);
+			else strcpy(s, "   ** not selected **");
+			OsdWrite(m++, s, 0, !cd32_on);
 
 			OsdWrite(m++);
 
@@ -6648,17 +6649,18 @@ void HandleUI(void)
 			strcat(s, cdtv_cd_on ? "CD " : "Disabled");
 			OsdWrite(m++, s, menusub == 3, 0);
 
-			strcpy(s, " CDTV CD           : ");
+			OsdWrite(m++, " CDTV CD:", cdtv_cd_on ? (menusub == 4) : 0, !cdtv_cd_on);
 			if (minimig_config.cdtv_drive.filename[0])
 			{
+				strcpy(s, "                                ");
 				char *path = HomeDir();
 				int len = strlen(path);
 				char *name = minimig_config.cdtv_drive.filename;
 				if (!strncasecmp(name, path, len)) name += len + 1;
-				strncat(s, name, 25);
+				strncpy(&s[3], name, 25);
 			}
-			else strcat(s, "** not selected **");
-			OsdWrite(m++, s, cdtv_cd_on ? (menusub == 4) : 0, !cdtv_cd_on);
+			else strcpy(s, "   ** not selected **");
+			OsdWrite(m++, s, 0, !cdtv_cd_on);
 		}
 
 		for (int i = m; i < OsdGetSize() - 1; i++) OsdWrite(i, "", 0, 0);

--- a/menu.cpp
+++ b/menu.cpp
@@ -178,6 +178,10 @@ enum MENU
 	MENU_MINIMIG_DISK1,
 	MENU_MINIMIG_DISK2,
 	MENU_MINIMIG_HDFFILE_SELECTED,
+	MENU_MINIMIG_CD32CDTV1,
+	MENU_MINIMIG_CD32CDTV2,
+	MENU_MINIMIG_CD32FILE_SELECTED,
+	MENU_MINIMIG_CDTVFILE_SELECTED,
 	MENU_MINIMIG_ADFFILE_SELECTED,
 	MENU_MINIMIG_ROMFILE_SELECTED,
 	MENU_MINIMIG_EXTROMFILE_SELECTED,
@@ -342,6 +346,8 @@ static char SelectedLabel[1024] = {};
 static char Selected_F[16][1024] = {};
 static char Selected_S[16][1024] = {};
 static char Selected_tmp[1024] = {};
+static char Selected_CD32[1024] = {};
+static char Selected_CDTV[1024] = {};
 
 void StoreIdx_F(int idx, const char *path)
 {
@@ -6457,47 +6463,29 @@ void HandleUI(void)
 		m = 0;
 		parentstate = menustate;
 		{
-			int cdtv_on = (minimig_config.chipset & CONFIG_CDTV) ? 1 : 0;
 			int ide_on  = (minimig_config.ide_cfg & 1) ? 1 : 0;
-			int io_on   = ide_on || cdtv_on;
 
-			menumask = 0xC01;
+			menumask = 0x1C01;
 			if (ide_on)  menumask |= 0x002;
-			if (io_on)   menumask |= 0x154;
+			if (ide_on)  menumask |= 0x154;
 			OsdWrite(m++, "", 0, 0);
 
-			const char *iomode = cdtv_on ? "CDTV" : (ide_on ? "IDE " : "OFF ");
 			strcpy(s, " I/O controller    : ");
-			strcat(s, iomode);
+			strcat(s, ide_on ? "IDE " : "OFF ");
 			OsdWrite(m++, s, menusub == 0, 0);
 
 			strcpy(s, " Fast-IDE (68020)  : ");
-			if (cdtv_on) strcat(s, "N/A");
-			else         strcat(s, (minimig_config.ide_cfg & 0x20) ? "Off" : "On ");
-			OsdWrite(m++, s, menusub == 1, cdtv_on || !ide_on || !(minimig_config.cpu & 2));
+			strcat(s, (minimig_config.ide_cfg & 0x20) ? "Off" : "On ");
+			OsdWrite(m++, s, menusub == 1, !ide_on || !(minimig_config.cpu & 2));
 			if (!(minimig_config.cpu & 2)) menumask &= ~2;
-			OsdWrite(m++);
 
 			uint n = 2, t = 8;
 			for (uint i = 0; i < 4; i++)
 			{
-				if (cdtv_on)
-				{
-					static const char *cdtv_slot_label[4] = {
-						" CD0           : ",
-						" HD0  (SCSI)   : ",
-						" HD1  (SCSI)   : ",
-						" HD2  (SCSI)   : "
-					};
-					strcpy(s, cdtv_slot_label[i]);
-				}
-				else
-				{
-					strcpy(s, (i & 2) ? " Sec. " : " Pri. ");
-					strcat(s, (i & 1) ? " Slave: " : "Master: ");
-				}
+				strcpy(s, (i & 2) ? " Sec. " : " Pri. ");
+				strcat(s, (i & 1) ? " Slave: " : "Master: ");
 				strcat(s, (minimig_config.hardfile[i].cfg == 2) ? "Removable/CD" : minimig_config.hardfile[i].cfg ? "Fixed/HDD" : "Disabled");
-				OsdWrite(m++, s, io_on ? (menusub == n++) : 0, !io_on);
+				OsdWrite(m++, s, ide_on ? (menusub == n++) : 0, !ide_on);
 				if (minimig_config.hardfile[i].filename[0])
 				{
 					strcpy(s, "                                ");
@@ -6511,20 +6499,20 @@ void HandleUI(void)
 				{
 					strcpy(s, "   ** not selected **");
 				}
-				enable = io_on && minimig_config.hardfile[i].cfg;
+				enable = ide_on && minimig_config.hardfile[i].cfg;
 				if (enable) menumask |= t;	// Make hardfile selectable
 				OsdWrite(m++, s, menusub == n++, enable == 0);
 				t <<= 2;
-				if(i == 1) OsdWrite(m++);
 			}
+
+			OsdWrite(m++, " CD32 / CDTV drives        \x16", menusub == 10, 0);
 		}
 
-		OsdWrite(m++);
 		sprintf(s, " Floppy Disk Turbo : %s", minimig_config.floppy.speed ? "On" : "Off");
-		OsdWrite(m++, s, menusub == 10, 0);
-		OsdWrite(m++);
+		OsdWrite(m++, s, menusub == 11, 0);
 
-		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 11, 0);
+		for (int i = m; i < OsdGetSize() - 1; i++) OsdWrite(i, "", 0, 0);
+		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 12, 0);
 		menustate = MENU_MINIMIG_DISK2;
 		break;
 
@@ -6537,33 +6525,13 @@ void HandleUI(void)
 			{
 				if (select || minus || plus)
 				{
-					int cur;
-					if (minimig_config.chipset & CONFIG_CDTV)   cur = 2;
-					else if (minimig_config.ide_cfg & 1)        cur = 1;
-					else                                        cur = 0;
-					int next = minus ? ((cur + 2) % 3) : ((cur + 1) % 3);
-					if (next == 0)
-					{
-						minimig_config.ide_cfg &= ~1;
-						minimig_config.chipset &= ~CONFIG_CDTV;
-					}
-					else if (next == 1)
-					{
-						minimig_config.ide_cfg |= 1;
-						minimig_config.chipset &= ~CONFIG_CDTV;
-					}
-					else
-					{
-						minimig_config.ide_cfg &= ~1;
-						minimig_config.chipset |= CONFIG_CDTV;
-					}
-					minimig_ConfigChipset(minimig_config.chipset);
+					minimig_config.ide_cfg ^= 1;
 					menustate = MENU_MINIMIG_DISK1;
 				}
 			}
 			else if (menusub == 1)
 			{
-				if (select && !(minimig_config.chipset & CONFIG_CDTV))
+				if (select)
 				{
 					minimig_config.ide_cfg ^= 0x20;
 					menustate = MENU_MINIMIG_DISK1;
@@ -6604,13 +6572,18 @@ void HandleUI(void)
 					else if (recent_init(500)) menustate = MENU_RECENT1;
 				}
 			}
-			else if (menusub == 10 && select) // return to previous menu
+			else if (menusub == 10 && select)
+			{
+				menusub = 0;
+				menustate = MENU_MINIMIG_CD32CDTV1;
+			}
+			else if (menusub == 11 && select) // return to previous menu
 			{
 				minimig_config.floppy.speed ^= 1;
 				minimig_ConfigFloppy(minimig_config.floppy.drives, minimig_config.floppy.speed);
 				menustate = MENU_MINIMIG_DISK1;
 			}
-			else if (menusub == 11 && select) // return to previous menu
+			else if (menusub == 12 && select) // return to previous menu
 			{
 				menustate = MENU_MINIMIG_MAIN1;
 				menusub = 5;
@@ -6621,10 +6594,157 @@ void HandleUI(void)
 		{
 			menustate = MENU_NONE1;
 		}
+		else if (right)
+		{
+			menustate = MENU_MINIMIG_CD32CDTV1;
+			menusub = 0;
+		}
 		else if (back || left)
 		{
 			menustate = MENU_MINIMIG_MAIN1;
 			menusub = 5;
+		}
+		break;
+
+	case MENU_MINIMIG_CD32CDTV1:
+		helptext_idx = HELPTEXT_HARDFILE;
+		OsdSetTitle("CD32 / CDTV");
+
+		m = 0;
+		parentstate = menustate;
+		{
+			int cd32_on = minimig_config.cd32_drive.cfg ? 1 : 0;
+			int cdtv_on = (minimig_config.chipset & CONFIG_CDTV) ? 1 : 0;
+			int cdtv_cd_on = minimig_config.cdtv_drive.cfg ? 1 : 0;
+
+			menumask = 0x2D;
+			if (cd32_on)   menumask |= 0x02;
+			if (cdtv_cd_on) menumask |= 0x10;
+			OsdWrite(m++, "", 0, 0);
+
+			strcpy(s, " CD32 drive        : ");
+			strcat(s, cd32_on ? "CD " : "Disabled");
+			OsdWrite(m++, s, menusub == 0, 0);
+
+			strcpy(s, " CD32 CD           : ");
+			if (minimig_config.cd32_drive.filename[0])
+			{
+				char *path = HomeDir();
+				int len = strlen(path);
+				char *name = minimig_config.cd32_drive.filename;
+				if (!strncasecmp(name, path, len)) name += len + 1;
+				strncat(s, name, 25);
+			}
+			else strcat(s, "** not selected **");
+			OsdWrite(m++, s, cd32_on ? (menusub == 1) : 0, !cd32_on);
+
+			OsdWrite(m++);
+
+			strcpy(s, " CDTV mode         : ");
+			strcat(s, cdtv_on ? "On " : "Off");
+			OsdWrite(m++, s, menusub == 2, 0);
+
+			strcpy(s, " CDTV drive        : ");
+			strcat(s, cdtv_cd_on ? "CD " : "Disabled");
+			OsdWrite(m++, s, menusub == 3, 0);
+
+			strcpy(s, " CDTV CD           : ");
+			if (minimig_config.cdtv_drive.filename[0])
+			{
+				char *path = HomeDir();
+				int len = strlen(path);
+				char *name = minimig_config.cdtv_drive.filename;
+				if (!strncasecmp(name, path, len)) name += len + 1;
+				strncat(s, name, 25);
+			}
+			else strcat(s, "** not selected **");
+			OsdWrite(m++, s, cdtv_cd_on ? (menusub == 4) : 0, !cdtv_cd_on);
+		}
+
+		for (int i = m; i < OsdGetSize() - 1; i++) OsdWrite(i, "", 0, 0);
+		OsdWrite(OsdGetSize() - 1, STD_BACK, menusub == 5, 0);
+		menustate = MENU_MINIMIG_CD32CDTV2;
+		break;
+
+	case MENU_MINIMIG_CD32CDTV2:
+		saved_menustate = MENU_MINIMIG_CD32CDTV1;
+
+		if (select || recent || minus || plus)
+		{
+			if (menusub == 0)
+			{
+				if (select || minus || plus)
+				{
+					minimig_config.cd32_drive.cfg = minimig_config.cd32_drive.cfg ? 0 : 2;
+					cd_drive_open(0, minimig_config.cd32_drive.cfg ? minimig_config.cd32_drive.filename : "");
+					menustate = MENU_MINIMIG_CD32CDTV1;
+				}
+			}
+			else if (menusub == 1 && minimig_config.cd32_drive.cfg)
+			{
+				if (select || recent)
+				{
+					fs_Options = SCANO_DIR | SCANO_UMOUNT;
+					fs_MenuSelect = MENU_MINIMIG_CD32FILE_SELECTED;
+					fs_MenuCancel = MENU_MINIMIG_CD32CDTV1;
+					strcpy(fs_pFileExt, "ISOCUECHDIMG");
+					if (select)
+					{
+						if (!Selected_CD32[0]) memcpy(Selected_CD32, minimig_config.cd32_drive.filename, sizeof(Selected_CD32));
+						SelectFile(Selected_CD32, fs_pFileExt, fs_Options, fs_MenuSelect, fs_MenuCancel);
+					}
+					else if (recent_init(500)) menustate = MENU_RECENT1;
+				}
+			}
+			else if (menusub == 2)
+			{
+				if (select || minus || plus)
+				{
+					minimig_config.chipset ^= CONFIG_CDTV;
+					minimig_ConfigChipset(minimig_config.chipset);
+					menustate = MENU_MINIMIG_CD32CDTV1;
+				}
+			}
+			else if (menusub == 3)
+			{
+				if (select || minus || plus)
+				{
+					minimig_config.cdtv_drive.cfg = minimig_config.cdtv_drive.cfg ? 0 : 2;
+					cd_drive_open(1, minimig_config.cdtv_drive.cfg ? minimig_config.cdtv_drive.filename : "");
+					menustate = MENU_MINIMIG_CD32CDTV1;
+				}
+			}
+			else if (menusub == 4 && minimig_config.cdtv_drive.cfg)
+			{
+				if (select || recent)
+				{
+					fs_Options = SCANO_DIR | SCANO_UMOUNT;
+					fs_MenuSelect = MENU_MINIMIG_CDTVFILE_SELECTED;
+					fs_MenuCancel = MENU_MINIMIG_CD32CDTV1;
+					strcpy(fs_pFileExt, "ISOCUECHDIMG");
+					if (select)
+					{
+						if (!Selected_CDTV[0]) memcpy(Selected_CDTV, minimig_config.cdtv_drive.filename, sizeof(Selected_CDTV));
+						SelectFile(Selected_CDTV, fs_pFileExt, fs_Options, fs_MenuSelect, fs_MenuCancel);
+					}
+					else if (recent_init(500)) menustate = MENU_RECENT1;
+				}
+			}
+			else if (menusub == 5 && select) // return to previous menu
+			{
+				menustate = MENU_MINIMIG_DISK1;
+				menusub = 10;
+			}
+		}
+
+		if (menu)
+		{
+			menustate = MENU_NONE1;
+		}
+		else if (back || left)
+		{
+			menustate = MENU_MINIMIG_DISK1;
+			menusub = 10;
 		}
 		break;
 
@@ -6644,6 +6764,36 @@ void HandleUI(void)
 			}
 
 			menustate = MENU_MINIMIG_DISK1;
+		}
+		break;
+
+	case MENU_MINIMIG_CD32FILE_SELECTED:
+		{
+			memcpy(Selected_CD32, selPath, sizeof(Selected_CD32));
+			recent_update(SelectedDir, selPath, SelectedLabel, 500);
+			uint len = strlen(selPath);
+			if (len > sizeof(minimig_config.cd32_drive.filename) - 1) len = sizeof(minimig_config.cd32_drive.filename) - 1;
+			if (len) memcpy(minimig_config.cd32_drive.filename, selPath, len);
+			minimig_config.cd32_drive.filename[len] = 0;
+
+			cd_drive_open(0, minimig_config.cd32_drive.filename);
+
+			menustate = MENU_MINIMIG_CD32CDTV1;
+		}
+		break;
+
+	case MENU_MINIMIG_CDTVFILE_SELECTED:
+		{
+			memcpy(Selected_CDTV, selPath, sizeof(Selected_CDTV));
+			recent_update(SelectedDir, selPath, SelectedLabel, 500);
+			uint len = strlen(selPath);
+			if (len > sizeof(minimig_config.cdtv_drive.filename) - 1) len = sizeof(minimig_config.cdtv_drive.filename) - 1;
+			if (len) memcpy(minimig_config.cdtv_drive.filename, selPath, len);
+			minimig_config.cdtv_drive.filename[len] = 0;
+
+			cd_drive_open(1, minimig_config.cdtv_drive.filename);
+
+			menustate = MENU_MINIMIG_CD32CDTV1;
 		}
 		break;
 

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -200,17 +200,25 @@ static inline bool cd32_active(void)
 {
 	return (minimig_config.cpu & 0x03) == 3
 	    && ((minimig_config.chipset >> 2) & 7) == 6
-	    && minimig_config.cd32_drive.cfg == 2;
-}
-
-static bool cd_is_mounted(void)
-{
-	return cd32_drive.cd && (cd32_drive.chd_f || cd32_drive.f);
+	    && (minimig_config.cd32_drive.cfg == 2 || minimig_config.hardfile[0].cfg == 2);
 }
 
 static drive_t *cd_find_drive(void)
 {
-	return cd_is_mounted() ? &cd32_drive : NULL;
+	if (cd32_drive.cd && (cd32_drive.chd_f || cd32_drive.f)) return &cd32_drive;
+
+	for (int p = 0; p < 2; p++) {
+		for (int d = 0; d < 2; d++) {
+			drive_t *drv = &ide_inst[p].drive[d];
+			if (drv->cd && (drv->chd_f || drv->f)) return drv;
+		}
+	}
+	return NULL;
+}
+
+static bool cd_is_mounted(void)
+{
+	return cd_find_drive() != NULL;
 }
 
 static uint16_t akiko_read_status(void)

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -200,33 +200,17 @@ static inline bool cd32_active(void)
 {
 	return (minimig_config.cpu & 0x03) == 3
 	    && ((minimig_config.chipset >> 2) & 7) == 6
-	    && minimig_config.hardfile[0].cfg == 2;
+	    && minimig_config.cd32_drive.cfg == 2;
 }
 
 static bool cd_is_mounted(void)
 {
-	for (int p = 0; p < 2; p++) {
-		for (int d = 0; d < 2; d++) {
-			drive_t *drv = &ide_inst[p].drive[d];
-			if (drv->cd && (drv->chd_f || drv->f)) {
-				return true;
-			}
-		}
-	}
-	return false;
+	return cd32_drive.cd && (cd32_drive.chd_f || cd32_drive.f);
 }
 
 static drive_t *cd_find_drive(void)
 {
-	for (int p = 0; p < 2; p++) {
-		for (int d = 0; d < 2; d++) {
-			drive_t *drv = &ide_inst[p].drive[d];
-			if (drv->cd && (drv->chd_f || drv->f)) {
-				return drv;
-			}
-		}
-	}
-	return NULL;
+	return cd_is_mounted() ? &cd32_drive : NULL;
 }
 
 static uint16_t akiko_read_status(void)
@@ -1404,12 +1388,9 @@ void akiko_cd32_poll(void)
 	static int unmounted_dump_throttle = 0;
 	if (!mounted && (unmounted_dump_throttle++ % 60) == 0 && unmounted_dump_throttle < 5*60) {
 		akiko_diag(
-			"[akiko] ide_inst dump: "
-			"[0,0]p=%d/c=%d/chd=%p/f=%p  [0,1]p=%d/c=%d/chd=%p/f=%p",
-			ide_inst[0].drive[0].present, ide_inst[0].drive[0].cd,
-			(void*)ide_inst[0].drive[0].chd_f, (void*)ide_inst[0].drive[0].f,
-			ide_inst[0].drive[1].present, ide_inst[0].drive[1].cd,
-			(void*)ide_inst[0].drive[1].chd_f, (void*)ide_inst[0].drive[1].f
+			"[akiko] cd32_drive dump: p=%d/c=%d/chd=%p/f=%p",
+			cd32_drive.present, cd32_drive.cd,
+			(void*)cd32_drive.chd_f, (void*)cd32_drive.f
 		);
 	}
 #endif

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -100,7 +100,15 @@ static inline bool cdtv_active(void)
 
 static drive_t *cdtv_find_drive(void)
 {
-	return (cdtv_drive.cd && (cdtv_drive.chd_f || cdtv_drive.f)) ? &cdtv_drive : NULL;
+	if (cdtv_drive.cd && (cdtv_drive.chd_f || cdtv_drive.f)) return &cdtv_drive;
+
+	for (int p = 0; p < 2; p++) {
+		for (int d = 0; d < 2; d++) {
+			drive_t *drv = &ide_inst[p].drive[d];
+			if (drv->cd && (drv->chd_f || drv->f)) return drv;
+		}
+	}
+	return NULL;
 }
 
 static uint16_t cdtv_read_status(void)

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -100,15 +100,7 @@ static inline bool cdtv_active(void)
 
 static drive_t *cdtv_find_drive(void)
 {
-	for (int p = 0; p < 2; p++) {
-		for (int d = 0; d < 2; d++) {
-			drive_t *drv = &ide_inst[p].drive[d];
-			if (drv->cd && (drv->chd_f || drv->f)) {
-				return drv;
-			}
-		}
-	}
-	return NULL;
+	return (cdtv_drive.cd && (cdtv_drive.chd_f || cdtv_drive.f)) ? &cdtv_drive : NULL;
 }
 
 static uint16_t cdtv_read_status(void)

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -519,6 +519,7 @@ int minimig_cfg_load(int num)
 		if (size == sizeof(minimig_config) || size == 5152 || size == 5216)
 		{
 			static mm_configTYPE tmpconf = {};
+			memset((void*)&tmpconf, 0, sizeof(tmpconf));
 			if (FileLoadConfig(filename, &tmpconf, sizeof(tmpconf)))
 			{
 				// check file id and version

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -448,6 +448,9 @@ static void ApplyConfiguration(char reloadkickstart)
 		(hdd_open(2) ? 8 : 0) |
 		(hdd_open(3) ? 16 : 0));
 
+	cd_drive_open(0, minimig_config.cd32_drive.cfg ? minimig_config.cd32_drive.filename : "");
+	cd_drive_open(1, minimig_config.cdtv_drive.cfg ? minimig_config.cdtv_drive.filename : "");
+
 	minimig_ConfigMemory(memcfg);
 	minimig_ConfigCPU(minimig_config.cpu);
 
@@ -513,7 +516,7 @@ int minimig_cfg_load(int num)
 	{
 		BootPrint("Opened configuration file\n");
 		printf("Configuration file size: %s, %d\n", filename, size);
-		if (size == sizeof(minimig_config) || size == 5152)
+		if (size == sizeof(minimig_config) || size == 5152 || size == 5216)
 		{
 			static mm_configTYPE tmpconf = {};
 			if (FileLoadConfig(filename, &tmpconf, sizeof(tmpconf)))
@@ -578,6 +581,10 @@ int minimig_cfg_load(int num)
 		minimig_config.hardfile[2].filename[0] = 0;
 		minimig_config.hardfile[3].cfg = 0;
 		minimig_config.hardfile[3].filename[0] = 0;
+		minimig_config.cd32_drive.cfg = 0;
+		minimig_config.cd32_drive.filename[0] = 0;
+		minimig_config.cdtv_drive.cfg = 0;
+		minimig_config.cdtv_drive.filename[0] = 0;
 		BootPrintEx(">>> No config found. Using defaults. <<<");
 	}
 

--- a/support/minimig/minimig_config.h
+++ b/support/minimig/minimig_config.h
@@ -58,6 +58,8 @@ typedef struct
 	unsigned char   cpu;
 	unsigned char   autofire;
 	char            info[64];
+	mm_hardfileTYPE cd32_drive;
+	mm_hardfileTYPE cdtv_drive;
 } mm_configTYPE;
 
 extern mm_configTYPE minimig_config;


### PR DESCRIPTION
**Draft — not ready for review yet.** Opened early for visibility; still under test on hardware.

Follow-on to #1258, which landed native CD32 (Akiko) and CDTV CD-ROM host support. That PR mounted the disc through `hardfile[0]` of the shared Gayle IDE array — the simplest thing that worked, but it couples the CD bridges to the emulated IDE controller: the disc occupies a real Gayle slot the guest can also see, an IDE hard drive and a CD32 disc can't be configured independently, and the Drives page has no room left to show either mount.

### What this does

Each bridge gets a standalone `drive_t` (`cd32_drive`, `cdtv_drive`) outside `ide_inst[]`, so mounting a disc can never interact with Gayle register traffic (`ide_io()`, `ide_reset()`, …). Akiko and the CDTV DMAC read the `drive_t` directly over their own SPI/UIO paths and never touch Gayle registers.

1. **`minimig: give CD32 and CDTV their own drive slots and OSD page`**
   - `ide_cdrom`: `cd_drive_parse()`, a pointer-targeted variant of `cdrom_parse()`.
   - `ide`: `cd_drive_open()` to mount/unmount a slot by filename.
   - `minimig_config`: `cd32_drive` / `cdtv_drive` appended to `mm_configTYPE`. Appending rather than growing `hardfile[]` in place keeps old 5216-byte `.cfg` files loadable through the existing back-compat path, with the new fields zeroed.
   - `menu`: a dedicated CD32/CDTV drives page.

2. **`minimig: give the CD32/CDTV mounted filenames their own row`** — the mount row printed state and path on one 32-column line, so any real path was cut off. Now the state is on the selectable row and the filename on the line below, as the floppy and hardfile rows already do.

3. **`minimig: keep pre-slot configs working with the CD32/CDTV drive slots`** — two regressions the new slots introduce for `.cfg` files written before them:
   - `minimig_cfg_load()` reads into a `static mm_configTYPE`. A short 5216-byte config only fills the head of that buffer, so the appended `cd32_drive` / `cdtv_drive` tail kept whatever the *previous* config left there. An old config loaded after a CD32 one inherits `cd32_drive.cfg == 2`, and since such configs already satisfy the other two `cd32_active()` conditions (68020 + AGA), that arms the Akiko bridge underneath a launcher that never asked for it. Load-order dependent, so it presents as "some games sometimes". Fixed by zeroing the buffer before the load.
   - Those configs carry the disc in `hardfile[0]` (`cfg == 2`), which the bridges no longer look at. Restores the Gayle scan as a fallback when the dedicated slot is empty, and accepts `hardfile[0].cfg == 2` in `cd32_active()` again.

### Testing

DE10-Nano, Minimig-AGA `cd32_cdtv` core @ `36dff18` (unmodified — this is userspace-only):

- Native CD32 and CDTV launchers using the new dedicated slots: boot to game, mounted filenames displayed in full.
- A 128-launcher legacy fleet that still mounts via `hardfile[0..2]` and IDEFix97/CD32-Emulator: unchanged behaviour, and specifically no longer mis-arms Akiko when launched after a native title.