### PR TITLE
minimig: CDTV NVRAM persistence, OSD-open save policy, full-width status read

### DIFF
--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -54,8 +54,6 @@ static void akiko_diag(const char *fmt, ...);
 #define AKIKO_NVRAM_FILE_LEGACY       "/media/fat/saves/Minimig/cd32.nvr"
 #define AKIKO_STATUS_NVR_DIRTY        (1u << 7)
 #define AKIKO_NVRAM_POLL_PERIOD_MS    1000
-#define AKIKO_NVRAM_DIRTY_DEBOUNCE_MS 30000
-#define AKIKO_NVRAM_MIN_SAVE_INTERVAL_MS 60000
 
 #define AKIKO_SECTOR_BYTES 2352
 
@@ -1494,9 +1492,7 @@ void akiko_cd32_poll(void)
 	}
 
 	{
-		static uint32_t nvr_dirty_seen_at    = 0;
-		static uint32_t nvr_last_save_at     = 0;
-		static int      nvr_menu_was_present = 0;
+		static int nvr_menu_was_present = 0;
 		const bool nvr_dirty_now  = (status & AKIKO_STATUS_NVR_DIRTY) != 0;
 		const int  nvr_menu_now   = menu_present();
 		const bool osd_open_edge  = nvr_menu_now && !nvr_menu_was_present;
@@ -1504,26 +1500,10 @@ void akiko_cd32_poll(void)
 
 		if (nvr_dirty_now) {
 			cd_save_dirty_observed = true;
-			uint32_t now_ms = (uint32_t)GetTimer(0);
-			if (!nvr_dirty_seen_at) {
-				nvr_dirty_seen_at = now_ms;
-				akiko_diag("[akiko] NVR dirty observed at t=%u", now_ms);
-			}
-			const bool throttle_expired = rx_idle &&
-				(now_ms - nvr_dirty_seen_at) >= AKIKO_NVRAM_DIRTY_DEBOUNCE_MS;
-			const bool fire = osd_open_edge || throttle_expired;
-			const bool cooldown_clear = !nvr_last_save_at ||
-				(now_ms - nvr_last_save_at) >= AKIKO_NVRAM_MIN_SAVE_INTERVAL_MS;
-			if (fire && cooldown_clear) {
-				if (osd_open_edge) {
-					akiko_diag("[akiko] NVR flush: OSD opened with dirty pending");
-				}
+			if (osd_open_edge) {
+				akiko_diag("[akiko] NVR flush: OSD opened with dirty pending");
 				akiko_nvram_save_to_disk();
-				nvr_dirty_seen_at = 0;
-				nvr_last_save_at  = now_ms;
 			}
-		} else {
-			nvr_dirty_seen_at = 0;
 		}
 	}
 

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -224,7 +224,7 @@ static uint16_t akiko_read_status(void)
 	uint16_t res;
 	EnableIO();
 	res = spi_w(AKIKO_STATUS_CMD);
-	if (!res) res = (uint8_t)spi_w(0);
+	if (!res) res = spi_w(0);
 	DisableIO();
 	return res;
 }

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -6,11 +6,15 @@
 #include <stdbool.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
 
 #include <byteswap.h>
 
 #include "../../spi.h"
+#include "../../fpga_io.h"
 #include "../../user_io.h"
+#include "../../menu.h"
 #include "../../hardware.h"
 #include "../../ide.h"
 #include "../../ide_cdrom.h"
@@ -45,6 +49,12 @@ static void cdtv_diag(const char *fmt, ...)
 #define CDTV_STATUS_CDDA_REQ (1u << 8)
 #define CDTV_STATUS_CMD    0x63
 #define CDTV_STATUS_REQ    (1u << 6)
+#define CDTV_STATUS_NVR_DIRTY (1u << 12)
+
+#define CDTV_NVRAM_ADDR       0xF880
+#define CDTV_NVRAM_BYTES      16384
+#define CDTV_NVRAM_FILE_BYTES 32768
+#define CDTV_NVRAM_DIR        "/media/fat/saves/Minimig"
 
 static int cr511_command_length(uint8_t op)
 {
@@ -796,9 +806,223 @@ static void cdtv_dispatch(void)
 	cmd_need = 0;
 }
 
