### PR TITLE
minimig: fix A2065 CMD doorbell -- ARM still polled the old single-slot register

### DIFF
--- a/support/minimig/minimig_a2065.cpp
+++ b/support/minimig/minimig_a2065.cpp
@@ -87,6 +87,11 @@ static char *a2065_cfg_name(int num)
 static volatile uint8_t *map = NULL;
 static int card_up = 0;
 
+// Local read position in the FPGA's CMD ring (see minimig_a2065_ddr3.h). The
+// FPGA's write index only ever advances; comparing the two as unsigned
+// 32-bit counters is wrap-safe without needing to touch the ring itself.
+static uint32_t cmd_rd_idx = 0;
+
 static const char *iface_name = "eth0";
 static const char *parent_name = "eth0";
 static int mode = 0;
@@ -200,6 +205,26 @@ static uint64_t rd64(unsigned long off)
 static void wr64(unsigned long off, uint64_t val)
 {
 	memcpy((void *)(map + off), &val, 8);
+}
+
+// Current FPGA write index into the CMD ring. Free-running 32-bit counter,
+// only ever incremented by the FPGA — never wraps in practice.
+static uint32_t rd_wptr(void)
+{
+	return (uint32_t)rd64(DDR3_CMD_WPTR_OFF);
+}
+
+// One ring entry: bit0=valid, bits[7:1]=RAP, bits[23:8]=RDP data (see
+// minimig_a2065_ddr3.h). idx is masked to the ring size, not bounds-checked
+// against wptr — callers are responsible for only reading entries the FPGA
+// has actually published.
+static void ring_read_entry(uint32_t idx, uint8_t *rap_out, uint16_t *data_out)
+{
+	unsigned long off = DDR3_CMD_RING_OFF
+	                   + (unsigned long)(idx & DDR3_CMD_RING_MASK) * DDR3_CMD_RING_STRIDE;
+	uint64_t entry = rd64(off);
+	*rap_out  = (uint8_t)((entry >> DDR3_CMD_RAP_SHIFT) & DDR3_CMD_RAP_MASK);
+	*data_out = (uint16_t)((entry >> DDR3_CMD_DATA_SHIFT) & DDR3_CMD_DATA_MASK);
 }
 
 static void push_csr_shadow(void)
@@ -426,7 +451,9 @@ static int a2065_open(void)
 
 	boardram = map + DDR3_BRAM_OFF;
 
-	wr64(DDR3_CMD_OFF, 0);
+	// Start at the ring's current head — do not replay whatever the FPGA
+	// posted before the daemon was ready to read it.
+	cmd_rd_idx = rd_wptr();
 	wr64(DDR3_CSR_OFF, 0);
 	wr64(DDR3_INT_OFF, 0);
 
@@ -468,28 +495,49 @@ static int a2065_open(void)
 
 // One pass of the card's work, called from Main's poll loop.
 //
-// Two jobs: drain any register write the Amiga has posted through the doorbell,
-// and move received frames into its ring. Both are bounded and non-blocking, so
-// the cost per call stays small and predictable.
+// Two jobs: drain any register writes the Amiga has posted through the ring
+// doorbell, and move received frames into its ring. Both are bounded and
+// non-blocking, so the cost per call stays small and predictable.
 //
