### PR TITLE
input: also skip the Switch motion device under its mainline name

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -5319,7 +5319,7 @@ int input_test(int getchar)
 
 						if (input[n].vid == 0x057e)
 						{
-							if (strstr(input[n].name, " IMU"))
+							if (strstr(input[n].name, " IMU") || strstr(input[n].name, "(IMU)"))
 							{
 								// don't use Accelerometer
 								close(pool[n].fd);


### PR DESCRIPTION
Kernel 6.18's hid-nintendo names it "... (IMU)" instead of 5.15's
"... IMU", so the strstr(" IMU") check misses it and the node is merged
into the pad, putting accelerometer/gyro data on the stick axes. Match
both names.

Alternative to MiSTer-devel/Linux-Kernel_MiSTer#96, which restores the 5.15 name in the kernel instead. Only one of the two is needed.