+static char cd_save_path_active[256] = {0};
+static bool cd_save_load_pending     = false;
+static bool cd_save_dirty_observed   = false;
+static bool cd_save_load_failed      = false;
+
+static uint32_t nvr_verify_due_at_ms = 0;
+static char     nvr_verify_path[256] = {0};
+
+static uint64_t fnv1a_64(const char *s)
+{
+	uint64_t h = 1469598103934665603ull;
+	while (*s) {
+		h ^= (uint8_t)*s++;
+		h *= 1099511628211ull;
+	}
+	return h;
+}
+
+static void cdtv_compute_save_path(const char *cd_path, char *out, size_t outsz)
+{
+	const char *base = strrchr(cd_path, '/');
+	base = base ? base + 1 : cd_path;
+	snprintf(out, outsz, "%s/cdtv-%016" PRIx64 ".nvr", CDTV_NVRAM_DIR, fnv1a_64(base));
+}
+
+static void cdtv_nvram_dump(uint8_t *out)
+{
+	EnableIO();
+	spi8(UIO_DMA_READ);
+	spi32_w(CDTV_NVRAM_ADDR);
+	for (int i = 0; i < CDTV_NVRAM_BYTES; i++) out[i] = (uint8_t)spi_w(0);
+	DisableIO();
+}
+
+static void cdtv_nvram_upload(const uint8_t *buf)
+{
+	static uint16_t words[CDTV_NVRAM_BYTES / 2];
+	memcpy(words, buf, CDTV_NVRAM_BYTES);
+
+	EnableIO();
+	fpga_spi_fast(UIO_DMA_WRITE);
+	fpga_spi_fast(CDTV_NVRAM_ADDR);
+	fpga_spi_fast(0);
+	fpga_spi_fast_block_write(words, CDTV_NVRAM_BYTES / 2);
+	DisableIO();
+}
+
+static bool cdtv_nvram_load_from_path(const char *path)
+{
+	struct stat st;
+	if (stat(path, &st) != 0) {
+		cdtv_dbg("NVR load skip: no file at %s (errno=%d)", path, errno);
+		return false;
+	}
+	if (st.st_size < CDTV_NVRAM_BYTES) {
+		cdtv_dbg("NVR load skip: %s too small %lld (want >= %d)",
+		         path, (long long)st.st_size, CDTV_NVRAM_BYTES);
+		return false;
+	}
+
+	static uint8_t nvr[CDTV_NVRAM_BYTES];
+	FILE *f = fopen(path, "rb");
+	if (!f) {
+		cdtv_dbg("NVR load FAIL: fopen(%s) errno=%d", path, errno);
+		cd_save_load_failed = true;
+		return false;
+	}
+	size_t got = fread(nvr, 1, CDTV_NVRAM_BYTES, f);
+	fclose(f);
+	if (got != CDTV_NVRAM_BYTES) {
+		cdtv_dbg("NVR load FAIL: read %u of %d bytes from %s",
+		         (unsigned)got, CDTV_NVRAM_BYTES, path);
+		cd_save_load_failed = true;
+		return false;
+	}
+
+	cdtv_nvram_upload(nvr);
+
+	cd_save_load_failed = false;
+	strncpy(nvr_verify_path, path, sizeof(nvr_verify_path) - 1);
+	nvr_verify_path[sizeof(nvr_verify_path) - 1] = 0;
+	nvr_verify_due_at_ms = (uint32_t)GetTimer(100);
+	cdtv_dbg("NVR loaded (%d bytes from %s) - verify in 100 ms", CDTV_NVRAM_BYTES, path);
+	return true;
+}
+
+static void cdtv_nvram_verify_load_pending(void)
+{
+	if (!nvr_verify_due_at_ms) return;
+	if (!CheckTimer(nvr_verify_due_at_ms)) return;
+	nvr_verify_due_at_ms = 0;
+
+	static uint8_t verify[CDTV_NVRAM_BYTES];
+	static uint8_t expected[CDTV_NVRAM_BYTES];
+
+	cdtv_nvram_dump(verify);
+
+	FILE *f = fopen(nvr_verify_path, "rb");
+	if (!f) {
+		cdtv_dbg("NVR verify: fopen(%s) failed errno=%d", nvr_verify_path, errno);
+		cd_save_load_failed = true;
+		return;
+	}
+	size_t got = fread(expected, 1, CDTV_NVRAM_BYTES, f);
+	fclose(f);
+	if (got != CDTV_NVRAM_BYTES) {
+		cdtv_dbg("NVR verify: short read %u/%d", (unsigned)got, CDTV_NVRAM_BYTES);
+		cd_save_load_failed = true;
+		return;
+	}
+	if (!memcmp(expected, verify, CDTV_NVRAM_BYTES)) {
+		cdtv_dbg("NVR loaded %d bytes from %s (verify OK)",
+		         CDTV_NVRAM_BYTES, nvr_verify_path);
+		cd_save_load_failed = false;
+		return;
+	}
+
+	int first_bad = -1, mismatches = 0;
+	for (int i = 0; i < CDTV_NVRAM_BYTES; i++) {
+		if (verify[i] != expected[i]) {
+			if (first_bad < 0) first_bad = i;
+			mismatches++;
+		}
+	}
+	cdtv_dbg("NVR LOAD VERIFY FAILED: %d/%d mismatched (first @ 0x%04x)",
+	         mismatches, CDTV_NVRAM_BYTES, first_bad);
+	cd_save_load_failed = true;
+}
+
+static bool cdtv_nvram_save_to_path(const char *path)
+{
+	static uint8_t buf[CDTV_NVRAM_BYTES];
+	cdtv_nvram_dump(buf);
+
+	FILE *cur = fopen(path, "rb");
+	if (cur) {
+		static uint8_t disk_buf[CDTV_NVRAM_BYTES];
+		size_t n = fread(disk_buf, 1, CDTV_NVRAM_BYTES, cur);
+		fclose(cur);
+		if (n == CDTV_NVRAM_BYTES && !memcmp(disk_buf, buf, CDTV_NVRAM_BYTES)) {
+			cdtv_dbg("NVR save skipped: identical to %s", path);
+			return true;
+		}
+	}
+
+	if (mkdir(CDTV_NVRAM_DIR, 0755) != 0 && errno != EEXIST) {
+		cdtv_dbg("NVR mkdir(%s) failed: errno=%d", CDTV_NVRAM_DIR, errno);
+	}
+
+	char tmp_path[300];
+	snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
+
+	FILE *f = fopen(tmp_path, "wb");
+	if (!f) {
+		cdtv_dbg("NVR fopen(%s) failed: errno=%d", tmp_path, errno);
+		return false;
+	}
+
+	uint8_t zero[512] = {0};
+	size_t wrote = fwrite(buf, 1, CDTV_NVRAM_BYTES, f);
+	for (int i = 0; i < (CDTV_NVRAM_FILE_BYTES - CDTV_NVRAM_BYTES) / (int)sizeof(zero); i++) {
+		wrote += fwrite(zero, 1, sizeof(zero), f);
+	}
+	int flush = fflush(f);
+	int fsy   = fsync(fileno(f));
+	int cls   = fclose(f);
+	if (wrote != CDTV_NVRAM_FILE_BYTES || flush != 0 || fsy != 0 || cls != 0) {
+		cdtv_dbg("NVR write incomplete: wrote=%u flush=%d fsync=%d close=%d",
+		         (unsigned)wrote, flush, fsy, cls);
+		unlink(tmp_path);
+		return false;
+	}
+
+	if (rename(tmp_path, path) != 0) {
+		cdtv_dbg("NVR rename(%s -> %s) failed: errno=%d", tmp_path, path, errno);
+		unlink(tmp_path);
+		return false;
+	}
+
+	cdtv_dbg("NVR saved %d bytes to %s", CDTV_NVRAM_BYTES, path);
+	return true;
+}
+
+static bool cdtv_nvram_save_to_disk(void)
+{
+	if (!cd_save_path_active[0]) return false;
+	if (cd_save_load_failed) {
+		static bool warned_once = false;
+		if (!warned_once) {
+			cdtv_dbg("NVR save BLOCKED: load failed for %s - refusing to overwrite "
+			         "a real save with a blank NVRAM. Future blocks silent.",
+			         cd_save_path_active);
+			warned_once = true;
+		}
+		return false;
+	}
+	return cdtv_nvram_save_to_path(cd_save_path_active);
+}
+
 void cdtv_cd_set_cd_path(const char *path)
 {
 	if (!path) path = "";
+
+	char new_save[sizeof(cd_save_path_active)] = {0};
+	if (path[0]) cdtv_compute_save_path(path, new_save, sizeof(new_save));
+
+	if (strcmp(new_save, cd_save_path_active) != 0) {
+		if (cd_save_path_active[0] && cd_save_dirty_observed) {
+			cdtv_dbg("set_cd_path: flushing old save %s before swap", cd_save_path_active);
+			cdtv_nvram_save_to_path(cd_save_path_active);
+		}
+		strncpy(cd_save_path_active, new_save, sizeof(cd_save_path_active) - 1);
+		cd_save_path_active[sizeof(cd_save_path_active) - 1] = 0;
+		cd_save_dirty_observed = false;
+		cd_save_load_failed    = false;
+		cd_save_load_pending   = (cd_save_path_active[0] != 0);
+	}
 	strncpy(cd_path_active, path, sizeof(cd_path_active) - 1);
 	cd_path_active[sizeof(cd_path_active) - 1] = 0;
 
@@ -842,12 +1066,39 @@ void cdtv_cd_init(void)
 		stch_retries = STCH_RETRY_BUDGET;
 		stch_next_ms = GetTimer(0);
 	}
