### PR TITLE
minimig: let the CPU selector reach the 020 stock-speed setting

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -6357,6 +6357,7 @@ void HandleUI(void)
 		m = 0;
 		strcpy(s, " CPU      : ");
 		strcat(s, config_cpu_msg[minimig_config.cpu & 0x03]);
+		if ((minimig_config.cpu & 0x23) == 0x23) strcat(s, " 14MHz");
 		OsdWrite(m++, s, menusub == 0, 0);
 		strcpy(s, " D-Cache  : ");
 		strcat(s, (minimig_config.cpu & 16) ? "On" : "Off");
@@ -6426,18 +6427,15 @@ void HandleUI(void)
 		{
 			if (menusub == 0)
 			{
-				int cpu = minimig_config.cpu & 3;
-				if (minus)
-				{
-					cpu = (cpu == 0) ? 3 : (cpu == 3) ? 1 : 0;
-				}
-				else
-				{
-					cpu = (cpu == 0) ? 1 : (cpu == 1) ? 3 : 0;
-				}
+				static const unsigned char cpu_steps[4] = { 0, 1, 3, 0x23 };
+				int step = ((minimig_config.cpu & 3) == 0) ? 0 :
+				           ((minimig_config.cpu & 3) == 1) ? 1 :
+				           (minimig_config.cpu & 0x20) ? 3 : 2;
+
+				step = (step + (minus ? 3 : 1)) & 3;
 
 				menustate = MENU_MINIMIG_CHIPSET1;
-				minimig_config.cpu = (minimig_config.cpu & 0xfc) | cpu;
+				minimig_config.cpu = (minimig_config.cpu & 0xdc) | cpu_steps[step];
 				minimig_ConfigCPU(minimig_config.cpu);
 			}
 			else if (menusub == 1 && (minimig_config.cpu & 0x2))

--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -828,7 +828,7 @@ void minimig_ConfigMemory(unsigned char memory)
 
 void minimig_ConfigCPU(unsigned char cpu)
 {
-	spi_uio_cmd8(UIO_MM2_CPU, cpu & 0x1f);
+	spi_uio_cmd8(UIO_MM2_CPU, cpu & 0x3f);
 }
 
 void minimig_ConfigChipset(mm_configTYPE *config)


### PR DESCRIPTION
Minimig has carried an 020 stock-speed throttle since "Implement CD32 and CDTV" — `cachecfg[3]` in `rtl/cpu_wrapper.v`, fed from CPU config byte bit 5. **Nothing here can turn it on.** `minimig_ConfigCPU` masks the byte with `0x1f`, so bit 5 is dropped before it reaches the FPGA, and no menu row sets it. The feature is wired end to end in the RTL and unreachable from the UI.

Two changes:

```diff
-	spi_uio_cmd8(UIO_MM2_CPU, cpu & 0x1f);
+	spi_uio_cmd8(UIO_MM2_CPU, cpu & 0x3f);
```

and the bit gets a home in the existing CPU row rather than a new one.

### Why not a new menu row

`MENU_MINIMIG_CHIPSET1` already draws all sixteen OSD lines — fifteen items plus `STD_BACK` at `OsdGetSize() - 1`. An extra row pushes Back off the screen, and every `menusub` index below the insertion point shifts. So the CPU selector gains a fourth stop instead:

```
68000 -> 68010 -> 68020 -> 68020 14MHz -> 68000
```

The new stop is 68020 with bit 5 set, so the throttle is only reachable on the CPU it was calibrated for, with no separate greyed-out row. Stepping the selector always rewrites bit 5 from the table, so a config that arrives with the bit set on a non-020 heals on the next press. `menumask`, the row count and every other `menusub` index are unchanged.

### What it does on hardware

The 020 runs about 4.8x faster than a stock A1200. The throttle divides the pipeline rate by five, which brings the CPU-bound rows of the Copperline timing suite from **0.209x** real-A1200 wall time to **1.041x**. Measured on a DE10-Nano against a stock A1200 (68EC020 @ 14.19 MHz, AGA, 2 MB chip, KS 3.2.3).

Verified through this exact path — one bitstream, two configs differing only in CPU config bit 5, so the run exercises the CFG byte, the widened mask, `UIO_MM2_CPU`, `t_cpu_config[5]`, `cachecfg[3]` and the cooldown together. CPU-only rows moved by **4.979x**; the four chipset-paced control rows stayed within **0.0019** of unity against a pre-registered band of 0.02.

### Honest limits

It paces the CPU pipeline only, so it is an approximate CPU speed rather than an A1200 bus model — loops that interleave CPU work with chip access are not slowed the way silicon slows them. Per-instruction error against silicon still spans about +11% to -9%, because the core is not a 68EC020. The `14MHz` label names the machine being imitated; it is not a claim of cycle accuracy.

### Depends on

`MiSTer-devel/Minimig-AGA_MiSTer` — mainline reloads the cooldown with `4'd9`, which divides by ten and lands at **half** A1200 speed. Enabling this option against an unfixed core gives 2.081x. The one-constant fix is filed as a companion PR; the two need to go in together.

Companion RTL PR: MiSTer-devel/Minimig-AGA_MiSTer#233

