### PR TITLE
cdtv_cd: fire STCH on eject too, not just mount

### DIFF
--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -1130,7 +1130,7 @@ void cdtv_cd_set_cd_path(const char *path)
 	cdtv_play_drv      = NULL;
 	cd_finished = has_path ? 1 : 0;
 
-	stch_retries = has_path ? STCH_RETRY_BUDGET : 0;
+	stch_retries = STCH_RETRY_BUDGET;
 	stch_next_ms = GetTimer(0);
 
 	cdtv_dbg("set_cd_path: %s", has_path ? path : "(empty)");


### PR DESCRIPTION
## Summary
- `cdtv_cd_set_cd_path()` only armed the STCH interrupt retry budget on mount (`has_path` true); on eject it zeroed `cd_media` but armed zero retries, so an idle guest never got the status-change interrupt telling it to re-poll STATUS and notice the disc is gone.
- WinUAE's `cdtv.cpp` `ismedia()` poll thread fires `activate_stch` on any transition, either direction — this brings the bridge's host-side behaviour in line with that ground truth. Same bug class as the CD32/Akiko missing-media-status-push fix (#1279).
- One-line fix: arm `stch_retries = STCH_RETRY_BUDGET` unconditionally instead of `has_path ? STCH_RETRY_BUDGET : 0`.

## Test plan
- [x] HW-validated on real hardware: a FIFO test hook driving `ide_open(0, "")` against a live, actively-playing CDTV CDDA guest reproduces the bug pre-fix (zero STCH injects, no guest re-poll) and confirms the fix post-fix (immediate STCH inject, guest-initiated STATUS re-poll showing media absent, STCH retry cadence until the guest acknowledges via opcode 0x82).
- [ ] No compatibility run across the CDTV title fleet yet — opened as a draft pending that.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01PUb4ipv1AvEXxtF9gs6dAf