### PR TITLE
input: set Switch player/home LEDs under their mainline names too

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -2758,11 +2758,12 @@ static void update_num_hw(int dev, int num)
 			led_path = get_led_path(dev);
 			if (led_path)
 			{
-				set_led(led_path, ":home", num ? 1 : 15);
-				set_led(led_path, ":player1", (num == 0 || num == 1 || num == 5));
-				set_led(led_path, ":player2", (num == 0 || num == 2 || num == 6));
-				set_led(led_path, ":player3", (num == 0 || num == 3));
-				set_led(led_path, ":player4", (num == 0 || num == 4 || num == 5 || num == 6));
+				// 5.15 names first, then the mainline hid-nintendo names used by 6.18
+				if (!set_led(led_path, ":home", num ? 1 : 15)) set_led(led_path, ":blue:player-5", num ? 1 : 15);
+				if (!set_led(led_path, ":player1", (num == 0 || num == 1 || num == 5))) set_led(led_path, ":green:player-1", (num == 0 || num == 1 || num == 5));
+				if (!set_led(led_path, ":player2", (num == 0 || num == 2 || num == 6))) set_led(led_path, ":green:player-2", (num == 0 || num == 2 || num == 6));
+				if (!set_led(led_path, ":player3", (num == 0 || num == 3))) set_led(led_path, ":green:player-3", (num == 0 || num == 3));
+				if (!set_led(led_path, ":player4", (num == 0 || num == 4 || num == 5 || num == 6))) set_led(led_path, ":green:player-4", (num == 0 || num == 4 || num == 5 || num == 6));
 			}
 
 			if (repeat && JOYCON_COMBINED(dev)) dev = input[dev].bind; else break;


### PR DESCRIPTION
Kernel 6.18's hid-nintendo names the LEDs "<dev>:green:player-1".."-4"
and "<dev>:blue:player-5" instead of 5.15's ":player1"..":player4" and
":home", so the writes here silently fail and the LEDs never follow the
player number. Fall back to the mainline names.

Alternative to MiSTer-devel/Linux-Kernel_MiSTer#97, which restores the 5.15 LED names in the kernel instead. Only one of the two is needed.