### PR TITLE
PDP2011 front panel banner and SSH ODT

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -820,14 +820,15 @@ static void printSysInfo()
 
 static int  firstmenu = 0;
 static int  adjvisible;
+static int  menu_top_offset = 0;
 
 static void MenuWrite(unsigned char n, const char *s = "", unsigned char invert = 0, unsigned char stipple = 0, int arrow = 0)
 {
-	int row = n - firstmenu;
+	int row = n - firstmenu + menu_top_offset;
 
-	if (row < 0)
+	if (row < menu_top_offset)
 	{
-		if (invert) adjvisible = row;
+		if (invert) adjvisible = row - menu_top_offset;
 		return;
 	}
 
@@ -838,7 +839,7 @@ static void MenuWrite(unsigned char n, const char *s = "", unsigned char invert 
 	}
 
 	OsdSetArrow(arrow);
-	OsdWriteOffset(row, s, invert, stipple, 0, (row == 0 && firstmenu) ? 17 : (row == (OsdGetSize()-1) && !arrow) ? 16 : 0, 0);
+	OsdWriteOffset(row, s, invert, stipple, 0, (row == menu_top_offset && firstmenu) ? 17 : (row == (OsdGetSize()-1) && !arrow) ? 16 : 0, 0);
 }
 
 const char* get_rbf_name_bootcore(char *str)
@@ -1023,8 +1024,8 @@ static void pdp2011_front_panel_banner(int force)
 	if (!is_pdp2011() || page != 2)
 		return;
 	if (pdp2011_panel_banner(lines, force)) {
-		OsdWrite(OsdGetSize() - 3, lines[0], 0, 0);
-		OsdWrite(OsdGetSize() - 2, lines[1], 0, 0);
+		OsdWrite(0, lines[0], 0, 0);
+		OsdWrite(1, lines[1], 0, 0);
 	}
 }
 
@@ -1931,6 +1932,7 @@ void HandleUI(void)
 			menumask = 0;
 
 			OsdSetTitle(page ? title : user_io_get_core_name());
+			menu_top_offset = (is_pdp2011() && page == 2) ? 2 : 0;
 
 			dip_submenu = -1;
 			manual_submenu = -1;
@@ -2238,6 +2240,8 @@ void HandleUI(void)
 			if (!adjvisible) break;
 			firstmenu += adjvisible;
 		}
