### PR TITLE
minimig: repair the reserved CPU value when loading a config

### DIFF
--- a/support/minimig/minimig_config.cpp
+++ b/support/minimig/minimig_config.cpp
@@ -587,6 +587,8 @@ int minimig_cfg_load(int num)
 		BootPrintEx(">>> No config found. Using defaults. <<<");
 	}
 
+	if ((minimig_config.cpu & 0x03) == 0x02) minimig_config.cpu |= 0x01;
+
 	a2065_cfg_set(minimig_config.a2065_mode);
 
 	for (int i = 0; i < 4; i++)


### PR DESCRIPTION
`config_cpu_msg[]` reserves index 2 (`"-----"`), but nothing stops a stored config from carrying it. The generic load branch in `minimig_cfg_load` only sanity-checks `floppy.drives`, and the back-compat branch above it matches `sizeof(configTYPE_old)` **exactly**, so a config written by a fork with a differently-sized struct misses back-compat, falls through to the generic branch, and has its `cpu` byte copied verbatim.

`TG68KdotC_Kernel` decodes the two bits independently rather than as an enum:

- `cpu(1)` — 68020 addressing modes and instruction set (`TG68KdotC_Kernel.vhd:855, 1700, 2007`)
- `cpu(0)` — 68010/68020 exception stack frame format and SR behaviour (`:468, 2039`)

So value `2` is 68020 code with 68000-format exception frames. That is not a CPU that has ever existed, and it is worse than a hard failure would be: it boots, the OSD shows `-----`, and then it falls over in whatever first takes an exception.

### How this was found

A 5216-byte config in `config/minimig.cfg` — the slot that loads automatically at core start — held `cpu = 0x12`. Every other field in it was byte-identical to a working slot. Symptoms were a Kickstart 3.x HDF that would not mount at all, plus scattered library load failures on things that were fine a moment earlier, which sent me looking at IDE and at the CPU clock for some time before I diffed the config bytes.

### Why promote to 3 rather than clamp to 0

Bit 1 is already set, and it does double duty — it is also the selector for the large fast-RAM size table:

```c
config_memory_fast_msg[(minimig_config.cpu >> 1) & 1][...]
```

Clearing it would silently relayout memory on a config the user has been running. Setting bit 0 changes only the thing that is actually invalid.

Placed after the defaults block so the boot-screen `CPU:` line prints the repaired value.
