### PR TITLE
Recognize PC110 as an x86 variant

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -226,7 +226,15 @@ char is_menu()
 static int is_x86_type = 0;
 char is_x86()
 {
-	if (!is_x86_type) is_x86_type = strcasecmp(orig_name, "AO486") ? 2 : 1;
+	if (!is_x86_type)
+	{
+		if (!strcasecmp(orig_name, "AO486") ||
+		    !strcasecmp(orig_name, "PC110")
+		   )
+			is_x86_type = 1;
+		else
+			is_x86_type = 2;
+	}
 	return (is_x86_type == 1);
 }
 


### PR DESCRIPTION
Adds `PC110` to `is_x86()` alongside the existing x86 service identity, following the PCXT variant pattern used for PCXT-EGA, Tandy1000, and PCjr.

This lets the IBM PC110 core keep an independent core name, Home directory, ROM selectors, disk configuration, and UART configuration while reusing Main's existing x86 transport. It does not add a machine profile, firmware, disk geometry override, or PC110-specific storage behavior.

The coordinated core change is available in [ahmadexp/PC110_MiSTer#12](https://github.com/ahmadexp/PC110_MiSTer/pull/12). It changes the service identity to `PC110` and provides a backup-first migration that leaves existing files and settings untouched.

Motivated by [ahmadexp/PC110_MiSTer#11](https://github.com/ahmadexp/PC110_MiSTer/issues/11) and the PCXT-EGA variant precedent in commit 663104d49949942bf1c4651d50d59ed50f5e2a46.

Validation:

- Current upstream master builds successfully with the ARM GNU 10.2 toolchain.
- Built `bin/MiSTer` is an ARM EABI5 executable.
- The coordinated core passes RTL, RAM-module, identity-migration and installer simulations.
- A full Quartus 17.0.2 core build completed with zero errors, worst setup slack `+0.652 ns`, worst hold slack `+0.237 ns`, and zero TNS.
- MiSTer hardware `192.168.10.251` reports `/tmp/CORENAME` as `PC110`, loads both boot ROMs, boots the English PersonaWare VHD on consecutive loads, and enters IBM Easy-Setup through F1 during POST.

The hardware integration build is based on Main `$VER:260730` and also contains a private physical-PCMCIA service that is independent of this one-function identity change and is not part of this PR. The second test MiSTer is currently unreachable, so no two-board result is claimed.