-// A register write is DTACK-stretched by the FPGA until the doorbell is
-// drained, so the Amiga is held off for as long as it takes to get back here.
-// That is the reason this must not sit behind anything slow.
+// The FPGA never blocks on Main for the doorbell itself (the ring push and
+// its DTACK release are self-contained on the FPGA side — see
+// a2065_ddr3_mailbox.v), but a queued register write only takes effect once
+// this drains it, so CSR state and IDON/interrupt timing still depend on
+// getting back here promptly.
+// One ring's worth per pass. The ring is 256 entries deep — comfortably
+// more than the 68k can post between two poll passes (see the sizing note
+// in a2065_ddr3_mailbox.v) — so this stays bounded without ever falling
+// permanently behind.
+#define CMD_DRAIN_MAX DDR3_CMD_RING_ENTRIES
+
 void a2065_poll(void)
 {
 	if (!card_up) return;
 
-	uint64_t cmd = rd64(DDR3_CMD_OFF);
-	if (cmd & DDR3_CMD_PENDING_BIT)
+	uint32_t wptr = rd_wptr();
+	uint32_t pending = wptr - cmd_rd_idx;   // unsigned subtraction, wrap-safe
+
+	if (pending)
 	{
-		uint8_t  rap_v = (cmd >> DDR3_CMD_RAP_SHIFT) & DDR3_CMD_RAP_MASK;
-		uint16_t data  = (cmd >> DDR3_CMD_DATA_SHIFT) & DDR3_CMD_DATA_MASK;
+		if (pending > CMD_DRAIN_MAX)
+		{
+			// Fell behind by more than the ring holds — the oldest entries
+			// are already overwritten on the FPGA side. Jump to the oldest
+			// one still valid rather than replay stale slots.
+			cmd_rd_idx = wptr - CMD_DRAIN_MAX;
+			pending = CMD_DRAIN_MAX;
+		}
 
-		chip_wput(A2065_RAP_OFF, rap_v);
-		chip_wput(A2065_RDP_OFF, data);
+		for (uint32_t n = 0; n < pending; n++)
+		{
+			uint8_t  rap_v;
+			uint16_t data;
+			ring_read_entry(cmd_rd_idx, &rap_v, &data);
+			cmd_rd_idx++;
 
-		wr64(DDR3_CMD_OFF, 0);
-		__sync_synchronize();
+			chip_wput(A2065_RAP_OFF, rap_v);
+			chip_wput(A2065_RDP_OFF, data);
+		}
 
 		push_csr_shadow();
 		update_int_state();
@@ -555,7 +603,10 @@ void a2065_start(void)
 		}
 	}
 
-	wr64(DDR3_CMD_OFF, 0);
+	// Resync to wherever the FPGA's ring head is right now — a core reset
+	// re-inits the mailbox on its side too, so an old rd_idx would either
+	// stall (behind a wptr that just reset to 0) or replay stale entries.
+	cmd_rd_idx = rd_wptr();
 	wr64(DDR3_CSR_OFF, 0);
 	wr64(DDR3_INT_OFF, 0);
 

--- a/support/minimig/minimig_a2065_ddr3.h
+++ b/support/minimig/minimig_a2065_ddr3.h
@@ -21,16 +21,23 @@
 #define DDR3_BRAM_OFF           0x0000UL
 #define DDR3_BRAM_SIZE          0x8000UL
 
-/* ── CMD: FPGA→ARM doorbell (Avalon 0x1000) ──────────────────────── */
-#define DDR3_CMD_OFF            0x8000UL
-#define DDR3_CMD_PENDING_BIT    (1ULL << 0)
+/* ── CMD ring: FPGA→ARM doorbell (Phase 2 — ring buffer) ──────────
+ * The FPGA never blocks on ARM: each RDP write is pushed into a 256-entry
+ * ring at DDR3_CMD_RING_OFF, then the write index is republished at
+ * DDR3_CMD_WPTR_OFF (see a2065_ddr3_mailbox.v). ARM tracks its own read
+ * index locally and drains whatever is new each poll pass — there is no
+ * ack to write back. Entry format is bit-identical to the old single-slot
+ * doorbell word: bit0=valid (always 1; entries are only ever pushed once
+ * valid), bits[7:1]=RAP, bits[23:8]=RDP data. */
+#define DDR3_CMD_WPTR_OFF       0x8008UL   /* Avalon 0x1001 */
+#define DDR3_CMD_RING_OFF       0x8800UL   /* Avalon 0x1100 */
+#define DDR3_CMD_RING_ENTRIES   256UL
+#define DDR3_CMD_RING_MASK      (DDR3_CMD_RING_ENTRIES - 1)
+#define DDR3_CMD_RING_STRIDE    8UL        /* bytes per 64-bit entry */
 #define DDR3_CMD_RAP_SHIFT      1
 #define DDR3_CMD_RAP_MASK       0x7FULL
 #define DDR3_CMD_DATA_SHIFT     8
 #define DDR3_CMD_DATA_MASK      0xFFFFULL
