### PR TITLE
minimig: Akiko media changes without resetting the machine

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -6809,6 +6809,13 @@ void HandleUI(void)
 
 	case MENU_MINIMIG_CD32FILE_START:
 		{
+			if (!selPath[0])
+			{
+				minimig_config.cd32_drive.filename[0] = 0;
+				minimig_cd_drive_open(0, "");
+				menustate = MENU_MINIMIG_MAIN1;
+				break;
+			}
 			memcpy(Selected_CD32, selPath, sizeof(Selected_CD32));
 			recent_update(SelectedDir, selPath, SelectedLabel, 501);
 
@@ -6839,6 +6846,13 @@ void HandleUI(void)
 
 	case MENU_MINIMIG_CDTVFILE_START:
 		{
+			if (!selPath[0])
+			{
+				minimig_config.cdtv_drive.filename[0] = 0;
+				minimig_cd_drive_open(1, "");
+				menustate = MENU_MINIMIG_MAIN1;
+				break;
+			}
 			memcpy(Selected_CDTV, selPath, sizeof(Selected_CDTV));
 			recent_update(SelectedDir, selPath, SelectedLabel, 502);
 

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -153,6 +153,17 @@ typedef enum {
 static cd_media_level_t cd_media_level = CD_MEDIA_UNKNOWN;
 static bool     cd_media_push_pending = false;
 static bool     cd_media_event        = false;
+// Mounting a disc while one is already in swaps it with no removal in between,
+// which no physical drive can do - the tray has to open. A guest is told
+// present, then present again, and that is not a media change, so AmigaOS
+// keeps serving the old volume from cache and the new disc never appears.
+// Owe the guest the absent edge first.
+static bool     cd_media_swap_absent  = false;
+static uint32_t cd_media_swap_ready_ms = 0;
+// The tray cannot open and shut in the same instant, and the removal has to
+// reach CDFileSystem before the arrival lands or the two collapse back into
+// no change at all.
+#define AKIKO_SWAP_SETTLE_MS 700
 
 #define AKIKO_TOC_REPEAT       3
 #define AKIKO_TOC_PUSH_PERIOD_MS 20
@@ -1334,6 +1345,8 @@ void akiko_cd32_init(void)
 	cd_media_level   = CD_MEDIA_UNKNOWN;
 	cd_media_push_pending = false;
 	cd_media_event   = false;
+	cd_media_swap_absent   = false;
+	cd_media_swap_ready_ms = 0;
 	toc_point_count  = 0;
 	toc_push_idx     = -1;
 	toc_push_last_ms = 0;
@@ -1369,6 +1382,11 @@ void akiko_cd32_poll(void)
 	const cd_media_level_t level = mounted ? CD_MEDIA_PRESENT : CD_MEDIA_ABSENT;
 
 	if (level != cd_media_level || cd_media_event) {
+		// A disc arriving on top of a disc. The level does not move, so without
+		// this the announcement is present->present and the guest correctly
+		// treats it as nothing having happened.
+		const bool swap = cd_media_event && (level == CD_MEDIA_PRESENT)
+		                  && (cd_media_level == CD_MEDIA_PRESENT);
 		cd_media_event   = false;
 		cd_data_lba_base = -1;
 		akiko_prefetch_invalidate();
@@ -1379,6 +1397,7 @@ void akiko_cd32_poll(void)
 		toc_push_idx     = -1;
 		cd_media_level   = level;
 		cd_media_push_pending = true;
+		if (swap) cd_media_swap_absent = true;
 		if (level == CD_MEDIA_PRESENT) akiko_build_toc();
 		akiko_diag("[akiko] media level -> %s (cd_init=%u, announce pending)",
 		           (level == CD_MEDIA_PRESENT) ? "present" : "absent",
@@ -1448,7 +1467,23 @@ void akiko_cd32_poll(void)
 		return;
 	}
 
-	if (cd_media_push_pending && cd_initialized >= 2 && rx_idle) {
+	// The removal half of a swap, sent before the arrival even though a disc is
+	// mounted, so cd_media_present() is not the source of the status here.
+	if (cd_media_swap_absent && cd_initialized >= 2 && rx_idle) {
+		uint8_t r[2];
+		r[0] = 0x0a;
+		r[1] = 0x00;
+		akiko_send_response(r, 2);
+		cd_media_swap_absent   = false;
+		cd_media_swap_ready_ms = (uint32_t)GetTimer(AKIKO_SWAP_SETTLE_MS);
+		akiko_diag("[akiko] swap: media-status push opcode=0x0a status=0x00 "
+		           "(removal edge, arrival held %u ms)", AKIKO_SWAP_SETTLE_MS);
+		return;
+	}
+
+	if (cd_media_push_pending && cd_initialized >= 2 && rx_idle
+	    && (!cd_media_swap_ready_ms || CheckTimer(cd_media_swap_ready_ms))) {
+		cd_media_swap_ready_ms = 0;
 		uint8_t r[2];
 		r[0] = 0x0a;
 		r[1] = cd_media_present() ? 0x01 : 0x00;

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -144,11 +144,15 @@ static int32_t cd_cdda_lba_next = -1;
 static int32_t cd_cdda_lba_end  = -1;
 static drive_t *cd_cdda_drv     = NULL;
 
-static bool     cd_last_mounted     = false;
+typedef enum {
+	CD_MEDIA_UNKNOWN = -1,
+	CD_MEDIA_ABSENT  = 0,
+	CD_MEDIA_PRESENT = 1
+} cd_media_level_t;
 
-static bool     g_akiko_pending_minimig_reset = false;
-
-static uint8_t  cd_post_info_media_push_pending = 0;
+static cd_media_level_t cd_media_level = CD_MEDIA_UNKNOWN;
+static bool     cd_media_push_pending = false;
+static bool     cd_media_event        = false;
 
 #define AKIKO_TOC_REPEAT       3
 #define AKIKO_TOC_PUSH_PERIOD_MS 20
@@ -207,6 +211,11 @@ static inline bool cd32_active(void)
 static bool cd_is_mounted(void)
 {
 	return cd_find_drive() != NULL;
+}
+
+static inline bool cd_media_present(void)
+{
+	return cd_media_level == CD_MEDIA_PRESENT;
 }
 
 static uint16_t akiko_read_status(void)
@@ -387,6 +396,7 @@ static void cmd_info(const uint8_t *cmd)
 	memcpy(&r[2], AKIKO_FIRMWARE, 18);
 	akiko_send_response(r, 20);
 	cd_initialized = 2;
+	cd_media_push_pending = true;
 	akiko_dbg("INFO -> initialized=2\n");
 	akiko_build_toc();
 }
@@ -407,7 +417,7 @@ static void cmd_stop(const uint8_t *cmd)
 {
 	uint8_t r[2];
 	r[0] = cmd[0];
-	r[1] = cd_is_mounted() ? 0x00 : (CH_ERR_NODISK | cd_door);
+	r[1] = cd_media_present() ? 0x00 : (CH_ERR_NODISK | cd_door);
 	cd_playing = 0;
 	cd_paused = 0;
 	cd_data_lba_base = -1;
@@ -424,7 +434,7 @@ static void cmd_pause(const uint8_t *cmd)
 {
 	uint8_t r[2];
 	r[0] = cmd[0];
-	if (!cd_is_mounted()) {
+	if (!cd_media_present()) {
 		r[1] = CH_ERR_NODISK | cd_door;
 	} else {
 		r[1] = (cd_playing ? CDS_PLAYING : 0) | cd_door;
@@ -433,21 +443,21 @@ static void cmd_pause(const uint8_t *cmd)
 	toc_push_last_ms = 0;
 	cd_paused = 1;
 	akiko_send_response(r, 2);
-	akiko_dbg("PAUSE (playing=%d, mounted=%d)\n", cd_playing, cd_is_mounted());
+	akiko_dbg("PAUSE (playing=%d, present=%d)\n", cd_playing, cd_media_present());
 }
 
 static void cmd_unpause(const uint8_t *cmd)
 {
 	uint8_t r[2];
 	r[0] = cmd[0];
-	if (!cd_is_mounted()) {
+	if (!cd_media_present()) {
 		r[1] = CH_ERR_NODISK | cd_door;
 	} else {
 		r[1] = (cd_playing ? CDS_PLAYING : 0) | cd_door;
 	}
 	cd_paused = 0;
 	akiko_send_response(r, 2);
-	akiko_dbg("UNPAUSE (playing=%d, mounted=%d)\n", cd_playing, cd_is_mounted());
+	akiko_dbg("UNPAUSE (playing=%d, present=%d)\n", cd_playing, cd_media_present());
 }
 
 static int cdrom_speed = 1;
@@ -464,7 +474,7 @@ static void cmd_multi(const uint8_t *cmd)
 		cdrom_speed = new_speed;
 	}
 
-	if (!cd_is_mounted()) {
+	if (!cd_media_present()) {
 		r[1] = 0x01;
 		akiko_send_response(r, 2);
 		akiko_dbg("PLAY: no disk\n");
@@ -1269,6 +1279,8 @@ static void akiko_handle_sec_req(void)
 
 void akiko_cd32_set_cd_path(const char *path)
 {
+	cd_media_event = true;
+
 	char new_path[256] = {0};
 	if (path && *path) {
 		compute_save_path(path, new_path, sizeof(new_path));
@@ -1324,13 +1336,14 @@ void akiko_cd32_init(void)
 	cd_cdda_lba_next = -1;
 	cd_cdda_lba_end  = -1;
 	cd_cdda_drv      = NULL;
-	cd_last_mounted  = false;
+	cd_media_level   = CD_MEDIA_UNKNOWN;
+	cd_media_push_pending = false;
+	cd_media_event   = false;
 	toc_point_count  = 0;
 	toc_push_idx     = -1;
 	toc_push_last_ms = 0;
 
 	akiko_prefetch_invalidate();
-	cd_post_info_media_push_pending = 0;
 
 	cd_save_dirty_observed = false;
 	cd_save_load_failed = false;
@@ -1357,19 +1370,29 @@ static void akiko_diag(const char *fmt, ...)
 
 void akiko_cd32_poll(void)
 {
+	const bool mounted = cd32_active() && cd_is_mounted();
+	const cd_media_level_t level = mounted ? CD_MEDIA_PRESENT : CD_MEDIA_ABSENT;
+
+	if (level != cd_media_level || cd_media_event) {
+		cd_media_event   = false;
+		cd_data_lba_base = -1;
+		akiko_prefetch_invalidate();
+		cd_cdda_lba_next = -1;
+		cd_cdda_lba_end  = -1;
+		cd_cdda_drv      = NULL;
+		toc_point_count  = 0;
+		toc_push_idx     = -1;
+		cd_media_level   = level;
+		cd_media_push_pending = true;
+		if (level == CD_MEDIA_PRESENT) akiko_build_toc();
+		akiko_diag("[akiko] media level -> %s (cd_init=%u, announce pending)",
+		           (level == CD_MEDIA_PRESENT) ? "present" : "absent",
+		           cd_initialized);
+	}
+
 	if (!cd32_active()) return;
 
 	usleep(20);
-
-	bool mounted = cd_is_mounted();
-
-	if (g_akiko_pending_minimig_reset) {
-		g_akiko_pending_minimig_reset = false;
-		akiko_diag("[akiko] mediachange: BIOS was stuck on no-CD splash, "
-		           "triggering minimig_reset()");
-		minimig_reset();
-		return;
-	}
 
 	static bool first_poll = true;
 	if (first_poll) {
@@ -1406,39 +1429,6 @@ void akiko_cd32_poll(void)
 	}
 #endif
 
-	static bool media_absent_push_pending = false;
-	static bool mediachanged_push_pending = false;
-	static bool had_prior_unmount = false;
-	if (mounted != cd_last_mounted) {
-		cd_data_lba_base = -1;
-		akiko_prefetch_invalidate();
-		cd_cdda_lba_next = -1;
-		cd_cdda_lba_end  = -1;
-		cd_cdda_drv      = NULL;
-		toc_point_count  = 0;
-		toc_push_idx     = -1;
-		if (!mounted) {
-			media_absent_push_pending = true;
-			mediachanged_push_pending = false;
-			had_prior_unmount = true;
-		} else {
-			media_absent_push_pending = false;
-			akiko_build_toc();
-			if (cd_initialized >= 2) {
-				if (had_prior_unmount) {
-					mediachanged_push_pending = true;
-				} else {
-					g_akiko_pending_minimig_reset = true;
-					mediachanged_push_pending = false;
-				}
-			}
-		}
-		cd_last_mounted = mounted;
-		akiko_diag("[akiko] media change -> mounted=%d cd_init=%u (absent=%d, mediachanged=%d)",
-		           mounted, cd_initialized,
-		           media_absent_push_pending, mediachanged_push_pending);
-	}
-
 	uint16_t status = akiko_read_status();
 #if AKIKO_CD32_DEBUG
 	static uint16_t last_status = 0xffff;
@@ -1451,35 +1441,28 @@ void akiko_cd32_poll(void)
 #endif
 	const bool rx_idle = !(status & AKIKO_STATUS_RX_BUSY);
 
-	if (mounted && cd_initialized == 0 && rx_idle) {
-		uint8_t r[2];
-		r[0] = 0x0a;
-		r[1] = 0x01;
-		akiko_send_response(r, 2);
+	if (cd_initialized == 0 && rx_idle) {
+		if (cd_media_present()) {
+			uint8_t r[2];
+			r[0] = 0x0a;
+			r[1] = 0x01;
+			akiko_send_response(r, 2);
+			akiko_diag("[akiko] auto-init media-status push: opcode=0x0a status=0x01");
+		}
 		cd_initialized = 1;
-		akiko_diag("[akiko] auto-init media-status push: opcode=0x0a status=0x01 (cd_initialized=1)");
+		return;
 	}
 
-	if (mediachanged_push_pending && mounted && cd_initialized >= 2 && rx_idle) {
+	if (cd_media_push_pending && cd_initialized >= 2 && rx_idle) {
 		uint8_t r[2];
 		r[0] = 0x0a;
-		r[1] = 0x01;
+		r[1] = cd_media_present() ? 0x01 : 0x00;
 		akiko_send_response(r, 2);
-		mediachanged_push_pending = false;
+		cd_media_push_pending = false;
 		akiko_build_toc();
-		akiko_diag("[akiko] mediachange push: opcode=0x0a status=0x01 (TOC rebuilt 2x)");
+		akiko_diag("[akiko] media-status push: opcode=0x0a status=0x%02x", r[1]);
+		return;
 	}
-
-	if (media_absent_push_pending && !mounted && rx_idle) {
-		uint8_t r[2];
-		r[0] = 0x0a;
-		r[1] = 0x00;
-		akiko_send_response(r, 2);
-		media_absent_push_pending = false;
-		akiko_diag("[akiko] eject media-status push: opcode=0x0a status=0x00");
-	}
-
-	(void)cd_post_info_media_push_pending;
 
 	if (cd_initialized == 2 && toc_push_idx >= 0 && rx_idle) {
 		uint32_t now_ms = (uint32_t)GetTimer(0);

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -1140,7 +1140,7 @@ static int akiko_prefetch_get(drive_t *drv, uint32_t lba, uint8_t *out_buf)
 	return 0;
 }
 
-static void akiko_handle_sec_req(void)
+static bool akiko_handle_sec_req(void)
 {
 	struct timespec ts0, ts1, ts2, ts3;
 	static int64_t phase_a_us = 0, phase_b_us = 0, phase_c_us = 0;
@@ -1163,24 +1163,18 @@ static void akiko_handle_sec_req(void)
 
 	if (cd_data_lba_base == -1) {
 		akiko_dbg("sec_req but no data read armed (counter=%u)\n", counter);
-		memset(buf, 0, sizeof(buf));
-		akiko_push_sector(buf);
-		return;
+		return false;
 	}
 
 	drive_t *drv = cd_find_drive();
 	if (!drv) {
 		akiko_dbg("sec_req but no CD drive (counter=%u)\n", counter);
-		memset(buf, 0, sizeof(buf));
-		akiko_push_sector(buf);
-		return;
+		return false;
 	}
 
 	int32_t signed_lba = cd_data_lba_base + (int32_t)counter;
 	if (signed_lba < 0) {
-		memset(buf, 0, sizeof(buf));
-		akiko_push_sector(buf);
-		return;
+		return false;
 	}
 	uint32_t lba = (uint32_t)signed_lba;
 
@@ -1195,7 +1189,7 @@ static void akiko_handle_sec_req(void)
 		}
 		memset(buf, 0, sizeof(buf));
 		akiko_push_sector(buf);
-		return;
+		return true;
 	}
 
 	{
@@ -1226,7 +1220,7 @@ static void akiko_handle_sec_req(void)
 				held_audio_lba = UINT32_MAX;
 				held_count = 0;
 			}
-			return;
+			return false;
 		}
 	}
 
@@ -1240,12 +1234,12 @@ static void akiko_handle_sec_req(void)
 		akiko_diag("[akiko] sec_req lba=%u %s (retry %u/%u)", lba,
 		           (rc == -1) ? "prefetch FAIL" : "cached invalid",
 		           fail_count, MAX_FAIL_RETRIES);
-		if (fail_count < MAX_FAIL_RETRIES) return;
+		if (fail_count < MAX_FAIL_RETRIES) return false;
 		akiko_diag("[akiko] sec_req lba=%u retry cap reached — push silence, advance", lba);
 		fail_lba = UINT32_MAX;
 		memset(buf, 0, sizeof(buf));
 		akiko_push_sector(buf);
-		return;
+		return true;
 	}
 	clock_gettime(CLOCK_MONOTONIC, &ts2);
 
@@ -1275,6 +1269,7 @@ static void akiko_handle_sec_req(void)
 		phase_a_us = phase_b_us = phase_c_us = 0;
 		bucket_count = 0;
 	}
+	return true;
 }
 
 void akiko_cd32_set_cd_path(const char *path)
@@ -1527,8 +1522,7 @@ void akiko_cd32_poll(void)
 	}
 
 	if (status & AKIKO_STATUS_SEC_REQ) {
-		akiko_handle_sec_req();
-		return;
+		if (akiko_handle_sec_req()) return;
 	}
 
 	if (!(status & AKIKO_STATUS_REQ)) return;


### PR DESCRIPTION
Four commits against `343c75c`. Together they make a CD32/CDTV disc insert, eject and swap behave as media changes rather than as reasons to reboot the Amiga. Each commit carries its own reasoning; the short version:

**`minimig: report media state to the CD32 BIOS instead of resetting the machine`** — the bridge could not distinguish "drive empty" from "drive state not yet known", so the first insert after boot had no transition to report and fell back to `minimig_reset()`. It now tracks a three-state media level and sends the unsolicited `0A 00` / `0A 01` media-status frame that a real drive sends, which is what the BIOS is actually waiting on.

**`minimig: do not reboot the machine when a disc is ejected from the start menu`** — the Start CD32/CDTV Game selectors are opened `SCANO_UMOUNT`, so backspace returns an empty path meaning eject. Both handlers ran their normal body on it: applied `CONFIG_PRESET_CD32`/`_CDTV` over the user's settings and reset. The `..._SELECTED` handlers already treated the same keypress correctly.

**`akiko: stop delivering zero-filled sectors as successful reads`** — `akiko_handle_sec_req()` pushed 2352 zero bytes whenever it had nothing to deliver, advancing `cdrom_sector_counter` so `cd.device` booked a garbage sector as a successful read. WinUAE declines instead and leaves the counter unadvanced. Withholding exposed a second bug: a held `SEC_REQ` returned unconditionally and starved the command drain, which two existing decline paths were already hitting.

**`akiko: a disc swap must show the guest the removal, not a second arrival`** — mounting a disc over a mounted disc announced present after present, which is not a media change, so AmigaOS kept serving the old volume from cache. The level does not move across a swap, so the existing test could not tell one from a repeat. The absent edge a physical tray cannot avoid is now synthesised before the arrival.

### Testing

Real hardware (DE10-Nano, Minimig-AGA `dfb9a01`), CD32 ROM 40.60 pair.

- Insert and eject at the CD32 no-disc animation: 8/8 cold boots.
- Disc **swap** under a running AmigaOS booted from a hardfile, so the CD is only data: insert and swap each announced `0a 00` → `0a 01`, the guest read sectors off the new disc, and the machine did not reset. Previous swap tests all ran with the OS booted from the disc being removed, where the reset is authentic and masked the result.
- First mount into a provably empty drive (fresh process, no image open) announces the arrival only — no synthetic removal.

Note that on a real CD32 an eject **does** reset the machine unless the running software inhibits it, so a reset after a removal is not by itself a regression; these changes are judged on whether the guest is shown the correct edge.

### Caveats — why this is a draft

- `stop delivering zero-filled sectors as successful reads` has had no compatibility run across the game fleet. It was exercised on a normal CD boot (5000+ prefetch hits, no stalls) but that is not the same thing. It is the one commit here I would want more coverage on before merge; it can be dropped without affecting the other three.
- The swap fix holds the arrival for a fixed 700 ms so the removal reaches CDFileSystem first. That interval is a judgement call, not a measured figure.
