### PR TITLE
minimig: pace the Akiko ext-bus block write (fixes Z2 fast RAM + CD black screen)

### DIFF
--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -57,6 +57,9 @@ static void akiko_diag(const char *fmt, ...);
 
 #define AKIKO_SECTOR_BYTES 2352
 
+#define AKIKO_FILL_CHUNK_WORDS 64
+#define AKIKO_FILL_GAP_US      10
+
 static const int command_lengths[16] = {
 	1, 2, 1, 1, 12, 2, 1, 1, 4, 1, 2, -1, -1, -1, -1, -1
 };
@@ -696,11 +699,19 @@ static void akiko_ext_block_write(uint16_t addr, const uint8_t *buf, int bytes)
 	static uint16_t words[AKIKO_SECTOR_BYTES / 2];
 	memcpy(words, buf, bytes);
 
+	int total = bytes / 2;
+
 	EnableIO();
 	fpga_spi_fast(UIO_DMA_WRITE);
 	fpga_spi_fast(addr);
 	fpga_spi_fast(0);
-	fpga_spi_fast_block_write(words, bytes / 2);
+	int off = 0;
+	while (off < total) {
+		int n = total - off < AKIKO_FILL_CHUNK_WORDS ? total - off : AKIKO_FILL_CHUNK_WORDS;
+		fpga_spi_fast_block_write(words + off, n);
+		off += n;
+		if (off < total) usleep(AKIKO_FILL_GAP_US);
+	}
 	DisableIO();
 }
 


### PR DESCRIPTION
Enabling Z2 fast RAM with a CD mounted boots the CD32 core to a black screen. Bisected on hardware to the ext-bus transport move (MiSTer-devel/Minimig-AGA_MiSTer#218 and #1267 here).

`akiko_ext_block_write()` sent the whole 2352-byte sector as one continuous burst. Chunking it at 64 words with a `usleep` between chunks scores 8/8 alive at Z2 8M, against 0/2 unpatched, with the no-fast-RAM control green on the same pair.

**Follow-up:** further measurement after this merged showed the chunking is incidental — the only variable that matters is elapsed time per sector, and the constants here are misleading (`usleep(10)` really takes ~92 us on this device, so this spends 1.66 ms per sector rather than the 180 us it reads as). #1278 replaces it with an explicit sector delivery rate limit.