### PR TITLE
Report ROM loading progress in debug output

### DIFF
--- a/support/arcade/mra_loader.cpp
+++ b/support/arcade/mra_loader.cpp
@@ -42,6 +42,7 @@ struct arc_struct {
 	int ifrom;
 	int ito;
 	int imap;
+	int has_file_part;
 	int file_size;
 	uint32_t address;
 	uint32_t crc;
@@ -324,7 +325,7 @@ static int rom_patch(const uint8_t *buf, int offset, uint16_t len, int dataop)
 	return 1;
 }
 
-static void rom_finish(int send, uint32_t address, int index)
+static void rom_finish(int send, uint32_t address, int index, int show_debug_progress)
 {
 	if (romlen[0] && romdata)
 	{
@@ -339,9 +340,31 @@ static void rom_finish(int send, uint32_t address, int index)
 			// prepare transmission of new file
 			user_io_set_download(1, address ? len : 0);
 
+			int debug_progress = -1;
 			if (address)
 			{
-				shmem_put(fpga_mem(address), len, data);
+				void *shmem = shmem_map(fpga_mem(address), len);
+				if (shmem)
+				{
+					if (show_debug_progress)
+					{
+						uint32_t sent = 0;
+						uint32_t copy_size = ((uint32_t)len + 9) / 10;
+						user_io_debug_progress(0, len, &debug_progress);
+						while (sent < (uint32_t)len)
+						{
+							uint32_t chunk = ((uint32_t)len - sent > copy_size) ? copy_size : (uint32_t)len - sent;
+							memcpy((uint8_t *)shmem + sent, data + sent, chunk);
+							sent += chunk;
+							user_io_debug_progress(sent, len, &debug_progress);
+						}
+					}
+					else
+					{
+						memcpy(shmem, data, len);
+					}
+					shmem_unmap(shmem, len);
+				}
 			}
 			else
 			{
@@ -349,6 +372,7 @@ static void rom_finish(int send, uint32_t address, int index)
 				sprintf(str, "ROM #%d", index);
 
 				ProgressMessage(0, 0, 0, 0);
+				if (show_debug_progress) user_io_debug_progress(0, len, &debug_progress);
 				while (romlen[0] > 0)
 				{
 					ProgressMessage("Sending", str, len - romlen[0], len);
@@ -358,6 +382,7 @@ static void rom_finish(int send, uint32_t address, int index)
 
 					romlen[0] -= chunk;
 					data += chunk;
+					if (show_debug_progress) user_io_debug_progress(len - romlen[0], len, &debug_progress);
 				}
 				ProgressMessage(0, 0, 0, 0);
 			}
@@ -481,6 +506,7 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 			arc_info->zipname[0] = 0;
 			arc_info->address = 0;
 			arc_info->insideinterleave = 0;
+			arc_info->has_file_part = 0;
 			MD5Init(&arc_info->context);
 			ProgressMessage(0, 0, 0, 0);
 		}
@@ -843,7 +869,7 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 
 				checksumsame |= no_checksum;
 
-				rom_finish(checksumsame, arc_info->address, arc_info->romindex);
+				rom_finish(checksumsame, arc_info->address, arc_info->romindex, arc_info->has_file_part);
 			}
 			arc_info->insiderom = 0;
 		}