+
+		menu_top_offset = 0;
 
 		if (!entry)
 		{

--- a/menu.cpp
+++ b/menu.cpp
@@ -63,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "joymapping.h"
 #include "recent.h"
 #include "support.h"
+#include "support/pdp2011/panel.h"
 #include "bootcore.h"
 #include "ide.h"
 #include "profiling.h"
@@ -1015,6 +1016,17 @@ static int gun_side = 0;
 static int gun_idx = 0;
 static int32_t gun_pos[4] = {};
 static int page = 0;
+
+static void pdp2011_front_panel_banner(int force)
+{
+	char lines[2][32];
+	if (!is_pdp2011() || page != 2)
+		return;
+	if (pdp2011_panel_banner(lines, force)) {
+		OsdWrite(OsdGetSize() - 3, lines[0], 0, 0);
+		OsdWrite(OsdGetSize() - 2, lines[1], 0, 0);
+	}
+}
 
 static void menu_button_name(int button, char *buf, size_t bsize)
 {
@@ -2237,6 +2249,7 @@ void HandleUI(void)
 
 		parentstate = menustate;
 		menustate = MENU_GENERIC_MAIN3;
+		pdp2011_front_panel_banner(1);
 
 		// set helptext with core display on top of basic info
 		sprintf(helptext_custom, HELPTEXT_SPACER);
@@ -2290,6 +2303,7 @@ void HandleUI(void)
 
 	case MENU_GENERIC_MAIN3:
 		saved_menustate = MENU_GENERIC_MAIN1;
+		pdp2011_front_panel_banner(0);
 
 		// F/S option not found -> deactivate mgl.
 		if (!mgl->done && mgl->item[mgl->current].submenu < 0)

--- a/support/pdp2011/panel.cpp
+++ b/support/pdp2011/panel.cpp
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "panel.h"
+#include "../../hardware.h"
+#include "../../spi.h"
+
+static void oct6(char *dst, unsigned v)
+{
+	for (int i = 5; i >= 0; i--) {
+		dst[i] = '0' + (v & 7);
+		v >>= 3;
+	}
+	dst[6] = 0;
+}
+
+int pdp2011_panel_banner(char lines[2][32], int force)
+{
+	static unsigned long next;
+	static char cache[2][32];
+	static int cached;
+
+	if (!force && cached && next && !CheckTimer(next)) {
+		snprintf(lines[0], 32, "%s", cache[0]);
+		snprintf(lines[1], 32, "%s", cache[1]);
+		return 0;
+	}
+
+	spi_uio_cmd_cont(UIO_PDP_PANEL);
+	uint16_t r7 = spi_w(0);
+	uint16_t psw = spi_w(0);
+	uint16_t ir = spi_w(0);
+	uint16_t flags = spi_w(0);
+	uint16_t data = 0, addr = 0;
+	if (flags & 8) {
+		data = spi_w(0);
+		addr = spi_w(0);
+	}
+	DisableIO();
+
+	next = GetTimer(50);
+
+	char line0[32], line1[32];
+	if (flags & 1) {
+		char pc[7], sw[7], star[7];
+		oct6(pc, r7);
+		oct6(sw, psw);
+		oct6(star, ir);
+		snprintf(line0, sizeof(line0), " PC %s  PSW %s  %s",
+			pc, sw, (flags & 0x8000) ? " RUN" : "HALT");
+		if (flags & 8) {
+			char ma[7], d[7];
+			oct6(ma, addr);
+			oct6(d, data);
+			if (flags & 2)
+				snprintf(line1, sizeof(line1),
+					(flags & 4) ? "*PC %s  MA %s  D   NXM" : "*PC %s  MA %s  D %s",
+					star, ma, d);
+			else
+				snprintf(line1, sizeof(line1),
+					(flags & 4) ? "*PC ------  MA %s  D   NXM" : "*PC ------  MA %s  D %s",
+					ma, d);
+		} else if (flags & 2) {
+			snprintf(line1, sizeof(line1), "*PC %s", star);
+		} else {
+			snprintf(line1, sizeof(line1), "*PC ------");
+		}
+	} else {
+		snprintf(line0, sizeof(line0), " PC ------  PSW ------  ----");
+		snprintf(line1, sizeof(line1), "*PC ------");
+	}
+
+	int changed = !cached || strcmp(cache[0], line0) || strcmp(cache[1], line1);
+	snprintf(cache[0], sizeof(cache[0]), "%s", line0);
+	snprintf(cache[1], sizeof(cache[1]), "%s", line1);
+	cached = 1;
+	snprintf(lines[0], 32, "%s", cache[0]);
+	snprintf(lines[1], 32, "%s", cache[1]);
+	return force || changed;
+}

--- a/support/pdp2011/panel.cpp
+++ b/support/pdp2011/panel.cpp
@@ -1,10 +1,21 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
 
 #include "panel.h"
 #include "../../hardware.h"
 #include "../../spi.h"
+#include "../../user_io.h"
+
+#define ODT_SOCK "/tmp/pdp2011.odt"
 
 static void oct6(char *dst, unsigned v)
 {
@@ -13,6 +24,26 @@ static void oct6(char *dst, unsigned v)
 		v >>= 3;
 	}
 	dst[6] = 0;
+}
+
+struct panel_snap {
+	uint16_t r7, psw, ir, flags, data, addr;
+};
+
+static void panel_read(struct panel_snap *s)
+{
+	spi_uio_cmd_cont(UIO_PDP_PANEL);
+	s->r7 = spi_w(0);
+	s->psw = spi_w(0);
+	s->ir = spi_w(0);
+	s->flags = spi_w(0);
+	s->data = 0;
+	s->addr = 0;
+	if (s->flags & 8) {
+		s->data = spi_w(0);
+		s->addr = spi_w(0);
+	}
+	DisableIO();
 }
 
 int pdp2011_panel_banner(char lines[2][32], int force)
@@ -27,47 +58,38 @@ int pdp2011_panel_banner(char lines[2][32], int force)
 		return 0;
 	}
 
