### PR TITLE
minimig: limit Akiko sector delivery to drive speed instead of pacing the fill

### DIFF
--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -57,9 +57,6 @@ static void akiko_diag(const char *fmt, ...);
 
 #define AKIKO_SECTOR_BYTES 2352
 
-#define AKIKO_FILL_CHUNK_WORDS 64
-#define AKIKO_FILL_GAP_US      10
-
 static const int command_lengths[16] = {
 	1, 2, 1, 1, 12, 2, 1, 1, 4, 1, 2, -1, -1, -1, -1, -1
 };
@@ -699,19 +696,11 @@ static void akiko_ext_block_write(uint16_t addr, const uint8_t *buf, int bytes)
 	static uint16_t words[AKIKO_SECTOR_BYTES / 2];
 	memcpy(words, buf, bytes);
 
-	int total = bytes / 2;
-
 	EnableIO();
 	fpga_spi_fast(UIO_DMA_WRITE);
 	fpga_spi_fast(addr);
 	fpga_spi_fast(0);
-	int off = 0;
-	while (off < total) {
-		int n = total - off < AKIKO_FILL_CHUNK_WORDS ? total - off : AKIKO_FILL_CHUNK_WORDS;
-		fpga_spi_fast_block_write(words + off, n);
-		off += n;
-		if (off < total) usleep(AKIKO_FILL_GAP_US);
-	}
+	fpga_spi_fast_block_write(words, bytes / 2);
 	DisableIO();
 }
 
@@ -905,8 +894,26 @@ static bool akiko_nvram_save_to_disk(void)
 	return akiko_nvram_save_to_path(target);
 }
 
+#define AKIKO_SECTOR_PERIOD_US 6666
+
 static void akiko_push_sector(const uint8_t *buf)
 {
+	static struct timespec prev;
+	static bool have_prev = false;
+	struct timespec now;
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	if (have_prev) {
+		int64_t us = (int64_t)(now.tv_sec - prev.tv_sec) * 1000000
+		           + (now.tv_nsec - prev.tv_nsec) / 1000;
+		if (us >= 0 && us < AKIKO_SECTOR_PERIOD_US) {
+			usleep((useconds_t)(AKIKO_SECTOR_PERIOD_US - us));
+			clock_gettime(CLOCK_MONOTONIC, &now);
+		}
+	}
+	prev = now;
+	have_prev = true;
+
 	akiko_ext_block_write(AKIKO_SECTOR_ADDR, buf, AKIKO_SECTOR_BYTES);
 }
 


### PR DESCRIPTION
Follow-up to #1277. That fix works, but its shape is incidental and its constants are misleading.

**The only variable that matters is elapsed time per sector.** Measured at Z2 8M against Minimig-AGA `cd32_cdtv`, four samples per boot, scoring on video mode:

| added per sector | shape | result |
|---|---|---|
| 0 | unpaced | 0/2 |
| 0 | fill split into 18 bursts, no delay | 0/3 |
| 0.18 ms | 18 busy-waits | 0/1 |
| 0.37 ms | 4 sleeps | 0/3 |
| 0.74 ms | 8 sleeps | 2/3 |
| 1.64 ms | 18 busy-waits | 3/3 |
| 1.66 ms | 18 sleeps (#1277 as merged) | 8/8 |
| 1.68 ms | **one** sleep, single unbroken burst | 3/3 |

A busy-wait works as well as a sleep of the same length, so it is not the syscall yielding the CPU. One delay before a single unbroken burst works as well as eighteen delays inside it, so it is not burst length, chip-select behaviour, or write-strobe spacing either.

Worth knowing regardless of this PR: **`usleep(10)` really takes ~92 us on this device** (measured 10 -> 92.1, 50 -> 127, 100 -> 184 us). #1277 therefore spends 1.66 ms per sector, not the 180 us its constants read as, so anyone tuning those numbers would be tuning something other than what they appear to be.

So this states the constraint directly. A CD32 is a 2x unit — 150 sectors/s, 6.67 ms each — and nothing feeds this pipeline faster on real hardware, while we were feeding it as fast as the HPS could write. Each sector is held to that period and the single unbroken block write is restored.

**Gate: 8/8 alive at Z2 8M, no-fast-RAM control green on the same pair.**

Why the pipeline is rate-sensitive at all is not yet established — the host cannot overrun the sector buffer, since `sec_req` carries `!sector_ready && !pbx_busy`. The suspicion is sustained PBX DMA into `ram2`, which is where the data lands only when fast RAM is on, and which fits Z3 passing and 2M/4M/8M failing identically. That would be a core-side fix; this is the host-side one.