### PR TITLE
minimig: move a legacy config's CD into the dedicated drive slot

### DIFF
--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -503,6 +503,21 @@ static void ApplyConfiguration(char reloadkickstart)
 	minimig_set_extcfg(minimig_get_extcfg() & ~1);
 }
 
+static void migrate_legacy_cd_slot()
+{
+	if (minimig_config.hardfile[0].cfg != 2) return;
+	if (minimig_config.cd32_drive.cfg || minimig_config.cdtv_drive.cfg) return;
+
+	mm_hardfileTYPE *slot = 0;
+	if (minimig_config.chipset & CONFIG_CDTV) slot = &minimig_config.cdtv_drive;
+	else if ((minimig_config.cpu & 0x03) == 3 && ((minimig_config.chipset >> 2) & 7) == 6) slot = &minimig_config.cd32_drive;
+	if (!slot) return;
+
+	*slot = minimig_config.hardfile[0];
+	slot->cfg = 1;
+	printf("Legacy config: CD moved from hardfile[0] to the %s drive.\n", (slot == &minimig_config.cdtv_drive) ? "CDTV" : "CD32");
+}
+
 int minimig_cfg_load(int num)
 {
 	static const char config_id[] = "MNMGCFG0";
@@ -561,6 +576,8 @@ int minimig_cfg_load(int num)
 		}
 		else printf("Wrong configuration file size: %d (expected: %u)\n", size, sizeof(minimig_config));
 	}
+	if (result && size != (int)sizeof(minimig_config)) migrate_legacy_cd_slot();
+
 	if (!result) {
 		BootPrint("Can not open configuration file!\n");
 		BootPrint("Setting config defaults\n");


### PR DESCRIPTION
### The problem

`mm_configTYPE` gained dedicated `cd32_drive` / `cdtv_drive` slots after CD32 and CDTV
support first landed. Before that the disc lived in `hardfile[0]` with `cfg == 2`, and
that is still what every config saved by an earlier build contains — those files are
5152 or 5216 bytes and have no slot fields in them at all.

Nothing looks at `hardfile[0]` for a CD any more:

* `cd32_active()` / `cdtv_active()` are just `<slot>.cfg != 0`
* `cd_find_drive()` / `cdtv_find_drive()` are `minimig_cd_drive_get()`, which returns
  the dedicated slot or `NULL`

So one of these configs loads with both slots zeroed. The bridge is never armed, no CD
drive is ever opened, and the machine boots with an empty drive — on CD32 the Kickstart
never leaves its boot animation. The disc *is* still mounted, but into the Gayle array,
where the CD32 ROM's reads fall through and the log fills with `(!) Unsupported command`.

### The fix

Migrate the disc at config-load time, and only for a config that is actually short
(`size != sizeof(minimig_config)`), so a current config is never touched.

When such a config arrives with a disc in `hardfile[0]` and both slots empty, it is
copied into the slot the config's own machine description asks for:

* `cdtv_drive` when the chipset byte carries `CONFIG_CDTV`
* `cd32_drive` when the config is 68020 + AGA

Any other config is left alone, so a plain Amiga set that happens to have an IDE CD-ROM
on `hardfile[0]` is unaffected. `ApplyConfiguration()` already runs at the end of
`minimig_cfg_load()`, so the migrated slot is opened on the same pass with no further
plumbing.

`hardfile[0]` is deliberately **not** cleared. Leaving it is exactly what these configs
did before the slots existed, and clearing it would take the drive away from a config
that was deliberately using it through Gayle.

### Verification

Real hardware (DE10-Nano), Minimig-AGA `cd32_cdtv` @ `3002974`, a 5216-byte CD32 config
(`hardfile[0].cfg == 2`, chipset `0x18` = AGA, cpu `0x13` = 68020) pointing at a Cannon
Fodder CHD. Each row is a cold boot of the same config, sampled at 45/90/150/240 s:

| build | video mode | result |
|---|---|---|
| `560272c` (master) | `640x285` at every sample, 3/3 | CD32 boot animation, never gets past it |
| `560272c` + this commit | `304x480` / `320x480`, 2/2 | boots and draws game graphics |

`640x285` is the CD32 ROM's "insert disc" animation — the machine is alive, it just
never finds a disc.