-	spi_uio_cmd_cont(UIO_PDP_PANEL);
-	uint16_t r7 = spi_w(0);
-	uint16_t psw = spi_w(0);
-	uint16_t ir = spi_w(0);
-	uint16_t flags = spi_w(0);
-	uint16_t data = 0, addr = 0;
-	if (flags & 8) {
-		data = spi_w(0);
-		addr = spi_w(0);
-	}
-	DisableIO();
+	struct panel_snap s;
+	panel_read(&s);
 
 	next = GetTimer(50);
 
 	char line0[32], line1[32];
-	if (flags & 1) {
+	if (s.flags & 1) {
 		char pc[7], sw[7], star[7];
-		oct6(pc, r7);
-		oct6(sw, psw);
-		oct6(star, ir);
-		snprintf(line0, sizeof(line0), " PC %s  PSW %s  %s",
-			pc, sw, (flags & 0x8000) ? " RUN" : "HALT");
-		if (flags & 8) {
+		oct6(pc, s.r7);
+		oct6(sw, s.psw);
+		oct6(star, s.ir);
+		snprintf(line0, sizeof(line0), " PC %s PSW %s  %s",
+			pc, sw, (s.flags & 0x8000) ? " RUN" : "HALT");
+		if (s.flags & 8) {
 			char ma[7], d[7];
-			oct6(ma, addr);
-			oct6(d, data);
-			if (flags & 2)
+			oct6(ma, s.addr);
+			oct6(d, s.data);
+			if (s.flags & 2)
 				snprintf(line1, sizeof(line1),
-					(flags & 4) ? "*PC %s  MA %s  D   NXM" : "*PC %s  MA %s  D %s",
+					(s.flags & 4) ? "*PC %s MA %s D   NXM" : "*PC %s MA %s D %s",
 					star, ma, d);
 			else
 				snprintf(line1, sizeof(line1),
-					(flags & 4) ? "*PC ------  MA %s  D   NXM" : "*PC ------  MA %s  D %s",
+					(s.flags & 4) ? "*PC ------ MA %s D   NXM" : "*PC ------ MA %s D %s",
 					ma, d);
-		} else if (flags & 2) {
+		} else if (s.flags & 2) {
 			snprintf(line1, sizeof(line1), "*PC %s", star);
 		} else {
 			snprintf(line1, sizeof(line1), "*PC ------");
 		}
 	} else {
-		snprintf(line0, sizeof(line0), " PC ------  PSW ------  ----");
+		snprintf(line0, sizeof(line0), " PC ------ PSW ------  ----");
 		snprintf(line1, sizeof(line1), "*PC ------");
 	}
 
@@ -78,4 +100,302 @@ int pdp2011_panel_banner(char lines[2][32], int force)
 	snprintf(lines[0], 32, "%s", cache[0]);
 	snprintf(lines[1], 32, "%s", cache[1]);
 	return force || changed;
+}
+
+static void fmt_snap(char *out, size_t n, const struct panel_snap *s)
+{
+	char pc[7], psw[7], ir[7], ma[7], d[7];
+	oct6(pc, s->r7);
+	oct6(psw, s->psw);
+	oct6(ir, s->ir);
+	oct6(ma, s->addr);
+	oct6(d, s->data);
+	snprintf(out, n, "PC %s PSW %s *PC %s MA %s D %s %s%s\n",
+		pc, psw, (s->flags & 2) ? ir : "------",
+		ma, (s->flags & 4) ? "NXM   " : d,
+		(s->flags & 0x8000) ? "RUN" : "HALT",
+		(s->flags & 1) ? "" : " (no panel_dbg)");
+}
+
+static void set_sr(uint32_t v)
+{
+	int sr22 = (v & 017600000) ? 1 : 0;
+	uint16_t lo = (uint16_t)(v & 0177777);
+	user_io_status_set("[38]", sr22);
+	user_io_status_set("[36]", (lo >> 15) & 1);
+	user_io_status_set("[35:33]", (lo >> 12) & 7);
+	user_io_status_set("[32:30]", (lo >> 9) & 7);
+	user_io_status_set("[29:27]", (lo >> 6) & 7);
+	user_io_status_set("[26:24]", (lo >> 3) & 7);
+	user_io_status_set("[23:21]", lo & 7);
+}
+
+static void pulse(const char *opt)
+{
+	user_io_status_set(opt, 0);
+	WaitTimer(2);
+	user_io_status_set(opt, 1);
+	WaitTimer(4);
+	user_io_status_set(opt, 0);
+	WaitTimer(4);
+}
+
+static void ensure_halt(void)
+{
+	user_io_status_set("[16]", 1);
+	WaitTimer(4);
+}
+
+static int parse_oct(const char *s, uint32_t *out)
+{
+	char *end = 0;
+	while (*s == ' ' || *s == '\t') s++;
+	if (!*s) return 0;
+	unsigned long v = strtoul(s, &end, 8);
+	if (end == s) return 0;
+	*out = (uint32_t)v;
+	return 1;
+}
+
+static void odt_reply(int fd, const char *s)
+{
+	if (fd < 0 || !s) return;
+	size_t n = strlen(s);
+	if (n) (void)write(fd, s, n);
+	(void)write(fd, ".\n", 2);
+}
+
+static void odt_cmd(int fd, char *line)
+{
+	char reply[256];
+	struct panel_snap s;
+	uint32_t a = 0, d = 0;
+	char *cmd = line;
+	while (*cmd == ' ' || *cmd == '\t') cmd++;
+	char *arg = cmd;
+	while (*arg && *arg != ' ' && *arg != '\t') arg++;
+	if (*arg) {
+		*arg++ = 0;
+		while (*arg == ' ' || *arg == '\t') arg++;
+	}
+
+	if (!cmd[0] || !strcmp(cmd, "snap") || !strcmp(cmd, "?")) {
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "help")) {
+		odt_reply(fd,
+			"snap halt run cont start\n"
+			"load <oct>  exa  dep <oct>  sr <oct>\n"
+			"peek <oct>  poke <oct> <oct>\n"
+			"r7 <oct>    (17600000 + 177707)\n");
+		return;
+	}
+	if (!strcmp(cmd, "halt")) {
+		user_io_status_set("[16]", 1);
+		WaitTimer(4);
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "run") || !strcmp(cmd, "go")) {
+		/* Leave state_halt with cons_ena=1 so Continue actually runs. */
+		user_io_status_set("[16]", 0);
+		WaitTimer(4);
+		pulse("[17]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "cont") || !strcmp(cmd, "c")) {
+		ensure_halt();
+		pulse("[17]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "start")) {
+		odt_reply(fd, "ERR start resets the CPU; use r7 + cont\n");
+		return;
+	}
+	if (!strcmp(cmd, "sr")) {
+		if (!parse_oct(arg, &a)) { odt_reply(fd, "ERR sr <oct>\n"); return; }
+		set_sr(a);
+		odt_reply(fd, "OK\n");
+		return;
+	}
+	if (!strcmp(cmd, "load") || !strcmp(cmd, "l")) {
+		if (!parse_oct(arg, &a)) { odt_reply(fd, "ERR load <oct>\n"); return; }
+		ensure_halt();
+		set_sr(a);
+		pulse("[19]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "exa") || !strcmp(cmd, "e")) {
+		ensure_halt();
+		pulse("[20]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "dep") || !strcmp(cmd, "d")) {
+		if (!parse_oct(arg, &a)) { odt_reply(fd, "ERR dep <oct>\n"); return; }
+		ensure_halt();
+		set_sr(a);
+		pulse("[37]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "peek")) {
+		if (!parse_oct(arg, &a)) { odt_reply(fd, "ERR peek <oct>\n"); return; }
+		ensure_halt();
+		set_sr(a);
+		pulse("[19]");
+		pulse("[20]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "poke")) {
+		char *sp = arg;
+		while (*sp && *sp != ' ' && *sp != '\t') sp++;
+		if (*sp) *sp++ = 0;
+		while (*sp == ' ' || *sp == '\t') sp++;
+		if (!parse_oct(arg, &a) || !parse_oct(sp, &d)) {
+			odt_reply(fd, "ERR poke <oct> <oct>\n");
+			return;
+		}
+		ensure_halt();
+		set_sr(a);
+		pulse("[19]");
+		set_sr(d);
+		pulse("[37]");
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+	if (!strcmp(cmd, "r7")) {
+		if (!parse_oct(arg, &a)) { odt_reply(fd, "ERR r7 <oct>\n"); return; }
+		ensure_halt();
+		set_sr(017600000 | 0177707);
+		pulse("[19]");
+		set_sr(a & 0177777);
+		pulse("[37]");
+		set_sr(0);
+		panel_read(&s);
+		fmt_snap(reply, sizeof(reply), &s);
+		odt_reply(fd, reply);
+		return;
+	}
+
+	snprintf(reply, sizeof(reply), "ERR unknown '%s'\n", cmd);
+	odt_reply(fd, reply);
+}
+
+static int listen_fd = -1;
+static int client_fd = -1;
+static char inbuf[256];
+static int inlen;
+
+static void odt_close_client(void)
+{
+	if (client_fd >= 0) {
+		close(client_fd);
+		client_fd = -1;
+	}
+	inlen = 0;
+}
+
+static void odt_listen(void)
+{
+	if (listen_fd >= 0) return;
+	unlink(ODT_SOCK);
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) return;
+	int fl = fcntl(fd, F_GETFL, 0);
+	if (fl >= 0) fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+	struct sockaddr_un a;
+	memset(&a, 0, sizeof(a));
+	a.sun_family = AF_UNIX;
+	strncpy(a.sun_path, ODT_SOCK, sizeof(a.sun_path) - 1);
+	if (bind(fd, (struct sockaddr *)&a, sizeof(a)) < 0) {
+		close(fd);
+		return;
+	}
+	chmod(ODT_SOCK, 0666);
+	if (listen(fd, 2) < 0) {
+		close(fd);
+		unlink(ODT_SOCK);
+		return;
+	}
+	listen_fd = fd;
+}
+
+void pdp2011_odt_poll()
+{
+	if (!is_pdp2011()) {
+		if (listen_fd >= 0) {
+			odt_close_client();
+			close(listen_fd);
+			listen_fd = -1;
+			unlink(ODT_SOCK);
+		}
+		return;
+	}
+
+	odt_listen();
+	if (listen_fd < 0) return;
+
+	if (client_fd < 0) {
+		int c = accept(listen_fd, 0, 0);
+		if (c < 0) return;
+		int fl = fcntl(c, F_GETFL, 0);
+		if (fl >= 0) fcntl(c, F_SETFL, fl | O_NONBLOCK);
+		client_fd = c;
+		inlen = 0;
+	}
+
+	char tmp[128];
+	ssize_t n = read(client_fd, tmp, sizeof(tmp));
+	if (n < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+		odt_close_client();
+		return;
+	}
+	if (n == 0) {
+		odt_close_client();
+		return;
+	}
+	for (ssize_t i = 0; i < n; i++) {
+		char ch = tmp[i];
+		if (ch == '\r') continue;
+		if (ch == '\n') {
+			inbuf[inlen] = 0;
+			inlen = 0;
+			if (inbuf[0]) odt_cmd(client_fd, inbuf);
+			else {
+				struct panel_snap s;
+				char reply[256];
+				panel_read(&s);
+				fmt_snap(reply, sizeof(reply), &s);
+				odt_reply(client_fd, reply);
+			}
+			continue;
+		}
+		if (inlen < (int)sizeof(inbuf) - 1)
+			inbuf[inlen++] = ch;
+	}
 }

--- a/support/pdp2011/panel.h
+++ b/support/pdp2011/panel.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stddef.h>
+
+#define UIO_PDP_PANEL 0x50
+
+/* Fill lines[0] (PC/PSW/RUN) and lines[1] (*PC, MA, D). Returns 1 if
+ * either line should be redrawn. */
+int pdp2011_panel_banner(char lines[2][32], int force);

--- a/support/pdp2011/panel.h
+++ b/support/pdp2011/panel.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define UIO_PDP_PANEL 0x50
 
 /* Fill lines[0] (PC/PSW/RUN) and lines[1] (*PC, MA, D). Returns 1 if
  * either line should be redrawn. */
 int pdp2011_panel_banner(char lines[2][32], int force);
+
+/* Service /tmp/pdp2011.odt (Halt/Load/Examine/Deposit/Continue). */
+void pdp2011_odt_poll();

--- a/support/pdp2011/pdp-odt
+++ b/support/pdp2011/pdp-odt
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""SSH front-panel ODT. Talks to MiSTer_pdp2011 at /tmp/pdp2011.odt."""
+import os
+import socket
+import sys
+
+SOCK = "/tmp/pdp2011.odt"
+
+
+def talk(line):
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.connect(SOCK)
+    except OSError as e:
+        sys.stderr.write("pdp-odt: %s (%s). Is MiSTer_pdp2011 running the PDP2011 core?\n" % (SOCK, e))
+        return 2
+    s.sendall((line.strip() + "\n").encode())
+    buf = b""
+    s.settimeout(8)
+    while True:
+        try:
+            chunk = s.recv(4096)
+        except socket.timeout:
+            sys.stderr.write("pdp-odt: timeout\n")
+            return 1
+        if not chunk:
+            break
+        buf += chunk
+        if b"\n.\n" in buf or buf.endswith(b".\n"):
+            break
+    s.close()
+    sys.stdout.write(buf.decode("ascii", "replace"))
+    return 0 if b"\nERR" not in b"\n" + buf else 1
+
+
+def repl():
+    sys.stdout.write("pdp-odt  (help, snap, halt, run, cont, peek <oct>, poke <oct> <oct>, r7 <oct>)\n")
+    while True:
+        try:
+            line = input("odt> ")
+        except (EOFError, KeyboardInterrupt):
+            sys.stdout.write("\n")
+            return 0
+        line = line.strip()
+        if not line:
+            line = "snap"
+        if line in ("q", "quit", "exit"):
+            return 0
+        talk(line)
+
+
+def main():
+    if len(sys.argv) == 1:
+        return repl()
+    return talk(" ".join(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -240,6 +240,14 @@ char is_x86()
 	return (is_x86_type == 1);
 }
 
+static int is_pdp2011_type = 0;
+char is_pdp2011()
+{
+	if (!is_pdp2011_type)
+		is_pdp2011_type = !strcasecmp(orig_name, "PDP2011") ? 1 : 2;
+	return (is_pdp2011_type == 1);
+}
+
 static int is_snes_type = 0;
 char is_snes()
 {
@@ -444,6 +452,7 @@ void user_io_read_core_name()
 {
 	is_menu_type = 0;
 	is_x86_type  = 0;
+	is_pdp2011_type = 0;
 	is_no_type   = 0;
 	is_snes_type = 0;
 	is_sgb_type = 0;

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -42,6 +42,7 @@
 #include "frame_timer.h"
 #include "scaler.h"
 #include "support.h"
+#include "support/pdp2011/panel.h"
 
 static char core_path[1024] = {};
 static char rbf_path[1024] = {};
@@ -3224,6 +3225,9 @@ void user_io_poll()
 	{
 		check_status_change();
 	}
+
+	if (is_pdp2011())
+		pdp2011_odt_poll();
 
 	// sd card emulation
 	if (is_x86() || is_pcxt())

--- a/user_io.h
+++ b/user_io.h
@@ -270,6 +270,7 @@ void diskled_on();
 #define DISKLED_OFF void()
 
 char is_minimig();
+char is_pdp2011();
 char is_sharpmz();
 char is_menu();
 char is_x86();


### PR DESCRIPTION
## Summary
- Live two-line banner on the PDP2011 Front panel OSD page (`UIO_PDP_PANEL` 0x50): PC, PSW, RUN/HALT, *PC, MA, D. Banner sits on rows 0-1 so the Halt/Continue/SR switches stay visible underneath.
- Unix socket `/tmp/pdp2011.odt` for Halt/Load/Examine/Deposit/Continue (`peek`/`poke`/`r7`/`run`) so the core can be debugged from SSH while the KL11 console stays on ttyS1.
- `support/pdp2011/pdp-odt` is the on-box client. Gated on `is_pdp2011()` so other cores are unchanged.

Pairs with the PDP2011 core PR that adds the OSD Front panel page, Deposit, and 22-bit SR.

## Test plan
- [ ] Use a per-core binary (`MiSTer_pdp2011` / `MiSTer_PDP2011`); do not require overwriting `/media/fat/MiSTer`.
- [ ] `load_core` the matching bitstream, mount a disk, watch the Front panel numbers while the console is on S1.
- [ ] From SSH: `pdp-odt snap`, `halt`, `peek 1000` — banner MA/D follow.
- [ ] Other cores' OSD pages are unchanged.


Made with [Cursor](https://cursor.com)