+
+	cd_save_dirty_observed = false;
+	cd_save_load_failed    = false;
+	if (cd_save_path_active[0]) cd_save_load_pending = true;
+
 	cdtv_dbg("init media=%d isready=%d stch_retries=%d", cd_media, cd_isready, stch_retries);
 }
 
 void cdtv_cd_poll(void)
 {
 	if (!cdtv_active()) return;
+
+	if (cd_save_load_pending) {
+		cd_save_load_pending = false;
+		if (cd_save_path_active[0]) cdtv_nvram_load_from_path(cd_save_path_active);
+	}
+
+	cdtv_nvram_verify_load_pending();
+
+	{
+		static int nvr_menu_was_present = 0;
+		const bool nvr_dirty_now = (cdtv_read_status_full() & CDTV_STATUS_NVR_DIRTY) != 0;
+		const int  nvr_menu_now  = menu_present();
+		const bool osd_open_edge = nvr_menu_now && !nvr_menu_was_present;
+		nvr_menu_was_present     = nvr_menu_now;
+
+		if (nvr_dirty_now) cd_save_dirty_observed = true;
+
+		if (osd_open_edge && cd_save_dirty_observed) {
+			cdtv_dbg("NVR flush: OSD opened with dirty pending");
+			cdtv_nvram_save_to_disk();
+		}
+	}
 
 	if (stch_retries > 0 && CheckTimer(stch_next_ms)) {
 		cdtv_inject_stch();

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -126,7 +126,7 @@ static uint16_t cdtv_read_status(void)
 	uint16_t res;
 	EnableIO();
 	res = spi_w(CDTV_STATUS_CMD);
-	if (!res) res = (uint8_t)spi_w(0);
+	if (!res) res = spi_w(0);
 	DisableIO();
 	return res;
 }
@@ -222,19 +222,9 @@ static bool cdtv_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
 	return true;
 }
 
