### PR TITLE
Add low latency ULMB 2 compatibility

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -119,7 +119,7 @@ video_info=0
 ; Adjusting is done by changing pixel clock. Not every display supports variable pixel clock.
 ; For proper adjusting and to reduce possible out of range pixel clock, use 60Hz HDMI video
 ; modes as a base even for 50Hz systems.
-; Set to 3 for ULMB 2 support (single buffer with delayed vblank). Widescreen resolutions only.
+; Set to 3 for ULMB 2 support (single buffer with delayed vblank). Requires 16x9 and vrr_mode=0.
 vsync_adjust=0
 
 ; Variable Refresh Rate control

--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -115,6 +115,10 @@ video_info=0
 
 ; Set to 1 for automatic HDMI VSync rate adjust to match original VSync.
 ; Set to 2 for low latency mode (single buffer).
+; This option makes video butter smooth like on original emulated system.
+; Adjusting is done by changing pixel clock. Not every display supports variable pixel clock.
+; For proper adjusting and to reduce possible out of range pixel clock, use 60Hz HDMI video
+; modes as a base even for 50Hz systems.
 ; Set to 3 for ULMB 2 support (single buffer with delayed vblank)
 vsync_adjust=0
 

--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -119,6 +119,13 @@ video_info=0
 ; Adjusting is done by changing pixel clock. Not every display supports variable pixel clock.
 ; For proper adjusting and to reduce possible out of range pixel clock, use 60Hz HDMI video
 ; modes as a base even for 50Hz systems. 
+; Set to 3 for scanrate-locked mode: like 1, but the horizontal scanrate of the
+; video mode is held constant and the refresh difference is absorbed by the
+; vertical front porch instead of the pixel clock. Useful for displays whose
+; backlight strobing (ULMB/ULMB 2 and similar) locks to horizontal scanrate and
+; drops out when it moves. Requires a single global video_mode with enough
+; vertical blanking for the fastest core you run; cores too fast for the mode's
+; scanrate log a warning and fall back to minimum front porch.
 vsync_adjust=0
 
 ; Variable Refresh Rate control

--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -115,17 +115,7 @@ video_info=0
 
 ; Set to 1 for automatic HDMI VSync rate adjust to match original VSync.
 ; Set to 2 for low latency mode (single buffer).
-; This option makes video butter smooth like on original emulated system.
-; Adjusting is done by changing pixel clock. Not every display supports variable pixel clock.
-; For proper adjusting and to reduce possible out of range pixel clock, use 60Hz HDMI video
-; modes as a base even for 50Hz systems. 
-; Set to 3 for scanrate-locked mode: like 1, but the horizontal scanrate of the
-; video mode is held constant and the refresh difference is absorbed by the
-; vertical front porch instead of the pixel clock. Useful for displays whose
-; backlight strobing (ULMB/ULMB 2 and similar) locks to horizontal scanrate and
-; drops out when it moves. Requires a single global video_mode with enough
-; vertical blanking for the fastest core you run; cores too fast for the mode's
-; scanrate log a warning and fall back to minimum front porch.
+; Set to 3 for ULMB 2 support (single buffer with delayed vblank)
 vsync_adjust=0
 
 ; Variable Refresh Rate control

--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -119,7 +119,7 @@ video_info=0
 ; Adjusting is done by changing pixel clock. Not every display supports variable pixel clock.
 ; For proper adjusting and to reduce possible out of range pixel clock, use 60Hz HDMI video
 ; modes as a base even for 50Hz systems.
-; Set to 3 for ULMB 2 support (single buffer with delayed vblank)
+; Set to 3 for ULMB 2 support (single buffer with delayed vblank). Widescreen resolutions only.
 vsync_adjust=0
 
 ; Variable Refresh Rate control

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -48,7 +48,7 @@ static const ini_var_t ini_vars[] =
 	{ "VIDEO_MODE_PAL", (void*)(cfg.video_conf_pal), STRING, 0, sizeof(cfg.video_conf_pal) - 1 },
 	{ "VIDEO_MODE_NTSC", (void*)(cfg.video_conf_ntsc), STRING, 0, sizeof(cfg.video_conf_ntsc) - 1 },
 	{ "VIDEO_INFO", (void*)(&(cfg.video_info)), UINT8, 0, 10 },
-	{ "VSYNC_ADJUST", (void*)(&(cfg.vsync_adjust)), UINT8, 0, 2 },
+	{ "VSYNC_ADJUST", (void*)(&(cfg.vsync_adjust)), UINT8, 0, 3 },
 	{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1 },
 	{ "DVI_MODE", (void*)(&(cfg.dvi_mode)), UINT8, 0, 1 },
 	{ "HDMI_LIMITED", (void*)(&(cfg.hdmi_limited)), UINT8, 0, 2 },