-
-/* ── CMD_ACK: ARM→FPGA (write 0 to release, Avalon 0x1001) ──────── */
-#define DDR3_CMD_ACK_OFF        0x8008UL
 
 /* ── CSR_SHADOW: ARM→FPGA packed CSR0..CSR3 (Avalon 0x1002) ─────── */
 #define DDR3_CSR_OFF            0x8010UL
@@ -50,8 +57,8 @@
 #define DDR3_MAC_DATA_SHIFT     16
 
 /* ── Avalon equivalents ─────────────────────────────────────────── */
-#define AV_CMD          0x1000
-#define AV_CMD_ACK      0x1001
+#define AV_CMD_WPTR     0x1001
+#define AV_CMD_RING     0x1100
 #define AV_CSR          0x1002
 #define AV_INT          0x1003
 #define AV_RAP_MIRROR   0x1004


### PR DESCRIPTION
## Problem

`addnetinterface a2065` hung the Amiga outright, and LanceTest never completed — on any of eth0/eth1/macvlan, on real hardware with the A2065 core loaded (Minimig-AGA_MiSTer, [PR #215](https://github.com/MiSTer-devel/Minimig-AGA_MiSTer/pull/215)).

## Root cause

The FPGA-side doorbell (`a2065_ddr3_mailbox.v`) is a 256-entry ring buffer: each RAP/RDP write is pushed to `DDR3_CMD_RING` and the write index republished at `DDR3_CMD_WPTR`, specifically so the FPGA never blocks on Main for it.

The ARM-side LANCE emulation (`support/minimig/minimig_a2065.cpp`) was never updated to match this — it still polled the old single-slot doorbell at `DDR3_CMD_OFF`, an address the ring-based mailbox FSM never writes to. Every register write the Amiga posted landed in the ring and was silently never read. `CSR0`'s `IDON` bit never got set (`chip_init()` never ran), so the driver's post-INIT poll for it spun forever — that's the hang. LanceTest fails for the same reason: it does the same STOP/INIT/poll-IDON sequence before anything else can run.

## Fix

Track a local ring read index (`cmd_rd_idx`), synced to the FPGA's current write index on interface open/start (so a late-starting or restarted daemon doesn't replay stale history), and drain every new ring entry each poll pass instead of checking a dead pending bit. Bounded at one ring's worth (256 entries) per pass, matching the ring's own depth assumption; falling behind by more than that jumps to the oldest entry the FPGA hasn't already overwritten rather than replaying stale slots.

Also updated `minimig_a2065_ddr3.h` to describe the ring layout (`DDR3_CMD_WPTR_OFF`, `DDR3_CMD_RING_OFF`) instead of the dead single-slot/ack registers, and corrected a stale comment above `a2065_poll()` that described DTACK-stretch semantics the ring redesign already removed.

## Testing

Built against the Minimig-A2065-sysclean RTL (LANCE Am7990 emulation, same commit as upstream PR #215) on real MiSTer/DE10-Nano hardware:

- LanceTest diags: 5/5 PASS (buffer, config, interrupt, collision, internal loopback)
- `addnetinterface a2065` + DHCP + ping + HTTP download + AmiSpeedTest, clean interface teardown each time — repeated 3x back to back
- Verified on all three delivery modes: eth0 (BPF), eth1 (direct), macvlan

Before this fix: `addnetinterface a2065` hung the Amiga outright, LanceTest never completed, on all three modes.