-static uint16_t cdtv_read_status_full(void)
-{
-	uint16_t hi;
-	EnableIO();
-	hi = spi_w(CDTV_STATUS_CMD);
-	if (!hi) hi = (uint16_t)spi_w(0);
-	DisableIO();
-	return hi;
-}
-
 static bool cdtv_audio_fifo_ready(void)
 {
-	return (cdtv_read_status_full() & CDTV_STATUS_CDDA_REQ) != 0;
+	return (cdtv_read_status() & CDTV_STATUS_CDDA_REQ) != 0;
 }
 
 static void cdtv_push_audio_sector(const uint8_t *buf2352)
@@ -1087,7 +1077,7 @@ void cdtv_cd_poll(void)
 
 	{
 		static int nvr_menu_was_present = 0;
-		const bool nvr_dirty_now = (cdtv_read_status_full() & CDTV_STATUS_NVR_DIRTY) != 0;
+		const bool nvr_dirty_now = (cdtv_read_status() & CDTV_STATUS_NVR_DIRTY) != 0;
 		const int  nvr_menu_now  = menu_present();
 		const bool osd_open_edge = nvr_menu_now && !nvr_menu_was_present;
 		nvr_menu_was_present     = nvr_menu_now;


### PR DESCRIPTION
Host side of CDTV NVRAM persistence, plus a status-word fix that the RTL change makes necessary.

Pairs with MiSTer-devel/Minimig-AGA_MiSTer#219 — the status word and the new NVRAM sub-channel change on both sides together, so they need to land together.

## CDTV NVRAM persistence (`e97dab4`)

CDTV battram was volatile: the core held it in BRAM and nothing moved it to or from SD, so preferences and saved games were lost on every core load.

This mirrors the CD32 Akiko path. On mount the save file is derived from the disc image's basename (FNV-1a 64), giving `/media/fat/saves/Minimig/cdtv-<hash>.nvr` — one file per disc, as elsewhere in MiSTer. The image is pushed to the core over the new `0xF880` ext-bus sub-channel with a fast 16-bit block write, then read back 100 ms later and compared, so a failed upload is detected rather than silently masking a good save.

Writes go to a `.tmp` and are fsynced before the rename. A save that would be byte-identical is skipped, and a save is blocked outright when the preceding load failed, so a blank NVRAM cannot overwrite a real one.

Files use the WinUAE `cdtv.nvr` geometry: 16 KB of live battram followed by zero padding to 32 KB, which is the reachable window WinUAE masks to (`CDTV_NVRAM_MASK 16383`) and the offset at which it expects card memory to begin. Loads accept anything at least 16 KB and read only the first 16 KB, so images move between WinUAE and MiSTer in both directions.

## Save policy (`974e34f`)

Flush now happens when the OSD is opened, plus once when the disc is swapped or ejected. Nothing else.

The CD32 side previously also had a debounce fallback (`AKIKO_NVRAM_DIRTY_DEBOUNCE_MS` 30 s, `AKIKO_NVRAM_MIN_SAVE_INTERVAL_MS` 60 s) that wrote on a timer. That is removed, so both platforms now follow the same OSD-open policy and neither writes to the SD card on a background timer.

## Full-width status read (`7c9a8e6`)

Both status readers were:

```c
res = spi_w(STATUS_CMD);
if (!res) res = (uint8_t)spi_w(0);
```

The cast discards bits 8 and above — the akiko request, sector-request and rx-busy flags, the CDDA request, and the new CDTV dirty flag at bit 12. The fallback never fired in practice only because the status word carried a constant `4'hE` tag in its top nibble, which guaranteed the first read was non-zero.

The paired RTL PR reclaims that tag for flag bits, which removes the accident keeping the cast harmless. Dropping the cast is the fix; steering around it with a magic value is not.

`cdtv_read_status_full` existed solely as an untruncated duplicate of `cdtv_read_status` to work around the same problem. With the cast gone the two are identical, so it is folded away.

## Testing

Built for ARM and run on real hardware alongside the paired bitstream.

**The CDTV NVRAM save/load round trip is not verified end to end.** No CDTV title was found that actually writes battram, so the dirty → flush → reload path has not been exercised. The geometry and byte-lane mapping are reasoned against the WinUAE implementation rather than observed.

The status-word change (`7c9a8e6`) does affect the CD32 path and is worth attention in review on that basis alone.

Draft until the NVRAM gap is closed.
