### PR TITLE
akiko_cd32: support raw cue+bin discs in the CDDA audio path

### DIFF
--- a/ide_cdrom.cpp
+++ b/ide_cdrom.cpp
@@ -1199,6 +1199,16 @@ int cdrom_read_raw_sector(drive_t *drive, uint32_t lba, uint8_t *buf)
 	return -1;
 }
 
+bool cdrom_read_track_raw(track_t *track, uint32_t lba, uint8_t *buf, int buflen)
+{
+	if (!track || !buf) return false;
+	if (!track->f.opened()) return false;
+
+	uint32_t pos = track->skip + (lba - track->start) * track->sectorSize;
+	if (FileSeek(&track->f, pos, SEEK_SET) < 0) return false;
+	return FileReadAdv(&track->f, buf, buflen, -1) == buflen;
+}
+
 static int disc_info(drive_t *drv, uint16_t maxlen)
 {
 	if (!maxlen) return 0;
@@ -1930,11 +1940,8 @@ void ide_cdda_send_sector()
 				read_track = &drv->track[track->number-2];
 
 			}
-			uint32_t pos = read_track->skip + (drv->play_start_lba - read_track->start) * read_track->sectorSize;
-			if (FileSeek(&read_track->f, pos, SEEK_SET))
+			if (!cdrom_read_track_raw(read_track, drv->play_start_lba, cdda_buf, sizeof(cdda_buf)))
 			{
-				FileReadAdv(&read_track->f, cdda_buf, sizeof(cdda_buf), -1);
-			} else {
 				memset(cdda_buf, 0, sizeof(cdda_buf));
 			}
 		}

--- a/ide_cdrom.h
+++ b/ide_cdrom.h
@@ -9,6 +9,7 @@ void cdrom_mode_select(ide_config *ide);
 void ide_cdda_send_sector();
 
 int cdrom_read_raw_sector(struct drive_t *drive, uint32_t lba, uint8_t *buf);
+bool cdrom_read_track_raw(struct track_t *track, uint32_t lba, uint8_t *buf, int buflen);
 
 const char* cdrom_parse(uint32_t num, const char *filename);
 void cdrom_close_chd(drive_t *drv);

--- a/support/minimig/akiko_cd32.cpp
+++ b/support/minimig/akiko_cd32.cpp
@@ -933,7 +933,7 @@ static void akiko_push_sector(const uint8_t *buf)
 
 static bool cd_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
 {
-	if (!drv || !drv->chd_f || !buf2352) return false;
+	if (!drv || !buf2352) return false;
 
 	bool index0 = false;
 	track_t *track = NULL;
@@ -951,18 +951,24 @@ static bool cd_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
 			break;
 		}
 	}
-	(void)index0;
 
 	if (!track) return false;
 	if (track->attr & 0x40) return false;
 	if (track->sectorSize != AKIKO_CDDA_BYTES) return false;
 
-	uint32_t chd_lba = lba + track->chd_offset;
-	if (mister_chd_read_sector(drv->chd_f, chd_lba, 0, 0,
-	                           AKIKO_CDDA_BYTES, buf2352,
-	                           drv->chd_hunkbuf, &drv->chd_hunknum)
-	    != CHDERR_NONE) {
-		return false;
+	if (drv->chd_f) {
+		return cdrom_read_raw_sector(drv, lba, buf2352) == 0;
+	}
+
+	track_t *read_track = track;
+	if (index0 && track->number > 1) {
+		read_track = &drv->track[track->number - 2];
+	}
+	if (!cdrom_read_track_raw(read_track, lba, buf2352, AKIKO_CDDA_BYTES)) return false;
+
+	int16_t *samples = (int16_t *)buf2352;
+	for (int i = 0; i < AKIKO_CDDA_BYTES / 2; i++) {
+		samples[i] = (int16_t)bswap_16((uint16_t)samples[i]);
 	}
 	return true;
 }

--- a/support/minimig/cdtv_cd.cpp
+++ b/support/minimig/cdtv_cd.cpp
@@ -196,7 +196,7 @@ static void cdtv_push_sector(const uint8_t *buf, int len)
 
 static bool cdtv_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
 {
-	if (!drv || !drv->chd_f || !buf2352) return false;
+	if (!drv || !buf2352) return false;
 
 	track_t *track = NULL;
 	int real_tracks = drv->track_cnt > 0 ? drv->track_cnt - 1 : 0;
@@ -211,12 +211,22 @@ static bool cdtv_read_audio_sector(drive_t *drv, uint32_t lba, uint8_t *buf2352)
 	if (track->attr & 0x40) return false;
 	if (track->sectorSize != CDTV_CDDA_BYTES) return false;
 
-	uint32_t chd_lba = lba + track->chd_offset;
-	if (mister_chd_read_sector(drv->chd_f, chd_lba, 0, 0,
-	                           CDTV_CDDA_BYTES, buf2352,
-	                           drv->chd_hunkbuf, &drv->chd_hunknum)
-	    != CHDERR_NONE) {
-		return false;
+	if (drv->chd_f) {
+		uint32_t chd_lba = lba + track->chd_offset;
+		if (mister_chd_read_sector(drv->chd_f, chd_lba, 0, 0,
+		                           CDTV_CDDA_BYTES, buf2352,
+		                           drv->chd_hunkbuf, &drv->chd_hunknum)
+		    != CHDERR_NONE) {
+			return false;
+		}
+		return true;
+	}
+
+	if (!cdrom_read_track_raw(track, lba, buf2352, CDTV_CDDA_BYTES)) return false;
+
+	int16_t *samples = (int16_t *)buf2352;
+	for (int i = 0; i < CDTV_CDDA_BYTES / 2; i++) {
+		samples[i] = (int16_t)bswap_16((uint16_t)samples[i]);
 	}
 	return true;
 }
@@ -618,8 +628,8 @@ static void cdtv_dispatch(void)
 			uint16_t nsec  = ((uint16_t)cmd_buf[4] <<  8) | cmd_buf[5];
 
 			drive_t *drv = cdtv_find_drive();
-			if (!drv || !drv->chd_f) {
-				cdtv_dbg("READ DATA lba=%u nsec=%u — no drive/chd", lba, nsec);
+			if (!drv) {
+				cdtv_dbg("READ DATA lba=%u nsec=%u — no drive", lba, nsec);
 				cd_error    = 1;
 				cd_finished = 1;
 				rlen        = 0;


### PR DESCRIPTION
cd_read_audio_sector() required drv->chd_f unconditionally, so any CD32
disc mounted via .cue+.bin (never sets chd_f - only load_chd_file()
does) silently produced zero CD audio; the caller treats a false return
as "push silence".

For the CHD case, delegate to the existing cdrom_read_raw_sector() in
ide_cdrom.cpp, which already handles it. For the raw case, add a new
shared cdrom_read_track_raw() helper (also used to de-duplicate
ide_cdda_send_sector()'s own copy of this seek/read logic) that reads
straight from the track's own file, applying the same pregap
(index0-track-redirect) handling ide_cdda_send_sector() already relies
on. Raw CDDA samples also need a byte-swap that CHD-sourced samples
don't - ide_cdda_send_sector() already swaps only its CHD read for
exactly this reason - so cd_read_audio_sector() swaps its raw-path
output to match.

Confirmed on real hardware: CD32 CD audio now plays correctly for a
cue+bin-mounted disc.