--- a/video.cpp
+++ b/video.cpp
@@ -198,7 +198,8 @@ static_assert(sizeof(vmode_custom_param_t) == sizeof(vmode_custom_t::item));
 static void video_fb_config();
 static void video_calculate_cvt(int horiz_pixels, int vert_pixels, float refresh_rate, int reduced_blanking, vmode_custom_t *vmode);
 
-static constexpr int MIN_V_BPORCH = 6;
+// minimum vertical back porch when scanrate lock borrows blanking lines
+static constexpr int SCANLOCK_MIN_VBP = 6;
 
 static vmode_custom_t v_cur = {}, v_def = {}, v_pal = {}, v_ntsc = {};
 static int vmode_def = 0, vmode_pal = 0, vmode_ntsc = 0;
@@ -3401,42 +3402,35 @@ void video_mode_adjust(bool force)
 			double Fpix = 0;
 			if (adjust)
 			{
+				// staged timing, applied below only if nothing cancels the adjustment
+				uint32_t cand_vfp = v->item[6], cand_vbp = v->item[8];
 				if (cfg.vsync_adjust == 3)
 				{
-					// Hold the modeline's horizontal scanrate constant and absorb the refresh
-					// difference in the vertical blanking, so displays that lock backlight
-					// strobing to scanrate keep it engaged across cores.
+					// keep the pixel clock and htotal, put the refresh difference in vblank
 					const int htotal = v->item[1] + v->item[2] + v->item[3] + v->item[4];
 					const double scanrate = (v->Fpix * 1000000.0) / htotal;
-					const int vtotal = lround(v->Fpix * vtime / (htotal * 100.0));
+					const int min_vbp = ((int)v->item[8] < SCANLOCK_MIN_VBP) ? (int)v->item[8] : SCANLOCK_MIN_VBP;
+					const int vt_min = (int)v->item[5] + (int)v->item[7] + min_vbp + 1;
+
+					// vtotal is a 12-bit sum in the scaler
+					int vtotal = lround(v->Fpix * vtime / (htotal * 100.0));
+					const bool clamped = (vtotal < vt_min) || (vtotal > 4095);
+					if (vtotal < vt_min) vtotal = vt_min;
+					else if (vtotal > 4095) vtotal = 4095;
+
+					// take from the front porch first, then borrow from the back porch
 					const int vblank = vtotal - (int)v->item[5] - (int)v->item[7];
+					cand_vfp = (vblank - (int)v->item[8] < 1) ? 1 : vblank - (int)v->item[8];
+					cand_vbp = vblank - cand_vfp;
 
-					int vfp = vblank - (int)v->item[8];
-					int vbp = v->item[8];
-					if (vfp < 1)
-					{
-						// front porch exhausted: borrow from the back porch down to the CVT floor
-						vfp = 1;
-						vbp = vblank - 1;
-					}
-
-					if (vfp >= 1 && vfp <= 4095 && vbp >= MIN_V_BPORCH)
-					{
-						v->item[6] = vfp;
-						v->item[8] = vbp;
-						const double actual = vtotal * (100000000.0 / vtime);
-						printf("Scanrate lock: vtotal=%d vfp=%d vbp=%d, scanrate %.1fHz (%+.0f ppm)\n",
-							vtotal, vfp, vbp, actual, (actual - scanrate) * 1000000.0 / scanrate);
-					}
-					else
-					{
-						printf("Scanrate lock: cannot hold %.1fHz scanrate at %.3fHz (max %.2fHz for this mode). Using default timing.\n",
-							scanrate, 100000000.0 / vtime,
-							scanrate / (v->item[5] + v->item[7] + MIN_V_BPORCH + 1));
-					}
+					const double actual = vtotal * (100000000.0 / vtime);
+					printf("Scanrate lock: vtotal=%d vfp=%d vbp=%d, scanrate %.1fHz (%+.0f ppm)\n",
+						vtotal, (int)cand_vfp, (int)cand_vbp, actual, (actual - scanrate) * 1000000.0 / scanrate);
+					if (clamped) printf("Scanrate lock: %.3fHz is outside the lockable range (%.2f-%.2f Hz). Scanrate not held.\n",
+						100000000.0 / vtime, scanrate / 4095, scanrate / vt_min);
 				}
 
-				Fpix = 100 * (v->item[1] + v->item[2] + v->item[3] + v->item[4]) * (v->item[5] + v->item[6] + v->item[7] + v->item[8]);
+				Fpix = 100 * (v->item[1] + v->item[2] + v->item[3] + v->item[4]) * (v->item[5] + cand_vfp + v->item[7] + cand_vbp);
 				Fpix /= vtime;
 				if (Fpix < 2.f || Fpix > 300.f)
 				{
@@ -3455,6 +3449,13 @@ void video_mode_adjust(bool force)
 				{
 					printf("Estimated frame rate (%f Hz) is more than REFRESH_MAX(%f Hz). Canceling auto-adjust.\n", hz, cfg.refresh_max);
 					Fpix = 0;
+				}
+
+				// apply staged timing
+				if (Fpix && cfg.vsync_adjust == 3)
+				{
+					v->item[6] = cand_vfp;
+					v->item[8] = cand_vbp;
 				}
 			}
 
@@ -4394,6 +4395,7 @@ static void video_calculate_cvt_int(int h_pixels, int v_lines, float refresh_rat
 	// Based on xfree86 cvt.c and https://tomverbeure.github.io/video_timings_calculator
 
 	const float CLOCK_STEP = 0.25f;
+	const int MIN_V_BPORCH = 6;
 	const int V_FRONT_PORCH = 3;
 
 	const int h_pixels_rnd = (h_pixels / CELL_GRAN_RND) * CELL_GRAN_RND;

--- a/video.cpp
+++ b/video.cpp
@@ -3404,30 +3404,33 @@ void video_mode_adjust(bool force)
 			{
 				// staged timing, applied below only if nothing cancels the adjustment
 				uint32_t cand_vfp = v->item[6], cand_vbp = v->item[8];
+				double scanrate = 0;
+				bool scanlock = false;
+
 				if (cfg.vsync_adjust == 3)
 				{
 					// keep the pixel clock and htotal, put the refresh difference in vblank
-					const int htotal = v->item[1] + v->item[2] + v->item[3] + v->item[4];
-					const double scanrate = (v->Fpix * 1000000.0) / htotal;
-					const int min_vbp = ((int)v->item[8] < SCANLOCK_MIN_VBP) ? (int)v->item[8] : SCANLOCK_MIN_VBP;
-					const int vt_min = (int)v->item[5] + (int)v->item[7] + min_vbp + 1;
+					const int64_t htotal = (int64_t)v->item[1] + v->item[2] + v->item[3] + v->item[4];
+					const int64_t min_vbp = ((int64_t)v->item[8] < SCANLOCK_MIN_VBP) ? (int64_t)v->item[8] : SCANLOCK_MIN_VBP;
+					const int64_t vt_min = (int64_t)v->item[5] + v->item[7] + min_vbp + 1;
+					const int64_t vtotal = llround(v->Fpix * vtime / (htotal * 100.0));
+					scanrate = (v->Fpix * 1000000.0) / htotal;
 
-					// vtotal is a 12-bit sum in the scaler
-					int vtotal = lround(v->Fpix * vtime / (htotal * 100.0));
-					const bool clamped = (vtotal < vt_min) || (vtotal > 4095);
-					if (vtotal < vt_min) vtotal = vt_min;
-					else if (vtotal > 4095) vtotal = 4095;
-
-					// take from the front porch first, then borrow from the back porch
-					const int vblank = vtotal - (int)v->item[5] - (int)v->item[7];
-					cand_vfp = (vblank - (int)v->item[8] < 1) ? 1 : vblank - (int)v->item[8];
-					cand_vbp = vblank - cand_vfp;
-
-					const double actual = vtotal * (100000000.0 / vtime);
-					printf("Scanrate lock: vtotal=%d vfp=%d vbp=%d, scanrate %.1fHz (%+.0f ppm)\n",
-						vtotal, (int)cand_vfp, (int)cand_vbp, actual, (actual - scanrate) * 1000000.0 / scanrate);
-					if (clamped) printf("Scanrate lock: %.3fHz is outside the lockable range (%.2f-%.2f Hz). Scanrate not held.\n",
-						100000000.0 / vtime, scanrate / 4095, scanrate / vt_min);
+					// vtotal reaches the scaler as a 12-bit sum
+					scanlock = (vt_min <= 4095) && (vtotal >= vt_min) && (vtotal <= 4095);
+					if (scanlock)
+					{
+						// take from the front porch first, then borrow from the back porch
+						const int64_t vblank = vtotal - (int64_t)v->item[5] - v->item[7];
+						const int64_t vfp = (vblank - (int64_t)v->item[8] < 1) ? 1 : vblank - (int64_t)v->item[8];
+						cand_vfp = (uint32_t)vfp;
+						cand_vbp = (uint32_t)(vblank - vfp);
+					}
+					else
+					{
+						printf("Scanrate lock: %.3fHz needs vtotal %lld, outside the usable range %lld-4095. Trying standard adjustment.\n",
+							100000000.0 / vtime, (long long)vtotal, (long long)vt_min);
+					}
 				}
 
 				Fpix = 100 * (v->item[1] + v->item[2] + v->item[3] + v->item[4]) * (v->item[5] + cand_vfp + v->item[7] + cand_vbp);
@@ -3451,11 +3454,19 @@ void video_mode_adjust(bool force)
 					Fpix = 0;
 				}
 
-				// apply staged timing
-				if (Fpix && cfg.vsync_adjust == 3)
+				// nothing canceled the adjustment, so the staged timing is safe to apply
+				if (Fpix && scanlock)
 				{
 					v->item[6] = cand_vfp;
 					v->item[8] = cand_vbp;
+					const int vtotal = v->item[5] + v->item[6] + v->item[7] + v->item[8];
+					const double actual = vtotal * (100000000.0 / vtime);
+					printf("Scanrate lock: vtotal=%d vfp=%d vbp=%d, scanrate %.1fHz (%+.0f ppm)\n",
+						vtotal, v->item[6], v->item[8], actual, (actual - scanrate) * 1000000.0 / scanrate);
+				}
+				else if (Fpix && cfg.vsync_adjust == 3)
+				{
+					printf("Scanrate lock: standard adjustment applied, scanrate not held.\n");
 				}
 			}
 

--- a/video.cpp
+++ b/video.cpp
@@ -198,6 +198,8 @@ static_assert(sizeof(vmode_custom_param_t) == sizeof(vmode_custom_t::item));
 static void video_fb_config();
 static void video_calculate_cvt(int horiz_pixels, int vert_pixels, float refresh_rate, int reduced_blanking, vmode_custom_t *vmode);
 
+static constexpr int MIN_V_BPORCH = 6;
+
 static vmode_custom_t v_cur = {}, v_def = {}, v_pal = {}, v_ntsc = {};
 static int vmode_def = 0, vmode_pal = 0, vmode_ntsc = 0;
 
@@ -2282,7 +2284,7 @@ static void video_set_mode(vmode_custom_t *v, double Fpix)
 	for (int i = 9; i < 21; i++)
 	{
 		printf("0x%X, ", v_cur.item[i]);
-		if (i & 1) spi_w(v_cur.item[i] | ((i == 9 && Fpix && cfg.vsync_adjust == 2 && !is_menu()) ? 0x8000 : 0) | 0x4000);
+		if (i & 1) spi_w(v_cur.item[i] | ((i == 9 && Fpix && cfg.vsync_adjust >= 2 && !is_menu()) ? 0x8000 : 0) | 0x4000);
 		else
 		{
 			spi_w(v_cur.item[i]);
@@ -3399,6 +3401,41 @@ void video_mode_adjust(bool force)
 			double Fpix = 0;
 			if (adjust)
 			{
+				if (cfg.vsync_adjust == 3)
+				{
+					// Hold the modeline's horizontal scanrate constant and absorb the refresh
+					// difference in the vertical blanking, so displays that lock backlight
+					// strobing to scanrate keep it engaged across cores.
+					const int htotal = v->item[1] + v->item[2] + v->item[3] + v->item[4];
+					const double scanrate = (v->Fpix * 1000000.0) / htotal;
+					const int vtotal = lround(v->Fpix * vtime / (htotal * 100.0));
+					const int vblank = vtotal - (int)v->item[5] - (int)v->item[7];
+
+					int vfp = vblank - (int)v->item[8];
+					int vbp = v->item[8];
+					if (vfp < 1)
+					{
+						// front porch exhausted: borrow from the back porch down to the CVT floor
+						vfp = 1;
+						vbp = vblank - 1;
+					}
+
+					if (vfp >= 1 && vfp <= 4095 && vbp >= MIN_V_BPORCH)
+					{
+						v->item[6] = vfp;
+						v->item[8] = vbp;
+						const double actual = vtotal * (100000000.0 / vtime);
+						printf("Scanrate lock: vtotal=%d vfp=%d vbp=%d, scanrate %.1fHz (%+.0f ppm)\n",
+							vtotal, vfp, vbp, actual, (actual - scanrate) * 1000000.0 / scanrate);
+					}
+					else
+					{
+						printf("Scanrate lock: cannot hold %.1fHz scanrate at %.3fHz (max %.2fHz for this mode). Using default timing.\n",
+							scanrate, 100000000.0 / vtime,
+							scanrate / (v->item[5] + v->item[7] + MIN_V_BPORCH + 1));
+					}
+				}
+
 				Fpix = 100 * (v->item[1] + v->item[2] + v->item[3] + v->item[4]) * (v->item[5] + v->item[6] + v->item[7] + v->item[8]);
 				Fpix /= vtime;
 				if (Fpix < 2.f || Fpix > 300.f)
@@ -4357,7 +4394,6 @@ static void video_calculate_cvt_int(int h_pixels, int v_lines, float refresh_rat
 	// Based on xfree86 cvt.c and https://tomverbeure.github.io/video_timings_calculator
 
 	const float CLOCK_STEP = 0.25f;
-	const int MIN_V_BPORCH = 6;
 	const int V_FRONT_PORCH = 3;
 
 	const int h_pixels_rnd = (h_pixels / CELL_GRAN_RND) * CELL_GRAN_RND;

--- a/video.cpp
+++ b/video.cpp
@@ -201,6 +201,9 @@ static void video_calculate_cvt(int horiz_pixels, int vert_pixels, float refresh
 // minimum vertical back porch when scanrate lock borrows blanking lines
 static constexpr int SCANLOCK_MIN_VBP = 6;
 
+// margin on the rotation writer's head start, in input lines
+static constexpr int SCANLOCK_ROT_MARGIN = 5;
+
 static vmode_custom_t v_cur = {}, v_def = {}, v_pal = {}, v_ntsc = {};
 static int vmode_def = 0, vmode_pal = 0, vmode_ntsc = 0;
 
@@ -2281,11 +2284,25 @@ static void video_set_mode(vmode_custom_t *v, double Fpix)
 
 	printf("%chsync, %cvsync\n", !!v_cur.param.hpol ? '+' : '-', !!v_cur.param.vpol ? '+' : '-');
 
+	// keep the buffered scaler when output blanking outlasts the rotation writer's head start
+	bool rot_2buf_unsafe = false;
+	if (cfg.vsync_adjust == 3 && video_get_rotated() && current_video_info.htime && current_video_info.vtime)
+	{
+		const int64_t vtotal = (int64_t)v_cur.param.vact + v_cur.param.vfp + v_cur.param.vs + v_cur.param.vbp;
+		const int64_t vblank = vtotal - v_cur.param.vact;
+		if (vtotal > 0)
+		{
+			rot_2buf_unsafe = (vblank * current_video_info.vtime / vtotal) >
+				((int64_t)current_video_info.de_v + SCANLOCK_ROT_MARGIN) * current_video_info.htime;
+			if (rot_2buf_unsafe) printf("Rotated core needs more output blanking than it can absorb, using buffered scaler.\n");
+		}
+	}
+
 	printf("PLL: ");
 	for (int i = 9; i < 21; i++)
 	{
 		printf("0x%X, ", v_cur.item[i]);
-		if (i & 1) spi_w(v_cur.item[i] | ((i == 9 && Fpix && cfg.vsync_adjust >= 2 && !is_menu()) ? 0x8000 : 0) | 0x4000);
+		if (i & 1) spi_w(v_cur.item[i] | ((i == 9 && Fpix && cfg.vsync_adjust >= 2 && !is_menu() && !rot_2buf_unsafe) ? 0x8000 : 0) | 0x4000);
 		else
 		{
 			spi_w(v_cur.item[i]);


### PR DESCRIPTION
Yes, I have found another single-vendor feature to PR into main. Please tell me to pound sand if this isn't interesting to you, duder.

ULMB 2 is a technology by NVIDIA that does the whole backlight strobing for motion clarity thing. With their latest Pulsar monitors, they added the ability to do this through the HDMI port with 60hz sources (this used to be limited to display port).

The catch is that it needs to be a 60hz source... _but you can trick it_. If you draw the horizontal lines at the 60hz rate, and then you delay the vblank, you can get it working with sources 48-61hz.

For as stupid as the hoop is to jump through, it's pretty cool to see in motion.

I guarded this behind vsync_adjust 3, but maybe there is a better spot for it.

This is fully vibe coded, so there may be a better way to do this. With that said, I have tested it all weekend (and week - it's thursday I guess), and haven't run into any issues with various arcade and console titles.

It only works with widescreen resolutions (which is fine because pulsar monitors are only widescreen).