### PR TITLE
minimig: clear the A2065 DDR3 control words even when the card is off

### DIFF
--- a/support/minimig/minimig_a2065.cpp
+++ b/support/minimig/minimig_a2065.cpp
@@ -550,6 +550,26 @@ void a2065_stop(void)
 	printf("A2065: stopped\n");
 }
 
+static void a2065_ddr3_clear(void)
+{
+	volatile uint8_t *m = map;
+	bool borrowed = false;
+
+	if (!m)
+	{
+		m = (volatile uint8_t *)shmem_map(DDR3_FLAT_BASE, DDR3_FLAT_WINDOW_SIZE);
+		if (!m) return;
+		borrowed = true;
+	}
+
+	memset((void *)(m + DDR3_CMD_OFF), 0, 8);
+	memset((void *)(m + DDR3_CSR_OFF), 0, 8);
+	memset((void *)(m + DDR3_INT_OFF), 0, 8);
+	__sync_synchronize();
+
+	if (borrowed) shmem_unmap((void *)m, DDR3_FLAT_WINDOW_SIZE);
+}
+
 void a2065_start(void)
 {
 	// Already up: this is a Minimig reset, so put the LANCE back to its
@@ -561,6 +581,8 @@ void a2065_start(void)
 		update_int_state();
 		return;
 	}
+
+	a2065_ddr3_clear();
 
 	if (a2065_get_iface() == A2065_OFF) return;
 


### PR DESCRIPTION
The Minimig core can come up with nothing drawn and no disk or CD activity —
looking like a bad bitstream — depending on which core was loaded before it.
This is the A2065 mailbox reading uninitialised DDR3.

### Cause

The FPGA half of the A2065 is always instantiated, and its mailbox polls the
DDR3 control block unconditionally, latching `INT_STATE` bit 0 into the card's
INT2 output:

```verilog
// rtl/A2065/a2065_ddr3_mailbox.v
a2065_int2 <= avl_readdata[0];
```

`a2065_start()` only reaches `a2065_open()` — which zeroes those words — when a
host interface is selected. With the card off, which is the default, it returns
before that and the block is never initialised. DDR3 is not cleared between
cores, so the mailbox reads whatever the previously loaded core left there. A
stale bit 0 holds INT2 asserted, and the 68k takes level 2 interrupts from the
moment Exec enables them.

Measured on a DE10-Nano, `INT_STATE` read `0x9C1944562D41540D` at core start.

Because the trigger is leftover memory content rather than a race, the failure
is load-order dependent rather than random — which is what makes it look
intermittent and hard to bisect.

### Fix

Clear `CMD`, `CSR` and `INT_STATE` before deciding whether to bring the host
interface up, borrowing a temporary mapping when the card stays off. No change
when the card is enabled: `a2065_open()` still zeroes them as before.

Affects the mainline Minimig core as well as the CD32/CDTV work — `rtl/A2065`
is present on both `MiSTer` and `cd32_cdtv` in Minimig-AGA_MiSTer, and the
mailbox is instantiated regardless of the card setting.

### Testing

Built for ARM and run on a DE10-Nano. With the card off, Minimig comes up
consistently instead of depending on the previously loaded core.

Opened as a draft — happy to squash, reword, or narrow it if you'd prefer the
clear to live inside `a2065_open()` instead.
