### PR TITLE
minimig: the first disc after an eject is announced without a removal edge

### DIFF
--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -1382,11 +1382,8 @@ void akiko_cd32_poll(void)
 	const cd_media_level_t level = mounted ? CD_MEDIA_PRESENT : CD_MEDIA_ABSENT;
 
 	if (level != cd_media_level || cd_media_event) {
-		// A disc arriving on top of a disc. The level does not move, so without
-		// this the announcement is present->present and the guest correctly
-		// treats it as nothing having happened.
 		const bool swap = cd_media_event && (level == CD_MEDIA_PRESENT)
-		                  && (cd_media_level == CD_MEDIA_PRESENT);
+		                  && (cd_initialized >= 2);
 		cd_media_event   = false;
 		cd_data_lba_base = -1;
 		akiko_prefetch_invalidate();


### PR DESCRIPTION
Follow-up to #1279, on top of `cba7300`.

Boot the CD32 core from a CD, eject it, and put the same disc back. The guest
issues no commands and stays on the insert-disc animation. Mount a *different*
disc and it boots in four seconds. That second mount is the workaround people
have been living with, not the drive working.

The announcement the guest ignores is delivered correctly: the receive index
walks through all three bytes, the length register returns to idle, the
interrupt fires. The guest takes the frame and does nothing with it. What the
working mount sends instead is `0a 00`, a 700 ms hold, then `0a 01` — the
removal edge #1279 added for a disc landing on top of another disc.

A real drive cannot take a disc without its tray opening first, so the BIOS has
never had to handle a bare "present" appearing from nowhere, and it does not.
The eject case fell through because the predicate asked whether the *previous*
level was present; after an eject it is genuinely absent, so the code concluded
"not a swap" and announced the arrival in the one form that gets ignored.

The predicate now asks whether the guest is up rather than what the disc was
doing before. `cd_initialized >= 2` means the BIOS has finished initialising,
which excludes the cold boot — a machine booting from a CD still sees a single
arrival and is unchanged.

**Measured on hardware** (DE10-Nano, Minimig CD32 core, no hard disks so the
eject means something), mounting the disc that was just ejected and scoring
only that mount:

| | first mount after eject | workaround second mount |
|---|---|---|
| before | 0 commands, 0 sectors in 30 s | 27 commands, 3 sectors, 4.2 s |
| after | 23 commands, 2 sectors, 2.2 s | unchanged |

8/8 on the fixed binary; the control reproduces the failure. Every trial also
cold-boots the core from a CD, so the unchanged cold-boot path is exercised
eight times in the same run.

Host side only — one line in `support/minimig/akiko_cd32.cpp`, no RTL change,
no matching core PR. The three comment lines removed with it described the
swap-only reading this replaces.
