### PR TITLE
x86: add Z486 core support

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -229,7 +229,9 @@ char is_x86()
 	if (!is_x86_type)
 	{
 		if (!strcasecmp(orig_name, "AO486") ||
-		    !strcasecmp(orig_name, "PC110")
+		    !strcasecmp(orig_name, "PC110") ||
+		    !strcasecmp(orig_name, "Z486") ||
+		    !strcasecmp(orig_name, "Z386")
 		   )
 			is_x86_type = 1;
 		else


### PR DESCRIPTION
This adds Main_MiSTer support for the external
[z486_MiSTer](https://github.com/nand2mario/z486_MiSTer) core.

The patch is intentionally limited to recognizing `Z486` and legacy `Z386` as
x86 cores. Existing AO486 and PC110 behavior is unchanged.

Z486 uses the existing x86 support path for BIOS loading, IDE/floppy image
management, CMOS setup, and the MiSTer menu. RAM-size reporting remains inside
the core's RTC implementation, so Main requires no Z486-specific setup path.

The core is currently maintained as an external project. I expect to submit it
to MiSTer-devel once more of the remaining software-compatibility issues are
resolved.

## Validation

- [x] Clean ARM build of `MiSTer` and `MiSTer.elf`
- [x] Boot Z486 release `20260813` on MiSTer and verify BIOS and DOS startup
- [x] Verify IDE and floppy image selection and persistence on MiSTer
- [x] Verify CMOS reporting for 16, 32, 64, and 128 MB configurations with DOS 7.1
- [x] Boot Z386 release `20260806` through the legacy alias on MiSTer
- [x] Boot AO486 release `20260424` on MiSTer to confirm its existing behavior is unchanged

## Related projects

- CPU: [nand2mario/z486](https://github.com/nand2mario/z486)
- MiSTer core: [nand2mario/z486_MiSTer](https://github.com/nand2mario/z486_MiSTer)
- Forum discussion: [z486 Core (PC 80486)](https://misterfpga.org/viewtopic.php?t=10667)