@@ -877,6 +903,7 @@ static int xml_send_rom(XMLEvent evt, const XMLNode* node, SXML_CHAR* text, cons
 			//user_io_file_tx_body_filepart(getFullPath(fname),0,0);
 			if (strlen(arc_info->partname))
 			{
+				arc_info->has_file_part = 1;
 				char zipnames_list[kBigTextSize];
 
 				if (strlen(arc_info->partzipname))

--- a/support/n64/n64.cpp
+++ b/support/n64/n64.cpp
@@ -2652,6 +2652,7 @@ int n64_rom_tx(const char* name, const unsigned char idx, const uint32_t load_ad
 
 	uint32_t data_size = f.size;
 	uint32_t data_left = data_size;
+	int debug_progress = -1;
 
 	printf("N64 file \"%s\" with %u bytes to send for index %02x.\n", name, data_size, idx);
 
@@ -2693,6 +2694,7 @@ int n64_rom_tx(const char* name, const unsigned char idx, const uint32_t load_ad
 
 		user_io_set_download(1);
 		ProgressMessage();
+		user_io_debug_progress(0, data_size, &debug_progress);
 
 		while (data_left) {
 			uint32_t chunk = (data_left > sizeof(buf)) ? sizeof(buf) : data_left;
@@ -2702,6 +2704,7 @@ int n64_rom_tx(const char* name, const unsigned char idx, const uint32_t load_ad
 
 			ProgressMessage("Loading", n64_leaf_name(f.name), data_size - data_left, data_size);
 			data_left -= chunk;
+			user_io_debug_progress(data_size - data_left, data_size, &debug_progress);
 		}
 
 		printf("Done loading Game Boy ROM.\n");
@@ -2770,6 +2773,7 @@ int n64_rom_tx(const char* name, const unsigned char idx, const uint32_t load_ad
 	// prepare transmission of new file
 	user_io_set_download(1, load_addr ? data_size : 0);
 	ProgressMessage();
+	user_io_debug_progress(0, data_size, &debug_progress);
 
 	while (data_left) {
 		size_t chunk = (data_left > sizeof(buf)) ? sizeof(buf) : data_left;
@@ -2852,6 +2856,7 @@ int n64_rom_tx(const char* name, const unsigned char idx, const uint32_t load_ad
 
 		ProgressMessage("Loading", n64_leaf_name(f.name), data_size - data_left, data_size);
 		data_left -= chunk;
+		user_io_debug_progress(data_size - data_left, data_size, &debug_progress);
 		is_first_chunk = false;
 
 		// CRC32 is used for cheat look-up. Cheat files from gamehacking.org use byte swapped CRC32 for some reason...

--- a/support/neogeo/neogeo_loader.cpp
+++ b/support/neogeo/neogeo_loader.cpp
@@ -130,6 +130,13 @@ static const char *get_name(const char *path, const char *name)
 	return buf;
 }
 
+static struct
+{
+	uint32_t total;
+	uint32_t sent;
+	int percent;
+} neo_debug_progress;
+
 static uint32_t neogeo_file_tx(const char* path, const char* name, uint8_t neo_file_type, uint8_t index, uint32_t offset, uint32_t size)
 {
 	fileTYPE f = {};
@@ -306,7 +313,7 @@ static uint32_t load_rom_to_mem(const char* path, const char* name, uint8_t neo_
 		if (partsz > LOADBUF_SZ) partsz = LOADBUF_SZ;
 
 		uint32_t partszf = remainf;
-		if (partszf > LOADBUF_SZ) partszf = LOADBUF_SZ;
+		if (partszf > partsz) partszf = partsz;
 
 		//printf("partsz=%d, map_addr=0x%X\n", partsz, map_addr);
 		void *base = shmem_map(map_addr, partsz);
@@ -336,8 +343,15 @@ static uint32_t load_rom_to_mem(const char* path, const char* name, uint8_t neo_
 		}
 
 		ProgressMessage("Loading", dispname, size - (remain - partsz), size);
+		if (neo_debug_progress.total)
+		{
+			neo_debug_progress.sent += partszf;
+			if (neo_debug_progress.sent < partszf || neo_debug_progress.sent > neo_debug_progress.total) neo_debug_progress.sent = neo_debug_progress.total;
+			user_io_debug_progress(neo_debug_progress.sent, neo_debug_progress.total, &neo_debug_progress.percent);
+		}
 
 		shmem_unmap(base, partsz);
+		remainf -= partszf;
 		remain -= partsz;
 		map_addr += partsz;
 	}
@@ -1083,6 +1097,8 @@ void load_neo(char *path)
 			printf("ID=0x%X, PSize=%d, SSize=%d, MSize=%d, V1Size=%d, V2Size=%d, CSize=%d, Name=%s\n", hdr.NGH, hdr.PSize, hdr.SSize, hdr.MSize, hdr.V1Size, hdr.V2Size, hdr.CSize, hdr.Name);
 			char *p = strrchr(path, '/');
 			*p++ = 0;
+			neo_debug_progress = {hdr.PSize + hdr.SSize + hdr.MSize + hdr.V1Size + hdr.V2Size + hdr.CSize, 0, -1};
+			user_io_debug_progress(0, neo_debug_progress.total, &neo_debug_progress.percent);
 			uint32_t off = 4096;
 			if (hdr.PSize) neogeo_tx(path, p, NEO_FILE_RAW, 4, off, hdr.PSize);
 			off += hdr.PSize;
@@ -1109,6 +1125,7 @@ void load_neo(char *path)
 			}
 
 			if (hdr.CSize) neogeo_tx(path, p, NEO_FILE_SPR, 15, off, hdr.CSize, 0, 1);
+			neo_debug_progress = {};
 
 			printf("Setting cart ms5p to %u\n", ms5p);
 			set_config((ms5p & 1) << 17, 1 << 17);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -2053,6 +2053,23 @@ void user_io_file_tx_data(const uint8_t *addr, uint32_t len)
 	DisableFpga();
 }
 
+void user_io_debug_progress(uint32_t sent, uint32_t total, int *last_percent)
+{
+	static unsigned long start_time;
+
+	if (!total || !last_percent || *last_percent >= 100) return;
+	if (*last_percent < 0) start_time = GetTimer(0);
+	unsigned long elapsed = GetTimer(0) - start_time;
+
+	for (int percent = (*last_percent < 0) ? 0 : *last_percent + 10;
+	     percent <= 100 && (uint64_t)sent * 100 >= (uint64_t)total * percent; percent += 10)
+	{
+		printf("Loading ROM %3d%% (%lu ms)\n", percent, elapsed);
+		fflush(stdout);
+		*last_percent = percent;
+	}
+}
+
 void user_io_set_upload(unsigned char enable, int addr)
 {
 	EnableFpga();
@@ -2715,6 +2732,12 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 	int dosend = 1;
 	file_crc = 0;
 
+	const char *rom_name = strrchr(f.name, '/');
+	rom_name = rom_name ? rom_name + 1 : f.name;
+	char core_rom[64];
+	snprintf(core_rom, sizeof(core_rom), "%s.rom", user_io_get_core_name());
+	int debug_progress = (!strncasecmp(rom_name, "boot", 4) || strcasestr(rom_name, "bios") || !strcasecmp(rom_name, core_rom)) ? 100 : -1;
+
 	int snes_file = SNES_FILE_RAW;
 	if (is_snes() && bytes2send && !load_addr)
 	{
@@ -2796,12 +2819,14 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 				uint32_t remaining = rom_size;
 				uint32_t sent = 0;
 				const uint32_t chunk_size = 4096;
+				user_io_debug_progress(0, rom_size, &debug_progress);
 				while (remaining) {
 					uint32_t chunk = (remaining > chunk_size) ? chunk_size : remaining;
 					ProgressMessage("Loading", f.name, sent, rom_size);
 					user_io_file_tx_data(rom + sent, chunk);
 					sent += chunk;
 					remaining -= chunk;
+					user_io_debug_progress(sent, rom_size, &debug_progress);
 				}
 				free(rom);
 			}
@@ -2858,6 +2883,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 		uint8_t *mem = (uint8_t *)shmem_map(fpga_mem(load_addr), map_size);
 		if (mem)
 		{
+			user_io_debug_progress(0, size, &debug_progress);
 			while (bytes2send)
 			{
 				uint32_t gap = (is_snes() && (load_addr < 0x22000000) && (load_addr + size - bytes2send) >= 0x22000000) ? 0x800000 : 0;
@@ -2870,6 +2896,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 
 				if (use_progress) ProgressMessage("Loading", f.name, size - bytes2send, size);
 				bytes2send -= chunk;
+				user_io_debug_progress(size - bytes2send, size, &debug_progress);
 			}
 
 			shmem_unmap(mem, map_size);
@@ -2877,6 +2904,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 	}
 	else
 	{
+		if (dosend) user_io_debug_progress(0, size, &debug_progress);
 		while (dosend && bytes2send)
 		{
 			uint32_t chunk = (bytes2send > sizeof(buf)) ? sizeof(buf) : bytes2send;
@@ -2887,6 +2915,7 @@ int user_io_file_tx(const char* name, unsigned char index, char opensave, char m
 
 			if (use_progress) ProgressMessage("Loading", f.name, size - bytes2send, size);
 			bytes2send -= chunk;
+			user_io_debug_progress(size - bytes2send, size, &debug_progress);
 
 			if (skip >= chunk) skip -= chunk;
 			else

--- a/user_io.h
+++ b/user_io.h
@@ -232,6 +232,7 @@ void user_io_file_tx_data(const uint8_t *addr, uint32_t len);
 void user_io_set_upload(unsigned char enable, int addr = 0);
 void user_io_file_rx_data(uint8_t *addr, uint32_t len);
 void user_io_file_info(const char *ext);
+void user_io_debug_progress(uint32_t sent, uint32_t total, int *last_percent);
 int user_io_get_width();
 
 void user_io_check_reset(unsigned short modifiers, char useKeys);


### PR DESCRIPTION
Prints ROM loading progress in 10% increments to debug
Useful for debugging rom load speed and for external devices to display loading progress

```
Loading ROM   0% (0 ms)
Loading ROM  10% (135 ms)
Loading ROM  20% (268 ms)
Loading ROM  30% (399 ms)
Loading ROM  40% (533 ms)
Loading ROM  50% (666 ms)
Loading ROM  60% (801 ms)
Loading ROM  70% (933 ms)
Loading ROM  80% (1066 ms)
Loading ROM  90% (1199 ms)
Loading ROM 100% (1332 ms)
file_finish: 0x200000 bytes sent to FPGA
```

Ignores BIOS file and optical disc loading
Special handling of N64, Neo-Geo and .mra
Guarded by MiSTer.ini debug=1 - no new MiSTer.ini settings

Tested and working:
- Arcade MGL
- Neo-Geo
- Atari 7800
- Atari Lynx
- NES
- SNES
- N64
- Game Boy
- GBA
- SMS
- MegaDrive
- 32X
- TurboGrafx-16
- Jaguar
- Vectrex

Tested and intentionally untouched:
- CDi
- MegaCD
- PSX
- Saturn